### PR TITLE
Add DUNE-fem catalog probe + extract shared dotted-path walk

### DIFF
--- a/.github/workflows/knowledge-freshness.yml
+++ b/.github/workflows/knowledge-freshness.yml
@@ -57,7 +57,7 @@ jobs:
         # network hiccup resolved).
         run: |
           set -o pipefail
-          pytest tests/test_catalog_consistency.py tests/test_ingest_session.py -v -s 2>&1 | tee /tmp/catalog-test.log
+          pytest tests/test_catalog_consistency.py tests/test_ingest_session.py tests/test_introspect.py -v -s 2>&1 | tee /tmp/catalog-test.log
         # Only swallow failures on the weekly cron so the auto-issue step
         # can still run.  On PRs and pushes we WANT the workflow to fail
         # so the check is gating.

--- a/tests/groundtruth/_introspect.py
+++ b/tests/groundtruth/_introspect.py
@@ -1,0 +1,64 @@
+"""Shared dotted-path resolution for Python-introspection probes.
+
+Both the FEniCSx (``dolfinx.*``) and DUNE-fem (``dune.*``) probes need
+to resolve a dotted attribute path against an installed package,
+handling Python's lazy submodule loading: ``getattr`` on a parent
+package only sees submodules that the parent's ``__init__`` has
+already imported, so ``dolfinx.fem.petsc`` / ``dune.fem.space`` style
+paths require an explicit ``importlib.import_module`` fallback.
+
+Factored out so the walk logic lives in exactly one place -- a subtle
+algorithm duplicated across probes is a bug waiting to drift.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def resolve_dotted_path(dotted_path: str, expected_root: str) -> bool | None:
+    """Resolve ``dotted_path`` against the installed ``expected_root``
+    package.
+
+    Returns:
+        * ``True``  -- every segment resolved.
+        * ``False`` -- a segment is genuinely missing (neither an
+          attribute nor an importable submodule).
+        * ``None``  -- the root package is not importable at all, or
+          ``dotted_path`` is not rooted at ``expected_root`` (caller
+          passed an unrelated path).  Lets callers distinguish
+          "missing attribute" from "package unavailable / wrong root".
+
+    Walk strategy: for each segment try ``getattr``; on
+    ``AttributeError`` fall back to ``importlib.import_module`` of the
+    accumulated path (lazy submodule) before concluding the segment
+    is missing.
+    """
+    parts = dotted_path.split(".")
+    if not parts or parts[0] != expected_root:
+        return None
+    try:
+        obj: object = importlib.import_module(expected_root)
+    except ImportError:
+        return None
+    module_path = expected_root
+    for segment in parts[1:]:
+        next_path = f"{module_path}.{segment}"
+        try:
+            obj = getattr(obj, segment)
+        except AttributeError:
+            try:
+                obj = importlib.import_module(next_path)
+            except ImportError:
+                return False
+        module_path = next_path
+    return True
+
+
+def is_importable(package: str) -> bool:
+    """``True`` if ``package`` can be imported in the current env."""
+    try:
+        importlib.import_module(package)
+    except ImportError:
+        return False
+    return True

--- a/tests/groundtruth/_stubs.py
+++ b/tests/groundtruth/_stubs.py
@@ -40,9 +40,9 @@ from __future__ import annotations
 # Kratos install and would extend ``kratos.py`` or follow its pattern.
 
 
-# ── DUNE-fem (Python + C++) ───────────────────────────────────────────────
-def dune_grid_implementations() -> None:
-    return None
+# DUNE-fem -- implemented in ``dune.py`` (Python introspection via importlib
+# dotted-path walk, shared with the FEniCSx probe through ``_introspect``).
+# Test skips when ``dune`` is not importable (it builds C++ deps from source).
 
 
 # ── FEBio (XML schema) ────────────────────────────────────────────────────

--- a/tests/groundtruth/dune.py
+++ b/tests/groundtruth/dune.py
@@ -1,0 +1,52 @@
+"""Ground-truth probes for DUNE-fem.
+
+DUNE-fem's Python bindings expose a layered package tree rooted at
+``dune``: grid creation under ``dune.grid``, function spaces and
+schemes under ``dune.fem.space`` / ``dune.fem.scheme``, UFL
+integration under ``dune.ufl``.  The catalog references these by
+dotted path (``dune.fem.space``, ``dune.grid.reader.gmsh``,
+``dune.ufl``), so verification is a per-path attribute check.
+
+Like FEniCSx, DUNE-fem is rarely pip-installable cleanly (it builds
+C++ modules such as ``dune-alugrid`` from source).  All probes return
+``None`` when ``dune`` is not importable so the test skips in
+environments that lack it.
+
+Shares the dotted-path walk with the FEniCSx probe via
+``_introspect.resolve_dotted_path``.
+"""
+
+from __future__ import annotations
+
+from tests.groundtruth._introspect import is_importable, resolve_dotted_path
+
+
+def has_attr(dotted_path: str) -> bool | None:
+    """Resolve a ``dune.<path>`` dotted reference on the installed
+    ``dune`` package.  ``True`` / ``False`` / ``None`` (last when
+    ``dune`` is unimportable or the path is not rooted at ``dune``).
+
+    Handles DUNE's lazy submodule loading (``dune.fem.space`` etc.
+    are not all side-imported by ``dune.__init__``) -- see
+    ``_introspect.resolve_dotted_path``.
+    """
+    return resolve_dotted_path(dotted_path, "dune")
+
+
+def is_available() -> bool:
+    """``True`` if ``dune`` is importable in the current environment."""
+    return is_importable("dune")
+
+
+# Dotted paths the DUNE-fem catalog references in template code.
+# Hand-curated from src/backends/dune/generators/.  Checked in
+# addition to the live source scan so a path the regex misses
+# (split across lines, etc.) is still verified.
+CATALOG_API_PATHS: tuple[str, ...] = (
+    "dune.grid",
+    "dune.fem",
+    "dune.fem.space",
+    "dune.fem.scheme",
+    "dune.fem.function",
+    "dune.ufl",
+)

--- a/tests/groundtruth/fenics.py
+++ b/tests/groundtruth/fenics.py
@@ -23,60 +23,30 @@ test can reuse the same API map.
 
 from __future__ import annotations
 
-import importlib
+from tests.groundtruth._introspect import is_importable, resolve_dotted_path
 
 
 def has_attr(dotted_path: str) -> bool | None:
     """Return ``True`` / ``False`` if the dotted-path attribute can be
     resolved on the installed ``dolfinx`` package; return ``None``
-    when ``dolfinx`` is not importable at all so the caller can
-    distinguish "missing attribute" from "package missing".
+    when ``dolfinx`` is not importable or the path is not rooted at
+    ``dolfinx``.
 
-    Walks the dotted path one segment at a time.  ``getattr`` on a
-    parent package only sees submodules that have been imported by
-    the parent's ``__init__`` -- and dolfinx deliberately does NOT
-    side-import every submodule (notably ``dolfinx.fem.petsc`` is
-    only available after ``import dolfinx.fem.petsc``).  When
-    ``getattr`` raises ``AttributeError`` we therefore try
-    ``importlib.import_module`` on the same path before giving up;
-    this catches the petsc case and any other lazy-loaded submodule.
+    Handles dolfinx's lazy submodule loading (``dolfinx.fem.petsc`` is
+    only available after an explicit import) -- see
+    ``_introspect.resolve_dotted_path`` for the walk strategy.
 
     Example::
 
         has_attr("dolfinx.mesh.create_rectangle")    # True / False / None
         has_attr("dolfinx.fem.petsc.LinearProblem")  # True when petsc-enabled
     """
-    parts = dotted_path.split(".")
-    if not parts or parts[0] != "dolfinx":
-        # Dolfinx-specific; refuse other roots so callers don't
-        # accidentally pass an arbitrary path and get a misleading True.
-        return None
-    try:
-        obj: object = importlib.import_module("dolfinx")
-    except ImportError:
-        return None
-    module_path = "dolfinx"
-    for segment in parts[1:]:
-        next_path = f"{module_path}.{segment}"
-        try:
-            obj = getattr(obj, segment)
-        except AttributeError:
-            # Lazy-loaded submodule: try importing it explicitly.
-            try:
-                obj = importlib.import_module(next_path)
-            except ImportError:
-                return False
-        module_path = next_path
-    return True
+    return resolve_dotted_path(dotted_path, "dolfinx")
 
 
 def is_available() -> bool:
     """``True`` if ``dolfinx`` is importable in the current environment."""
-    try:
-        importlib.import_module("dolfinx")
-    except ImportError:
-        return False
-    return True
+    return is_importable("dolfinx")
 
 
 # Hand-curated list of dotted paths the catalog mentions in template

--- a/tests/test_catalog_consistency.py
+++ b/tests/test_catalog_consistency.py
@@ -742,8 +742,9 @@ class TestFenicsDolfinxAPIPaths(unittest.TestCase):
 # ── DUNE-fem ─────────────────────────────────────────────────────────────────
 
 
-# Match ``dune.<path>`` dotted references of any depth.  The negative
-# follow ``(?![\w])`` ensures we capture the full dotted run.
+# Match ``dune.<path>`` dotted references of any depth.  The trailing
+# ``\b`` plus the greedy ``(?:\.…)+`` group captures the full dotted
+# run (e.g. ``dune.grid.reader.gmsh``) rather than stopping early.
 _DUNE_DOTTED_RE = re.compile(r"\bdune(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b")
 
 

--- a/tests/test_catalog_consistency.py
+++ b/tests/test_catalog_consistency.py
@@ -26,6 +26,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from tests.groundtruth import dealii as dealii_gt  # noqa: E402
+from tests.groundtruth import dune as dune_gt  # noqa: E402
 from tests.groundtruth import fenics as fenics_gt  # noqa: E402
 from tests.groundtruth import fourc as fourc_gt  # noqa: E402
 from tests.groundtruth import kratos as kratos_gt  # noqa: E402
@@ -735,6 +736,70 @@ class TestFenicsDolfinxAPIPaths(unittest.TestCase):
             f"resolve on the installed package: {unresolved}\n"
             f"Likely an upstream rename or a build that omitted the "
             f"submodule (e.g. petsc-less dolfinx).",
+        )
+
+
+# ── DUNE-fem ─────────────────────────────────────────────────────────────────
+
+
+# Match ``dune.<path>`` dotted references of any depth.  The negative
+# follow ``(?![\w])`` ensures we capture the full dotted run.
+_DUNE_DOTTED_RE = re.compile(r"\bdune(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b")
+
+
+def _collect_dune_path_mentions() -> set[str]:
+    """Return every ``dune.<path>...`` dotted identifier referenced in
+    any DUNE-fem generator file under ``src/backends/dune/``.
+
+    Scoped to the backend's own generators (template code the agent
+    executes).  Like the FEniCSx scan, the cross-cutting
+    ``deep_knowledge.py`` is intentionally excluded -- it can carry
+    version-historical names that don't all resolve against one
+    DUNE release.
+    """
+    out: set[str] = set()
+    dune_dir = Path(__file__).parent.parent / "src" / "backends" / "dune"
+    if dune_dir.is_dir():
+        for py in dune_dir.rglob("*.py"):
+            out.update(
+                _DUNE_DOTTED_RE.findall(
+                    py.read_text(encoding="utf-8", errors="replace")
+                )
+            )
+    return out
+
+
+class TestDuneFemAPIPaths(unittest.TestCase):
+    """Every ``dune.<path>`` dotted reference the DUNE-fem catalog uses
+    must resolve on the installed ``dune`` package.
+
+    Skipped when ``dune`` is not importable -- DUNE-fem builds C++
+    modules (``dune-alugrid`` etc.) from source and is not cleanly
+    pip-installable, so a vanilla venv / CI runner skips.  Runs for
+    real wherever a built DUNE-fem is available.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not dune_gt.is_available():
+            raise unittest.SkipTest(
+                "dune not importable -- DUNE-fem builds C++ deps from "
+                "source and is not cleanly pip-installable."
+            )
+        cls.checked = (
+            _collect_dune_path_mentions() | set(dune_gt.CATALOG_API_PATHS)
+        )
+
+    def test_no_unresolved_dune_path(self):
+        unresolved = [
+            path for path in sorted(self.checked)
+            if dune_gt.has_attr(path) is False
+        ]
+        self.assertFalse(
+            unresolved,
+            f"\nDUNE-fem catalog references dune paths that do not "
+            f"resolve on the installed package: {unresolved}\n"
+            f"Likely an upstream rename or a build missing the module.",
         )
 
 

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -1,0 +1,82 @@
+"""Unit tests for the shared dotted-path walk in
+``tests/groundtruth/_introspect.py``.
+
+The FEniCSx and DUNE-fem catalog-consistency tests both rely on
+``resolve_dotted_path`` but SKIP in environments without dolfinx /
+dune (neither pip-installs cleanly) -- so the walk's True / False /
+None branches would otherwise never be asserted in CI.
+
+These tests exercise the algorithm against ``numpy`` (always
+installed as a base dependency), which has the same shape that
+matters: a top-level package with lazy submodules
+(``numpy.fft`` is not always side-imported by ``numpy.__init__``),
+exactly the case the PR-#7 fix addressed.  Locking it in here means
+a future refactor that re-breaks the lazy-submodule fallback fails a
+real assertion instead of silently passing because the FEniCSx/DUNE
+tests skip.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tests.groundtruth._introspect import (  # noqa: E402
+    is_importable,
+    resolve_dotted_path,
+)
+
+
+class TestResolveDottedPath(unittest.TestCase):
+    def test_top_level_attribute(self):
+        self.assertTrue(resolve_dotted_path("numpy.ndarray", "numpy"))
+
+    def test_nested_attribute(self):
+        self.assertTrue(resolve_dotted_path("numpy.linalg.norm", "numpy"))
+
+    def test_lazy_submodule_fallback(self):
+        # numpy.fft is a submodule not guaranteed to be exposed as an
+        # attribute by numpy.__init__ on every version -- this is the
+        # exact getattr-then-import_module path the PR-#7 fix added.
+        self.assertTrue(resolve_dotted_path("numpy.fft.fft", "numpy"))
+
+    def test_bare_root(self):
+        self.assertTrue(resolve_dotted_path("numpy", "numpy"))
+
+    def test_missing_top_level_attribute(self):
+        self.assertFalse(
+            resolve_dotted_path("numpy.definitely_not_here_xyz", "numpy")
+        )
+
+    def test_missing_nested_attribute(self):
+        self.assertFalse(
+            resolve_dotted_path("numpy.linalg.definitely_not_here_xyz", "numpy")
+        )
+
+    def test_wrong_root_returns_none(self):
+        # Path not rooted at the expected package -> None, distinct
+        # from False, so callers can tell "wrong question" from
+        # "missing attribute".
+        self.assertIsNone(resolve_dotted_path("scipy.whatever", "numpy"))
+
+    def test_unimportable_root_returns_none(self):
+        self.assertIsNone(
+            resolve_dotted_path(
+                "definitely_not_a_pkg_xyz.x", "definitely_not_a_pkg_xyz"
+            )
+        )
+
+
+class TestIsImportable(unittest.TestCase):
+    def test_installed_package(self):
+        self.assertTrue(is_importable("numpy"))
+
+    def test_missing_package(self):
+        self.assertFalse(is_importable("definitely_not_a_pkg_xyz"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Seventh backend wired into the catalog-consistency test, completing all
backends the project actually ships.  (FEBio stays a stub -- it's listed
but not installed/usable yet, so there's nothing to probe.)

DUNE-fem uses the same layered ``dune.<submodule>`` package shape as
FEniCSx's dolfinx.  Rather than duplicate the lazy-submodule walk -- the
exact algorithm a critic flagged as buggy in the FEniCSx PR -- this PR
extracts it to ``tests/groundtruth/_introspect.py`` and refactors
FEniCSx to use it too.  One source of truth for the walk.

## Coverage (all shipping backends now covered)

| Backend | Family | Status |
|---|---|---|
| 4C | source-grep | live |
| scikit-fem | introspection (flat) | live |
| deal.II | source-grep | live |
| NGSolve | introspection (flat) | live |
| Kratos | source-enumeration | live |
| FEniCSx | introspection (importlib walk) | live (skips w/o conda) |
| **DUNE-fem** | **introspection (importlib walk)** | **new (skips w/o build)** |
| FEBio | source-grep (XML) | stub (not installed yet) |

## Skip behaviour

\`pip install dune-fem\` fails on a vanilla runner (builds dune-alugrid
and friends from C++ source), so the test SKIPS in the standard venv /
CI -- same honest story as FEniCSx.  Runs for real wherever a built
DUNE-fem is importable.

## Test plan

- [x] \`pytest tests/test_catalog_consistency.py -v\` -- 10 pass + 2 skip (dolfinx + dune both unavailable)
- [x] FEniCSx refactor verified: its test still skips correctly through the shared helper
- [x] Shared \`resolve_dotted_path\` keeps the getattr-then-import_module fallback the FEniCSx critic required
- [x] CONTRIBUTING.md gate: source citation (dune package tree + reused fenics pattern); independent critic on this PR

## What's left after this

- FEBio probe -- deferred until FEBio is actually installed/usable
- Crystal-plasticity catalog enrichment (29 keys under-declared per the 4C soft-warning test)
- Optional: a conda CI lane so the FEniCSx + DUNE tests run for real instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)