### PR TITLE
Add FEniCSx catalog probe (6th backend coverage)

### DIFF
--- a/tests/groundtruth/_stubs.py
+++ b/tests/groundtruth/_stubs.py
@@ -18,13 +18,10 @@ from __future__ import annotations
 # additional modules.
 
 
-# ── FEniCSx / dolfinx (Python introspection) ──────────────────────────────
-def fenics_element_families() -> None:
-    return None
-
-
-def fenics_solver_types() -> None:
-    return None
+# FEniCSx / dolfinx -- implemented in ``fenics.py`` (Python introspection,
+# checks dolfinx submodule attributes via importlib walks).  Test skips when
+# dolfinx is not importable; pip wheels are not available on most platforms
+# so the canonical install is conda.
 
 
 # NGSolve -- implemented in ``ngsolve.py`` (Python introspection family).

--- a/tests/groundtruth/fenics.py
+++ b/tests/groundtruth/fenics.py
@@ -1,0 +1,101 @@
+"""Ground-truth probes for FEniCSx / dolfinx.
+
+FEniCSx exposes its API as a Python package tree rooted at
+``dolfinx``: mesh constructors under ``dolfinx.mesh``, function-space
+machinery under ``dolfinx.fem``, IO under ``dolfinx.io``, PETSc
+integration under ``dolfinx.fem.petsc``, and so on.  The catalog
+references these by their dotted path (``dolfinx.mesh.create_rectangle``,
+``dolfinx.fem.functionspace``, ``dolfinx.io.XDMFFile``), so the
+verification is a per-path attribute check.
+
+Unlike NGSolve / scikit-fem, dolfinx is rarely pip-installable in a
+clean way -- the canonical install is conda, with optional system
+wheel availability for some platform/Python combinations.  All probes
+here return ``None`` (or ``False`` for individual checks) when
+dolfinx is not importable so the test skips cleanly in environments
+that lack it.
+
+The catalog references for FEniCSx already exist in
+``scripts/fingerprint_solvers.py`` (``fingerprint_fenics()``); this
+module exposes the underlying primitives so the catalog-consistency
+test can reuse the same API map.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def has_attr(dotted_path: str) -> bool | None:
+    """Return ``True``/``False`` if the dotted-path attribute can be
+    resolved on the installed ``dolfinx`` package; return ``None``
+    when ``dolfinx`` is not importable at all so the caller can
+    distinguish "missing attribute" from "module unavailable".
+
+    Example::
+
+        has_attr("dolfinx.mesh.create_rectangle")  # True / False / None
+        has_attr("dolfinx.fem.petsc.LinearProblem")
+    """
+    parts = dotted_path.split(".")
+    if not parts or parts[0] != "dolfinx":
+        # The function is dolfinx-specific; refuse to evaluate
+        # anything else so the caller doesn't accidentally pass an
+        # arbitrary path and get a misleading True.
+        return None
+    try:
+        importlib.import_module("dolfinx")
+    except ImportError:
+        return None
+    # Walk the path; promote missing submodule imports to AttributeError
+    # so the answer is uniformly bool from here down.
+    obj: object | None = None
+    module_path = parts[0]
+    obj = importlib.import_module(module_path)
+    for segment in parts[1:]:
+        try:
+            obj = getattr(obj, segment)
+        except AttributeError:
+            return False
+        # If the segment is itself a submodule it may not have been
+        # imported yet; try the import explicitly.
+        if obj is None or (not callable(obj) and not hasattr(obj, "__dict__")):
+            try:
+                obj = importlib.import_module(f"{module_path}.{segment}")
+                module_path = f"{module_path}.{segment}"
+            except ImportError:
+                return False
+        else:
+            module_path = f"{module_path}.{segment}"
+    return True
+
+
+def is_available() -> bool:
+    """``True`` if ``dolfinx`` is importable in the current environment."""
+    try:
+        importlib.import_module("dolfinx")
+    except ImportError:
+        return False
+    return True
+
+
+# Canonical API map -- the catalog promises these dotted paths exist.
+# Sourced from `scripts/fingerprint_solvers.py::fingerprint_fenics`
+# so both modules stay in sync.  Extend when the catalog adds new
+# references.
+CATALOG_API_PATHS: tuple[str, ...] = (
+    "dolfinx.mesh.create_rectangle",
+    "dolfinx.mesh.create_box",
+    "dolfinx.mesh.create_unit_square",
+    "dolfinx.mesh.create_unit_cube",
+    "dolfinx.fem.functionspace",
+    "dolfinx.fem.Function",
+    "dolfinx.fem.dirichletbc",
+    "dolfinx.fem.locate_dofs_topological",
+    "dolfinx.fem.locate_dofs_geometrical",
+    "dolfinx.fem.petsc.LinearProblem",
+    "dolfinx.fem.petsc.NonlinearProblem",
+    "dolfinx.io.XDMFFile",
+    "dolfinx.io.VTKFile",
+    "dolfinx.default_scalar_type",
+)

--- a/tests/groundtruth/fenics.py
+++ b/tests/groundtruth/fenics.py
@@ -27,46 +27,46 @@ import importlib
 
 
 def has_attr(dotted_path: str) -> bool | None:
-    """Return ``True``/``False`` if the dotted-path attribute can be
+    """Return ``True`` / ``False`` if the dotted-path attribute can be
     resolved on the installed ``dolfinx`` package; return ``None``
     when ``dolfinx`` is not importable at all so the caller can
-    distinguish "missing attribute" from "module unavailable".
+    distinguish "missing attribute" from "package missing".
+
+    Walks the dotted path one segment at a time.  ``getattr`` on a
+    parent package only sees submodules that have been imported by
+    the parent's ``__init__`` -- and dolfinx deliberately does NOT
+    side-import every submodule (notably ``dolfinx.fem.petsc`` is
+    only available after ``import dolfinx.fem.petsc``).  When
+    ``getattr`` raises ``AttributeError`` we therefore try
+    ``importlib.import_module`` on the same path before giving up;
+    this catches the petsc case and any other lazy-loaded submodule.
 
     Example::
 
-        has_attr("dolfinx.mesh.create_rectangle")  # True / False / None
-        has_attr("dolfinx.fem.petsc.LinearProblem")
+        has_attr("dolfinx.mesh.create_rectangle")    # True / False / None
+        has_attr("dolfinx.fem.petsc.LinearProblem")  # True when petsc-enabled
     """
     parts = dotted_path.split(".")
     if not parts or parts[0] != "dolfinx":
-        # The function is dolfinx-specific; refuse to evaluate
-        # anything else so the caller doesn't accidentally pass an
-        # arbitrary path and get a misleading True.
+        # Dolfinx-specific; refuse other roots so callers don't
+        # accidentally pass an arbitrary path and get a misleading True.
         return None
     try:
-        importlib.import_module("dolfinx")
+        obj: object = importlib.import_module("dolfinx")
     except ImportError:
         return None
-    # Walk the path; promote missing submodule imports to AttributeError
-    # so the answer is uniformly bool from here down.
-    obj: object | None = None
-    module_path = parts[0]
-    obj = importlib.import_module(module_path)
+    module_path = "dolfinx"
     for segment in parts[1:]:
+        next_path = f"{module_path}.{segment}"
         try:
             obj = getattr(obj, segment)
         except AttributeError:
-            return False
-        # If the segment is itself a submodule it may not have been
-        # imported yet; try the import explicitly.
-        if obj is None or (not callable(obj) and not hasattr(obj, "__dict__")):
+            # Lazy-loaded submodule: try importing it explicitly.
             try:
-                obj = importlib.import_module(f"{module_path}.{segment}")
-                module_path = f"{module_path}.{segment}"
+                obj = importlib.import_module(next_path)
             except ImportError:
                 return False
-        else:
-            module_path = f"{module_path}.{segment}"
+        module_path = next_path
     return True
 
 
@@ -79,10 +79,19 @@ def is_available() -> bool:
     return True
 
 
-# Canonical API map -- the catalog promises these dotted paths exist.
-# Sourced from `scripts/fingerprint_solvers.py::fingerprint_fenics`
-# so both modules stay in sync.  Extend when the catalog adds new
-# references.
+# Hand-curated list of dotted paths the catalog mentions in template
+# code and structured knowledge.  These are checked in addition to
+# whatever the live source scan picks up, so a path that the catalog
+# DOES use but that our regex happens to miss (broken across lines,
+# embedded in a docstring fragment, etc.) is still verified.
+#
+# Partially overlaps with
+# ``scripts/fingerprint_solvers.py::fingerprint_fenics`` (~9 entries
+# in common); intentionally extends it because the catalog references
+# a few names the fingerprint script does not (``create_unit_square``
+# / ``create_unit_cube`` / ``locate_dofs_*`` / ``NonlinearProblem``).
+# When the two lists drift, update both; there is no programmatic
+# single source of truth.
 CATALOG_API_PATHS: tuple[str, ...] = (
     "dolfinx.mesh.create_rectangle",
     "dolfinx.mesh.create_box",

--- a/tests/test_catalog_consistency.py
+++ b/tests/test_catalog_consistency.py
@@ -657,25 +657,29 @@ _DOLFINX_DOTTED_RE = re.compile(r"\bdolfinx(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b")
 
 def _collect_dolfinx_path_mentions() -> set[str]:
     """Return every ``dolfinx.<path>...`` dotted identifier referenced
-    in any FEniCSx generator file or in the cross-cutting deep-
-    knowledge module.  Identifiers are kept as their raw dotted
-    form so the test can resolve each via ``has_attr``.
+    in any FEniCSx generator file under ``src/backends/fenics/``.
+
+    Deliberately excludes ``src/tools/deep_knowledge.py`` because its
+    ``_FENICS_KNOWLEDGE`` block contains an ``api_changes`` section
+    listing OLD-vs-NEW dolfinx names side by side
+    (``dolfinx.io.gmsh.model_to_mesh`` and the current
+    ``dolfinx.io.gmshio.model_to_mesh``, etc.).  Those historical
+    names are not all simultaneously present in any given dolfinx
+    version, so a scan that includes them would falsely fail the
+    test.  The catalog files under ``src/backends/fenics/`` only
+    contain template code the agent actually executes, so paths
+    there must resolve at runtime.
     """
     out: set[str] = set()
     repo_src = Path(__file__).parent.parent / "src"
-    paths: list[Path] = []
     fenics_dir = repo_src / "backends" / "fenics"
     if fenics_dir.is_dir():
-        paths.extend(fenics_dir.rglob("*.py"))
-    deep_knowledge = repo_src / "tools" / "deep_knowledge.py"
-    if deep_knowledge.is_file():
-        paths.append(deep_knowledge)
-    for py in paths:
-        out.update(
-            _DOLFINX_DOTTED_RE.findall(
-                py.read_text(encoding="utf-8", errors="replace")
+        for py in fenics_dir.rglob("*.py"):
+            out.update(
+                _DOLFINX_DOTTED_RE.findall(
+                    py.read_text(encoding="utf-8", errors="replace")
+                )
             )
-        )
     return out
 
 

--- a/tests/test_catalog_consistency.py
+++ b/tests/test_catalog_consistency.py
@@ -26,6 +26,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from tests.groundtruth import dealii as dealii_gt  # noqa: E402
+from tests.groundtruth import fenics as fenics_gt  # noqa: E402
 from tests.groundtruth import fourc as fourc_gt  # noqa: E402
 from tests.groundtruth import kratos as kratos_gt  # noqa: E402
 from tests.groundtruth import ngsolve as ngsolve_gt  # noqa: E402
@@ -642,6 +643,95 @@ class TestKratosApplications(unittest.TestCase):
             if strict:
                 self.fail(msg)
             print(f"\n[WARN catalog drift]\n{msg}", file=sys.stderr)
+
+
+# ── FEniCSx / dolfinx ────────────────────────────────────────────────────────
+
+
+# Catalog mentions of dolfinx attributes typically follow the
+# ``dolfinx.<submodule>.<name>`` pattern.  Match dotted paths of any
+# depth so submodule additions (``dolfinx.fem.petsc.LinearProblem``,
+# ``dolfinx.io.XDMFFile``) are picked up uniformly.
+_DOLFINX_DOTTED_RE = re.compile(r"\bdolfinx(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b")
+
+
+def _collect_dolfinx_path_mentions() -> set[str]:
+    """Return every ``dolfinx.<path>...`` dotted identifier referenced
+    in any FEniCSx generator file or in the cross-cutting deep-
+    knowledge module.  Identifiers are kept as their raw dotted
+    form so the test can resolve each via ``has_attr``.
+    """
+    out: set[str] = set()
+    repo_src = Path(__file__).parent.parent / "src"
+    paths: list[Path] = []
+    fenics_dir = repo_src / "backends" / "fenics"
+    if fenics_dir.is_dir():
+        paths.extend(fenics_dir.rglob("*.py"))
+    deep_knowledge = repo_src / "tools" / "deep_knowledge.py"
+    if deep_knowledge.is_file():
+        paths.append(deep_knowledge)
+    for py in paths:
+        out.update(
+            _DOLFINX_DOTTED_RE.findall(
+                py.read_text(encoding="utf-8", errors="replace")
+            )
+        )
+    return out
+
+
+class TestFenicsDolfinxAPIPaths(unittest.TestCase):
+    """Every ``dolfinx.<path>`` dotted reference the FEniCSx catalog
+    uses must resolve on the installed dolfinx package.
+
+    Skipped when dolfinx is not importable (typical in a non-conda
+    install -- the canonical dolfinx install path is conda, not pip).
+    The test runs whenever dolfinx IS available: in developer
+    environments using ``conda env create -f environment.yml``, in
+    the weekly cron job that installs ``.[all-solvers,dev]``, or in
+    any CI lane that explicitly conda-installs dolfinx.
+
+    For the contributor: this test fails when dolfinx renames an
+    API entry between releases (e.g. ``functionspace`` was
+    ``FunctionSpace`` in earlier versions) or moves a submodule
+    (e.g. ``dolfinx.fem.petsc.LinearProblem`` only exists when
+    PETSc is built in).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not fenics_gt.is_available():
+            raise unittest.SkipTest(
+                "dolfinx not importable -- pip wheels are not available "
+                "on most platforms; conda is the canonical install."
+            )
+        cls.mentions = _collect_dolfinx_path_mentions()
+        # Union the catalog scan with the fingerprint-script's canonical
+        # paths so a newly-added template that hasn't been scanned yet
+        # is still covered, and a path that exists in the catalog but is
+        # missing from the canonical list (drift the other direction)
+        # is also surfaced.
+        cls.checked = cls.mentions | set(fenics_gt.CATALOG_API_PATHS)
+
+    def test_no_unresolved_dolfinx_path(self):
+        # Each path is resolved via importlib walks; collect the
+        # failing ones with their failure mode for an actionable
+        # assertion message.
+        unresolved: list[str] = []
+        for path in sorted(self.checked):
+            ok = fenics_gt.has_attr(path)
+            if ok is False:
+                unresolved.append(path)
+            # ok is None -> dolfinx vanished mid-run; setUpClass would
+            # have caught the import failure earlier, so this shouldn't
+            # happen.  Leaving the branch implicit avoids hiding a
+            # genuine ImportError under a soft warning.
+        self.assertFalse(
+            unresolved,
+            f"\nFEniCSx catalog references dolfinx paths that do not "
+            f"resolve on the installed package: {unresolved}\n"
+            f"Likely an upstream rename or a build that omitted the "
+            f"submodule (e.g. petsc-less dolfinx).",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Sixth backend wired into the catalog-consistency test.  FEniCSx exposes
its API as a layered Python package (\`dolfinx.mesh.create_rectangle\`,
\`dolfinx.fem.functionspace\`, \`dolfinx.io.XDMFFile\`, \`dolfinx.fem.petsc.LinearProblem\`);
the probe walks dotted paths via \`importlib\` + \`getattr\`.

This is an extension of the Python-introspection family.  scikit-fem
and NGSolve check top-level attributes; FEniCSx requires submodule
traversal because the API is layered.

## Skip behaviour

\`pip install fenics-dolfinx\` fails on most platforms (no wheels);
canonical install is conda or system-built.  When dolfinx is not
importable the test skips cleanly (one skipped, zero failures
locally).  Test runs for real in conda envs or any CI lane that
explicitly conda-installs dolfinx.

## Coverage

| Backend | Family | Status |
|---|---|---|
| 4C | source-grep | live |
| scikit-fem | introspection (flat) | live |
| deal.II | source-grep | live |
| NGSolve | introspection (flat) | live |
| Kratos | source-enumeration | live |
| **FEniCSx** | **introspection (importlib walk)** | **new** |
| DUNE-fem | introspection (flat) | stub |
| FEBio | source-grep (XML) | stub |

6 of 8.

## Test plan

- [x] \`pytest tests/test_catalog_consistency.py -v\` -- 10 pass + 1 skip (dolfinx unavailable in venv)
- [x] \`has_attr("dolfinx.mesh.create_rectangle")\` returns \`None\` when dolfinx missing (correct sentinel)
- [x] No changes to the CI workflow install line -- dolfinx is genuinely not pip-installable on Ubuntu vanilla; the test skips in CI honestly
- [x] CONTRIBUTING.md gate: source citation (\`scripts/fingerprint_solvers.py::fingerprint_fenics\`); independent critic reviewing this PR

## Next pieces

- DUNE-fem probe (last of the Python-introspection family)
- FEBio probe (XML schema source-grep)
- Crystal-plasticity catalog enrichment (29 keys still under-declared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)