### PR TITLE
Fence catalog templates by content language, not backend input_format

### DIFF
--- a/src/core/backend.py
+++ b/src/core/backend.py
@@ -31,6 +31,41 @@ class InputFormat(Enum):
     JSON = "json"           # generic
 
 
+def detect_template_language(content: str, default: str) -> str:
+    """Sniff a template's first-line markers and return the markdown
+    fence language tag that matches the *content*, not the backend's
+    declared ``input_format``.
+
+    Catches the Kratos case: ``KratosBackend.input_format() == JSON``
+    (its native config-file format), but its catalog generators emit
+    Python scripts that use the ``KratosMultiphysics`` library
+    directly.  Tagging those as ``json`` confuses any client that
+    strips fences by language.
+
+    Falls back to ``default`` (typically ``backend.input_format().value``)
+    when no marker matches.
+    """
+    head = content.lstrip()[:200]
+    if not head:
+        return default
+    python_markers = (
+        '"""', "'''",
+        "#!/",
+        "from ", "import ",
+        "def ", "class ",
+        "# -*-",
+    )
+    if head.startswith(python_markers):
+        return "python"
+    if head.startswith(("<?xml", "<")):
+        return "xml"
+    if head.startswith(("{", "[")):
+        return "json"
+    if head.startswith(("//", "#include", "template<", "namespace ")):
+        return "cpp"
+    return default
+
+
 @dataclass
 class PhysicsCapability:
     """A physics problem this backend can solve."""

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.server import Context
+from core.backend import detect_template_language
 from core.registry import get_backend, available_backends
 
 _OUTPUT_DIR = Path(__file__).resolve().parents[2] / "simulation_outputs"
@@ -475,7 +476,7 @@ def register_consolidated_tools(mcp: FastMCP):
                     variant = p.template_variants[0] if p.template_variants else "2d"
                     try:
                         content = backend.generate_input(p.name, variant, {})
-                        fmt = backend.input_format().value
+                        fmt = detect_template_language(content, backend.input_format().value)
                         return f"```{fmt}\n{content}\n```"
                     except Exception as e:
                         return f"Error generating template: {e}"

--- a/src/tools/examples_search.py
+++ b/src/tools/examples_search.py
@@ -11,6 +11,7 @@ import json
 import os
 from pathlib import Path
 from mcp.server.fastmcp import FastMCP
+from core.backend import detect_template_language
 from core.registry import get_backend, available_backends
 
 # Auto-detect 4C paths
@@ -156,7 +157,7 @@ def register_example_tools(mcp: FastMCP):
                         for v in p.template_variants[:max_results]:
                             try:
                                 content = backend.generate_input(p.name, v, {})
-                                fmt = backend.input_format().value
+                                fmt = detect_template_language(content, backend.input_format().value)
                                 results.append(
                                     f"### {backend.display_name()} template: `{p.name}/{v}`\n\n```{fmt}\n{content[:8000]}```\n"
                                 )
@@ -280,7 +281,7 @@ def register_example_tools(mcp: FastMCP):
 
         try:
             content = backend.generate_input(physics, variant, {})
-            fmt = backend.input_format().value
+            fmt = detect_template_language(content, backend.input_format().value)
             return f"```{fmt}\n{content}\n```"
         except ValueError as e:
             return str(e)


### PR DESCRIPTION
## Summary

Closes finding F-003 from the layer-3 validation campaign.  The
\`examples\` tool fenced template output as
\`\\\`\\\`\\\`{backend.input_format().value}\` — for Kratos that's
\`json\` (its native config format), but its catalog generators emit
**Python scripts** that use \`KratosMultiphysics\` as a library.
Templates were going out tagged as JSON with Python content inside.

A client stripping fences by language tag mis-handles this.
My own layer-3 stdio test crashed with \`SyntaxError\` at line 1 of
the extracted file when I split on \`\\\`\\\`\\\`python\`: the literal
\`\\\`\\\`\\\`json\` line ended up in the executed file.

## Fix

Adds \`detect_template_language(content, default)\` in
\`src/core/backend.py\`: sniffs the first chars for Python / XML /
JSON / C++ markers and falls back to the backend's declared format
when no marker matches.  Used at the three fence-emission sites.

## Verified live

- \`examples\` for kratos linear-elasticity → fence is now
  \`\\\`\\\`\\\`python\` (was \`\\\`\\\`\\\`json\`).
- \`examples\` for fenics poisson → \`\\\`\\\`\\\`python\` (unchanged).
- \`pytest tests/test_catalog_consistency.py tests/test_introspect.py
  tests/test_ingest_session.py\` — 26 passed, 2 skipped (same as main).

## Why not a per-backend \`template_language()\` method?

That would be more principled but a bigger surface change.  The
content-sniff approach handles every realistic case without forcing
every backend to add a new method.  Easy to upgrade later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)