### PR TITLE
Grant issues:write so the drift auto-issue path actually works

### DIFF
--- a/.github/workflows/knowledge-freshness.yml
+++ b/.github/workflows/knowledge-freshness.yml
@@ -21,6 +21,17 @@ on:
       - '.github/workflows/knowledge-freshness.yml'
   workflow_dispatch:  # Manual trigger
 
+# Both drift jobs auto-file a GitHub issue on the weekly cron when the
+# catalog/fingerprint goes stale.  ``issues.create`` needs ``issues:
+# write``; the repo's default GITHUB_TOKEN permission is read-only, so
+# without this block the issue step 403s -- a failure that only shows
+# up the first time real drift is detected (verified by a one-off
+# dispatch run that confirmed the issue is created with this grant in
+# place).  ``contents: read`` is all the checkout needs.
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   catalog-consistency:
     # Lightweight: greps backend source for the canonical names the catalog


### PR DESCRIPTION
## Summary

Hardening fix for a latent bug in the drift-detection automation: the
weekly cron's auto-issue step would have **403'd the first time it
fired**.  Both jobs call \`github.rest.issues.create()\`, but the
workflow declared no \`permissions\` block and the repo's default
\`GITHUB_TOKEN\` is read-only.

Adds a top-level \`permissions: { contents: read, issues: write }\`.

## How this was found and verified

Static check first: \`gh api .../actions/permissions/workflow\` showed
\`default_workflow_permissions: read\`, and the workflow had no
\`permissions:\` block — so \`issues.create\` could not have worked.
The \`knowledge-drift\` label also didn't exist.

Then verified end-to-end (not just reasoned about):
1. Created the \`knowledge-drift\` label.
2. On a throwaway branch: added this grant + temporarily let the issue
   step fire on \`workflow_dispatch\` + injected a fake \`DYNAMICTYPE\`
   keyword to force the catalog test to fail.
3. Dispatched the workflow → it filed issue #9 "Catalog/source drift
   detected" with the label and the real pytest output in the body.
4. Closed the issue, deleted the scratch branch.

This commit is only the minimal permission grant; the verification
scaffolding was thrown away.

## Why it matters

Until now the "self-detecting" loop could detect drift (the test fails)
but could **not report it** (the issue step would silently 403 on the
cron). With this grant the loop is closed: Monday 06:00 UTC cron →
test fails on drift → issue auto-filed → human fixes the catalog.

## Test plan

- [x] YAML validates; \`permissions\` parsed correctly
- [x] Diff is +11 lines, permissions block only
- [x] Catalog tests still pass clean (10 pass / 2 skip)
- [x] End-to-end issue creation confirmed via dispatch run (issue #9, since closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)