### PR TITLE
Add session-journal ingest path: MCP action + standalone CLI

### DIFF
--- a/.github/workflows/knowledge-freshness.yml
+++ b/.github/workflows/knowledge-freshness.yml
@@ -9,11 +9,16 @@ on:
       - 'src/tools/deep_knowledge.py'
       - 'src/backends/*/backend.py'
   pull_request:
+    # Broad path filter so the lightweight tests gate every PR that
+    # could affect the catalog, the tooling around it, or the ingest
+    # pipeline.  Pure-docs PRs that touch only README.md / *.md still
+    # skip CI (documented intent); anything code-touching runs.
     paths:
-      - 'src/backends/**'
-      - 'src/tools/deep_knowledge.py'
-      - 'tests/groundtruth/**'
-      - 'tests/test_catalog_consistency.py'
+      - 'src/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - '.github/workflows/knowledge-freshness.yml'
   workflow_dispatch:  # Manual trigger
 
 jobs:
@@ -38,14 +43,17 @@ jobs:
         # probes land.
         run: pip install -e ".[skfem,dev]"
 
-      - name: Run catalog-consistency tests
-        # Tee into a file so the issue-creation step can reuse the
-        # exact output that produced the failure -- avoiding misleading
-        # issues if a second pytest run produces different output
-        # (e.g. cache repopulated, network hiccup resolved).
+      - name: Run lightweight gating tests
+        # Catalog-consistency + ingest-pipeline tests are the suite of
+        # checks that need no solver installs.  Keep them together in
+        # one fast job that gates every PR.  Tee into a file so the
+        # issue-creation step can reuse the exact output that produced
+        # the failure -- avoiding misleading issues if a second pytest
+        # run produces different output (e.g. cache repopulated,
+        # network hiccup resolved).
         run: |
           set -o pipefail
-          pytest tests/test_catalog_consistency.py -v -s 2>&1 | tee /tmp/catalog-test.log
+          pytest tests/test_catalog_consistency.py tests/test_ingest_session.py -v -s 2>&1 | tee /tmp/catalog-test.log
         # Only swallow failures on the weekly cron so the auto-issue step
         # can still run.  On PRs and pushes we WANT the workflow to fail
         # so the check is gating.

--- a/scripts/ingest_session.py
+++ b/scripts/ingest_session.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import uuid
 from pathlib import Path
@@ -39,6 +40,21 @@ from core.session_analyzer import (  # noqa: E402
     filter_against_existing,
     format_candidates,
 )
+
+
+_RETRY_SUFFIX_RE = re.compile(r"\s*\(retry \d+\)\s*$", re.IGNORECASE)
+
+
+def _normalise_title(title: str) -> str:
+    """Collapse a candidate title into a dedup-friendly form.
+
+    Strips leading/trailing whitespace, lowercases, removes a trailing
+    ``(retry N)`` suffix and collapses internal whitespace.  Matches the
+    spirit of the analyzer's intra-file fuzzy dedup (SequenceMatcher
+    >0.8) without pulling SequenceMatcher into the cross-file path.
+    """
+    cleaned = _RETRY_SUFFIX_RE.sub("", title)
+    return " ".join(cleaned.lower().split())
 
 
 def _gather(path: Path) -> list[Path]:
@@ -96,10 +112,19 @@ def main() -> int:
         except Exception as e:  # noqa: BLE001
             errors.append((s, e))
 
-    # De-duplicate on (category, solver, title); keep highest confidence.
+    # De-duplicate on a normalised (category, solver, title) key.  The
+    # in-file analyzer already runs fuzzy dedup (SequenceMatcher >0.8),
+    # but cross-file candidates with cosmetic differences (trailing
+    # whitespace, capitalisation, retry-count suffix) need to be
+    # collapsed too -- otherwise the contributor sees N near-identical
+    # entries for the same root cause.
     best: dict[tuple[str, str, str], CandidateKnowledge] = {}
     for c in all_candidates:
-        key = (c.category, c.solver or "", c.title)
+        key = (
+            c.category.strip().lower(),
+            (c.solver or "").strip().lower(),
+            _normalise_title(c.title),
+        )
         if key not in best or c.confidence > best[key].confidence:
             best[key] = c
     deduped = list(best.values())

--- a/scripts/ingest_session.py
+++ b/scripts/ingest_session.py
@@ -14,7 +14,9 @@ Usage:
     python scripts/ingest_session.py <path> --solver fourc   # filter by solver
 
 <path> may be a single ``session_*.json`` file or a directory; the
-directory case scans for ``session_*.json`` recursively-via-glob.
+directory case scans for ``session_*.json`` recursively (via
+``rglob``), so nested layouts like ``data/sessions/2026-05/`` are
+picked up automatically.
 
 This is the offline equivalent of calling ``session_insights('ingest',
 path=...)`` from inside Claude Code -- useful for community
@@ -59,7 +61,7 @@ def _normalise_title(title: str) -> str:
 
 def _gather(path: Path) -> list[Path]:
     if path.is_dir():
-        return sorted(path.glob("session_*.json"))
+        return sorted(path.rglob("session_*.json"))
     if path.is_file():
         return [path]
     return []
@@ -165,17 +167,17 @@ def main() -> int:
 
 
 def _existing_pitfalls(solver: str) -> list[str]:
-    """Lightweight version of consolidated._collect_existing_pitfalls()
+    """Lightweight version of ``consolidated._collect_existing_pitfalls()``
     that avoids importing the MCP server module (which spins up its
-    FastMCP context).  Walks the registered backends directly.
+    FastMCP context).  Uses only the public registry surface.
     """
-    from core.registry import load_all_backends, _backends
+    from core.registry import available_backends, load_all_backends
     pitfalls: list[str] = []
     try:
         load_all_backends()
     except Exception:
         return pitfalls
-    for b in _backends.values():
+    for b in available_backends():
         if solver and b.name() != solver:
             continue
         try:

--- a/scripts/ingest_session.py
+++ b/scripts/ingest_session.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Batch-ingest saved session journals into community-knowledge candidates.
+
+Reads one or more journals saved by the MCP server (``data/sessions/
+session_*.json``), runs the post-session analyzer over each, dedupes
+across the batch, and either prints the resulting candidates or saves
+them to ``data/community_knowledge/pending/`` for later inclusion in
+the catalog (the same path the ``session_insights`` MCP tool writes
+to during a live session).
+
+Usage:
+    python scripts/ingest_session.py <path>             # show candidates only
+    python scripts/ingest_session.py <path> --approve   # also save to pending/
+    python scripts/ingest_session.py <path> --solver fourc   # filter by solver
+
+<path> may be a single ``session_*.json`` file or a directory; the
+directory case scans for ``session_*.json`` recursively-via-glob.
+
+This is the offline equivalent of calling ``session_insights('ingest',
+path=...)`` from inside Claude Code -- useful for community
+contributors who have a folder of journals from past usage and want
+to triage them in one go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from core.session_analyzer import (  # noqa: E402
+    CandidateKnowledge,
+    analyze_journal_file,
+    filter_against_existing,
+    format_candidates,
+)
+
+
+def _gather(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(path.glob("session_*.json"))
+    if path.is_file():
+        return [path]
+    return []
+
+
+def _save_batch(candidates: list, out_dir: Path) -> Path:
+    """Write the deduped batch to ``community_knowledge/pending/``.
+
+    The filename includes a fresh uuid so multiple batch ingestions
+    accumulate rather than overwrite each other.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    batch_id = uuid.uuid4().hex[:12]
+    out = out_dir / f"session_batch_{batch_id}.json"
+    out.write_text(
+        json.dumps([c.to_dict() for c in candidates], indent=2, default=str)
+    )
+    return out
+
+
+def main() -> int:
+    description = (__doc__ or "").splitlines()[0] if __doc__ else ""
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "path", type=Path,
+        help="File or directory of session_*.json journals to ingest.",
+    )
+    parser.add_argument(
+        "--approve", action="store_true",
+        help="Save the deduped candidate batch to "
+             "data/community_knowledge/pending/ "
+             "(otherwise this is a dry run).",
+    )
+    parser.add_argument(
+        "--solver", default="",
+        help="Only keep candidates for this solver (e.g. 'fourc').",
+    )
+    args = parser.parse_args()
+
+    sources = _gather(args.path)
+    if not sources:
+        print(f"No session_*.json found at {args.path}", file=sys.stderr)
+        return 1
+
+    all_candidates = []
+    errors = []
+    for s in sources:
+        try:
+            all_candidates.extend(analyze_journal_file(s))
+        except Exception as e:  # noqa: BLE001
+            errors.append((s, e))
+
+    # De-duplicate on (category, solver, title); keep highest confidence.
+    best: dict[tuple[str, str, str], CandidateKnowledge] = {}
+    for c in all_candidates:
+        key = (c.category, c.solver or "", c.title)
+        if key not in best or c.confidence > best[key].confidence:
+            best[key] = c
+    deduped = list(best.values())
+
+    if args.solver:
+        deduped = [c for c in deduped if c.solver == args.solver]
+
+    # Cross-check against the catalog's existing pitfalls so we don't
+    # propose entries the upstream knowledge base already covers.
+    existing_pitfalls = _existing_pitfalls(args.solver)
+    novel = filter_against_existing(deduped, existing_pitfalls)
+
+    print(
+        f"Ingested {len(sources)} journal file(s); "
+        f"{len(all_candidates)} raw -> {len(deduped)} deduped -> "
+        f"{len(novel)} novel after catalog filter."
+    )
+    if errors:
+        print("Errors:")
+        for s, e in errors:
+            print(f"  {s.name}: {e}")
+
+    if not novel:
+        return 0
+
+    print()
+    print(format_candidates(novel))
+
+    if args.approve:
+        out_dir = REPO_ROOT / "data" / "community_knowledge" / "pending"
+        out = _save_batch(novel, out_dir)
+        print(f"\nSaved {len(novel)} candidate(s) to: {out.relative_to(REPO_ROOT)}")
+        print("Open a PR adding this file to share your findings upstream.")
+    else:
+        print("\n(Dry run.  Re-run with --approve to save to pending/.)")
+
+    return 0
+
+
+def _existing_pitfalls(solver: str) -> list[str]:
+    """Lightweight version of consolidated._collect_existing_pitfalls()
+    that avoids importing the MCP server module (which spins up its
+    FastMCP context).  Walks the registered backends directly.
+    """
+    from core.registry import load_all_backends, _backends
+    pitfalls: list[str] = []
+    try:
+        load_all_backends()
+    except Exception:
+        return pitfalls
+    for b in _backends.values():
+        if solver and b.name() != solver:
+            continue
+        try:
+            for p in b.supported_physics():
+                k = b.get_knowledge(p.name)
+                if k and isinstance(k, dict) and "pitfalls" in k:
+                    for pit in k["pitfalls"]:
+                        if isinstance(pit, str):
+                            pitfalls.append(pit)
+                        elif isinstance(pit, dict) and "text" in pit:
+                            pitfalls.append(pit["text"])
+        except Exception:
+            continue
+    return pitfalls
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -1259,13 +1259,24 @@ def register_consolidated_tools(mcp: FastMCP):
                 try:
                     all_candidates.extend(analyze_journal_file(s))
                 except Exception as e:
-                    errors.append(f"{s.name}: {e}")
-            # Cross-source de-duplication: collapse on (category, solver, title);
-            # keep the highest-confidence representative so the agent sees the
-            # strongest signal without N near-identical entries.
+                    # repr(e) keeps the exception type so a contributor
+                    # can tell `KeyError('events')` from a `FileNotFoundError`.
+                    errors.append(f"{s.name}: {e!r}")
+            # Cross-source de-duplication on a normalised key (the in-file
+            # analyzer runs fuzzy dedup already; cross-file dedup needs to
+            # match that contract or near-identical entries from N journals
+            # all survive as separate candidates).
+            import re as _re
+            _retry_re = _re.compile(r"\s*\(retry \d+\)\s*$", _re.IGNORECASE)
+            def _norm_title(t: str) -> str:
+                return " ".join(_retry_re.sub("", t).lower().split())
             best: dict[tuple[str, str, str], object] = {}
             for c in all_candidates:
-                key = (c.category, c.solver or "", c.title)
+                key = (
+                    c.category.strip().lower(),
+                    (c.solver or "").strip().lower(),
+                    _norm_title(c.title),
+                )
                 if key not in best or c.confidence > best[key].confidence:
                     best[key] = c
             candidates = list(best.values())

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -1203,8 +1203,9 @@ def register_consolidated_tools(mcp: FastMCP):
         """
         from pathlib import Path as _Path
 
-        from core.session_journal import SessionJournal, get_journal
+        from core.session_journal import get_journal
         from core.session_analyzer import (
+            CandidateKnowledge,
             analyze_journal,
             analyze_journal_file,
             filter_against_existing,
@@ -1270,7 +1271,7 @@ def register_consolidated_tools(mcp: FastMCP):
             _retry_re = _re.compile(r"\s*\(retry \d+\)\s*$", _re.IGNORECASE)
             def _norm_title(t: str) -> str:
                 return " ".join(_retry_re.sub("", t).lower().split())
-            best: dict[tuple[str, str, str], object] = {}
+            best: dict[tuple[str, str, str], CandidateKnowledge] = {}
             for c in all_candidates:
                 key = (
                     c.category.strip().lower(),

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -1171,22 +1171,44 @@ def register_consolidated_tools(mcp: FastMCP):
     # ═══════════════════════════════════════════════════════════
 
     @mcp.tool()
-    def session_insights(action: str = "review") -> str:
-        """Review knowledge discovered during this session.
+    def session_insights(action: str = "review", path: str = "") -> str:
+        """Review knowledge discovered during this session or from saved
+        journals on disk.
 
-        After your simulation session, call this to see what the agent
-        learned that could help future users.
+        Two flows are supported:
+
+        * In-session flow: call ``review`` -> ``approve_all`` /
+          ``reject_all`` during the live MCP session to surface
+          candidates from the current journal and save approved ones
+          to ``data/community_knowledge/pending/``.
+        * Ingest flow: call ``ingest`` with ``path`` pointing at a
+          previously-saved session journal (``data/sessions/session_*.json``,
+          which the server writes on shutdown) or at a directory of
+          such files.  Candidates are surfaced just like ``review``
+          and can be approved with ``approve_all``.
 
         Args:
             action:
-                - "review" — show candidate knowledge for approval
-                - "approve_all" — approve all candidates for contribution
-                - "reject_all" — dismiss all candidates
-                - "stats" — session statistics (events, solvers, errors)
+                - "review" — show candidate knowledge from the current
+                  session for approval
+                - "ingest" — load saved journal(s) from ``path`` and
+                  analyse them; requires ``path``
+                - "approve_all" — approve all pending candidates and
+                  save to community_knowledge/pending/
+                - "reject_all" — dismiss all pending candidates
+                - "stats" — current session statistics
+            path: file or directory used by the ``ingest`` action;
+                ignored otherwise.  Directories are scanned for
+                ``session_*.json``.
         """
-        from core.session_journal import get_journal
+        from pathlib import Path as _Path
+
+        from core.session_journal import SessionJournal, get_journal
         from core.session_analyzer import (
-            analyze_journal, filter_against_existing, format_candidates,
+            analyze_journal,
+            analyze_journal_file,
+            filter_against_existing,
+            format_candidates,
         )
 
         journal = get_journal()
@@ -1214,6 +1236,53 @@ def register_consolidated_tools(mcp: FastMCP):
             _pending_candidates.clear()
             _pending_candidates.extend(candidates)
             return format_candidates(candidates)
+
+        if action == "ingest":
+            if not path:
+                return (
+                    "Usage: session_insights('ingest', path='<file_or_dir>')\n"
+                    "Point at a session journal saved by the MCP server "
+                    "(data/sessions/session_*.json) or a directory of "
+                    "such files."
+                )
+            p = _Path(path)
+            if not p.exists():
+                return f"Path not found: {p}"
+            sources: list[_Path] = (
+                sorted(p.glob("session_*.json")) if p.is_dir() else [p]
+            )
+            if not sources:
+                return f"No session_*.json files found in {p}"
+            all_candidates: list = []
+            errors: list[str] = []
+            for s in sources:
+                try:
+                    all_candidates.extend(analyze_journal_file(s))
+                except Exception as e:
+                    errors.append(f"{s.name}: {e}")
+            # Cross-source de-duplication: collapse on (category, solver, title);
+            # keep the highest-confidence representative so the agent sees the
+            # strongest signal without N near-identical entries.
+            best: dict[tuple[str, str, str], object] = {}
+            for c in all_candidates:
+                key = (c.category, c.solver or "", c.title)
+                if key not in best or c.confidence > best[key].confidence:
+                    best[key] = c
+            candidates = list(best.values())
+            existing = _collect_existing_pitfalls()
+            candidates = filter_against_existing(candidates, existing)
+            _pending_candidates.clear()
+            _pending_candidates.extend(candidates)
+            header = (
+                f"Ingested {len(sources)} journal file(s); "
+                f"{len(all_candidates)} raw candidates -> "
+                f"{len(candidates)} novel after dedup + filter.\n"
+            )
+            if errors:
+                header += "Errors:\n  " + "\n  ".join(errors) + "\n"
+            if not candidates:
+                return header + "No new candidates."
+            return header + format_candidates(candidates)
 
         if action == "approve_all":
             if not _pending_candidates:

--- a/tests/test_ingest_session.py
+++ b/tests/test_ingest_session.py
@@ -68,9 +68,10 @@ class TestIngestSingleJournal(unittest.TestCase):
             c = candidates[0]
             self.assertEqual(c.solver, "fourc")
             self.assertEqual(c.physics, "solid_mechanics")
-            # The error message should appear somewhere in the candidate
-            # description -- exact format is up to the analyzer.
-            self.assertIn("FOUR_C_THROW", c.description.upper().replace("_", "_"))
+            # The fixture's FOUR_C_THROW error message should appear in
+            # the candidate description -- exact format is up to the
+            # analyzer, but the substring must survive.
+            self.assertIn("FOUR_C_THROW", c.description)
 
 
 class TestIngestBatchDedup(unittest.TestCase):
@@ -142,6 +143,79 @@ class TestIngestCliApprove(unittest.TestCase):
         finally:
             for f in new_files:
                 f.unlink(missing_ok=True)
+
+
+class TestIngestSolverFilter(unittest.TestCase):
+    """The CLI's ``--solver`` flag must restrict candidates to that
+    solver only."""
+
+    def test_filter_drops_other_solvers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            # Two journals, two different solvers; both yield candidates.
+            j1 = _build_fixture_journal("filter-fourc-001")
+            j1.save(tmp_path)
+            j2 = SessionJournal(session_id="filter-skfem-001", started_at=1_700_000_000.0)
+            j2.record("tool_call", "run_simulation", solver="skfem", physics="poisson")
+            j2.record(
+                "tool_error", "run_simulation", solver="skfem", physics="poisson",
+                error_message="ImportError: cannot import name ElementTriP9",
+            )
+            j2.record("source_read", "developer", solver="skfem")
+            j2.record(
+                "parameter_override", "run_simulation",
+                solver="skfem", physics="poisson",
+                details={"element": "ElementTriP3"},
+            )
+            j2.record("tool_success", "run_simulation", solver="skfem", physics="poisson")
+            j2.save(tmp_path)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "ingest_session.py"),
+                    str(tmp_path),
+                    "--solver", "fourc",
+                ],
+                capture_output=True, text=True, timeout=30,
+            )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        # The fourc candidate must appear; the skfem candidate must not.
+        self.assertIn("Solver: fourc", result.stdout)
+        self.assertNotIn("Solver: skfem", result.stdout)
+
+
+class TestIngestMixedBatchPartialFailure(unittest.TestCase):
+    """A batch containing one malformed journal and one good one must
+    surface the error for the bad file and still extract candidates
+    from the good one -- not bail out on the first failure."""
+
+    def test_one_bad_one_good(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            # Good fixture journal.
+            _build_fixture_journal("mixed-good-001").save(tmp_path)
+            # Truly malformed: not valid JSON.  `SessionJournal.load()`
+            # tolerates missing optional fields, so we need an outright
+            # parse failure to exercise the error path.
+            (tmp_path / "session_mixed-bad-001.json").write_text(
+                "{not even JSON"
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "ingest_session.py"),
+                    str(tmp_path),
+                ],
+                capture_output=True, text=True, timeout=30,
+            )
+        # CLI itself succeeds (partial failure is reported, not raised).
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Errors:", result.stdout)
+        self.assertIn("session_mixed-bad-001.json", result.stdout)
+        # Still surfaces the good-journal candidate.
+        self.assertIn("Solver: fourc", result.stdout)
 
 
 class TestIngestCliDryRun(unittest.TestCase):

--- a/tests/test_ingest_session.py
+++ b/tests/test_ingest_session.py
@@ -1,0 +1,169 @@
+"""Tests for the session-journal ingest path -- both the MCP-side
+``session_insights('ingest', path=...)`` flow and the standalone CLI
+``scripts/ingest_session.py``.
+
+The fixture builds a small synthetic journal that exercises the
+"error -> source-read -> retry -> success" pattern the analyzer is
+designed to surface, and checks the resulting candidate is correctly
+extracted, de-duplicated across multiple files, and saved to the
+``community_knowledge/pending/`` staging dir when approved.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from core.session_analyzer import analyze_journal_file  # noqa: E402
+from core.session_journal import SessionJournal  # noqa: E402
+
+
+def _build_fixture_journal(session_id: str) -> SessionJournal:
+    """Synthesise a journal that the analyzer should surface as a
+    knowledge candidate.
+
+    Pattern: a tool call fails with a specific error, the agent reads
+    the relevant source file, retries with a fixed parameter, and
+    succeeds.  This is the "error -> success" pattern enumerated in
+    session_analyzer's module docstring.
+    """
+    j = SessionJournal(session_id=session_id, started_at=1_700_000_000.0)
+    j.record("tool_call", "run_simulation", solver="fourc", physics="solid_mechanics")
+    j.record(
+        "tool_error", "run_simulation", solver="fourc", physics="solid_mechanics",
+        error_message=(
+            "FOUR_C_THROW: KINEM must be nonlinear for ElastHyper material"
+        ),
+    )
+    j.record(
+        "source_read", "developer", solver="fourc",
+        details={"file": "src/mat/4C_mat_elasthyper.cpp"},
+    )
+    j.record(
+        "parameter_override", "run_simulation",
+        solver="fourc", physics="solid_mechanics",
+        details={"KINEM": "nonlinear"},
+    )
+    j.record("tool_success", "run_simulation", solver="fourc", physics="solid_mechanics")
+    return j
+
+
+class TestIngestSingleJournal(unittest.TestCase):
+    """Loading a single saved journal and running the analyzer."""
+
+    def test_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            saved = _build_fixture_journal("fix-001").save(tmp_path)
+            self.assertTrue(saved.exists())
+            candidates = analyze_journal_file(saved)
+            self.assertTrue(candidates, "fixture should produce >=1 candidate")
+            c = candidates[0]
+            self.assertEqual(c.solver, "fourc")
+            self.assertEqual(c.physics, "solid_mechanics")
+            # The error message should appear somewhere in the candidate
+            # description -- exact format is up to the analyzer.
+            self.assertIn("FOUR_C_THROW", c.description.upper().replace("_", "_"))
+
+
+class TestIngestBatchDedup(unittest.TestCase):
+    """The CLI / MCP ingest flow should collapse identical candidates
+    from multiple journals into one entry."""
+
+    def test_three_identical_journals_collapse_to_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            for i in range(3):
+                _build_fixture_journal(f"fix-{i:03d}").save(tmp_path)
+            files = sorted(tmp_path.glob("session_*.json"))
+            self.assertEqual(len(files), 3)
+
+            # Aggregate across files exactly the way ingest_session.py does.
+            all_candidates = []
+            for f in files:
+                all_candidates.extend(analyze_journal_file(f))
+            best = {}
+            for c in all_candidates:
+                key = (c.category, c.solver or "", c.title)
+                if key not in best or c.confidence > best[key].confidence:
+                    best[key] = c
+            deduped = list(best.values())
+
+            # At least one raw candidate per file is expected; dedup should
+            # collapse identical ones.
+            self.assertGreaterEqual(len(all_candidates), 3)
+            self.assertLess(len(deduped), len(all_candidates))
+
+
+class TestIngestCliApprove(unittest.TestCase):
+    """The standalone CLI's --approve flag must drop a JSON file in
+    ``community_knowledge/pending/`` so a contributor can PR it.
+    """
+
+    def test_approve_writes_pending_file(self):
+        # Use a temp directory for both journals and (via env override
+        # of the repo root) the pending output.  The CLI writes
+        # relative to REPO_ROOT which is hard-coded at import; rather
+        # than mocking that, we point at the live pending/ dir and
+        # remove the artefact afterwards.
+        pending_dir = REPO_ROOT / "data" / "community_knowledge" / "pending"
+        before = set(pending_dir.glob("session_batch_*.json")) if pending_dir.exists() else set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _build_fixture_journal("approve-fix-001").save(tmp_path)
+
+            result = subprocess.run(
+                [
+                    sys.executable, str(REPO_ROOT / "scripts" / "ingest_session.py"),
+                    str(tmp_path), "--approve",
+                ],
+                capture_output=True, text=True, timeout=30,
+            )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Saved", result.stdout)
+
+        after = set(pending_dir.glob("session_batch_*.json"))
+        new_files = sorted(after - before)
+        self.assertEqual(len(new_files), 1, "exactly one batch file expected")
+
+        try:
+            entries = json.loads(new_files[0].read_text())
+            self.assertIsInstance(entries, list)
+            self.assertGreaterEqual(len(entries), 1)
+            self.assertEqual(entries[0].get("solver"), "fourc")
+        finally:
+            for f in new_files:
+                f.unlink(missing_ok=True)
+
+
+class TestIngestCliDryRun(unittest.TestCase):
+    """Dry-run mode (no --approve) must NOT touch the pending/ dir."""
+
+    def test_dry_run_does_not_write(self):
+        pending_dir = REPO_ROOT / "data" / "community_knowledge" / "pending"
+        before = set(pending_dir.glob("session_batch_*.json")) if pending_dir.exists() else set()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            _build_fixture_journal("dryrun-fix-001").save(tmp_path)
+            result = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "ingest_session.py"), str(tmp_path)],
+                capture_output=True, text=True, timeout=30,
+            )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Dry run", result.stdout)
+
+        after = set(pending_dir.glob("session_batch_*.json")) if pending_dir.exists() else set()
+        self.assertEqual(before, after, "dry run must not write any files")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_ingest_session.py
+++ b/tests/test_ingest_session.py
@@ -109,33 +109,41 @@ class TestIngestCliApprove(unittest.TestCase):
     """
 
     def test_approve_writes_pending_file(self):
-        # Use a temp directory for both journals and (via env override
-        # of the repo root) the pending output.  The CLI writes
-        # relative to REPO_ROOT which is hard-coded at import; rather
-        # than mocking that, we point at the live pending/ dir and
-        # remove the artefact afterwards.
+        # The CLI writes relative to REPO_ROOT which is hard-coded at
+        # import.  Rather than mock that, we record what's already in
+        # pending/, run the CLI, and remove only the artefacts the CLI
+        # created -- regardless of whether the subsequent assertions
+        # pass or fail.  The try/finally is critical: a stray
+        # session_batch_*.json left behind would leak into the next
+        # run and could pollute a real contributor's pending/ dir.
         pending_dir = REPO_ROOT / "data" / "community_knowledge" / "pending"
-        before = set(pending_dir.glob("session_batch_*.json")) if pending_dir.exists() else set()
-
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            _build_fixture_journal("approve-fix-001").save(tmp_path)
-
-            result = subprocess.run(
-                [
-                    sys.executable, str(REPO_ROOT / "scripts" / "ingest_session.py"),
-                    str(tmp_path), "--approve",
-                ],
-                capture_output=True, text=True, timeout=30,
-            )
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("Saved", result.stdout)
-
-        after = set(pending_dir.glob("session_batch_*.json"))
-        new_files = sorted(after - before)
-        self.assertEqual(len(new_files), 1, "exactly one batch file expected")
-
+        before = (
+            set(pending_dir.glob("session_batch_*.json"))
+            if pending_dir.exists() else set()
+        )
+        new_files: list[Path] = []
         try:
+            with tempfile.TemporaryDirectory() as tmp:
+                tmp_path = Path(tmp)
+                _build_fixture_journal("approve-fix-001").save(tmp_path)
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(REPO_ROOT / "scripts" / "ingest_session.py"),
+                        str(tmp_path), "--approve",
+                    ],
+                    capture_output=True, text=True, timeout=30,
+                )
+            after = (
+                set(pending_dir.glob("session_batch_*.json"))
+                if pending_dir.exists() else set()
+            )
+            new_files = sorted(after - before)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("Saved", result.stdout)
+            self.assertEqual(
+                len(new_files), 1, "exactly one batch file expected"
+            )
             entries = json.loads(new_files[0].read_text())
             self.assertIsInstance(entries, list)
             self.assertGreaterEqual(len(entries), 1)


### PR DESCRIPTION
## Summary

Producer side of the community-knowledge loop.  PR #1 introduced
catalog-consistency detection (catches *drift* automatically); this PR
introduces a path for catalog *growth* from real usage.

Two ways in:

* **From inside Claude Code / Cursor / any MCP client.**
  \`session_insights(action='ingest', path='<file_or_dir>')\` -- mirrors
  the existing in-session \`review\` action but loads a journal saved
  by an earlier MCP run (or a directory of them).  Candidates flow
  through the same dedup -> filter -> approve -> save pipeline.

* **Offline batch processing.**
  \`python scripts/ingest_session.py <path> [--approve] [--solver fourc]\` --
  for contributors who have a folder of journals from past sessions
  and want to triage them in one go.  Dry run by default; \`--approve\`
  writes one batch file with a fresh uuid into
  \`data/community_knowledge/pending/\` so multiple ingestions
  accumulate.

## Why it matters

The repo already had:
* In-process journaling (\`src/core/session_journal.py\`)
* Pattern-mining analyzer (\`src/core/session_analyzer.py\`)
* Live \`session_insights('review' / 'approve_all')\` MCP tool
* Loader that surfaces approved \`pending/\` entries back into
  knowledge queries (\`_load_community_knowledge\`)

What was missing was the way for a user to feed *previously saved
journals* back into that pipeline -- which is what makes \"many users
contribute over time\" actually possible.  Each MCP server shutdown
already writes the in-process journal to \`data/sessions/\`; this PR
just lets those files be re-analyzed offline or in a fresh session.

## Test plan

- [x] \`pytest tests/test_ingest_session.py -v\` -- 4/4 pass
- [x] \`pytest tests/ --ignore=tests/test_autodiscovery.py --ignore=tests/test_smoke_tests.py -q\` -- 164 pass / 33 skip / 1 pre-existing unrelated failure
- [x] End-to-end: build a fixture journal with the error-then-fix
      pattern, run \`scripts/ingest_session.py <dir>\`, see the
      analyzer surface the candidate, run with \`--approve\`, confirm
      the batch file lands in \`pending/\`

## Verification gate (per CONTRIBUTING.md once #2 merges)

- [x] No catalog changes; no new keyword strings introduced; catalog-
      consistency test still green
- [x] All new public functions have type hints
- [x] Tests cover both the happy path and the dry-run / no-write case
- [x] Source citation: reuses \`SessionJournal.load()\` and
      \`analyze_journal_file()\` unchanged -- see
      \`src/core/session_journal.py:180\` and
      \`src/core/session_analyzer.py:96\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)