### PR TITLE
Enrich MAT_crystal_plasticity catalog with all 29 source-declared keys

### DIFF
--- a/src/backends/fourc/generators/solid_mechanics.py
+++ b/src/backends/fourc/generators/solid_mechanics.py
@@ -267,17 +267,17 @@ class SolidMechanicsGenerator(BaseGenerator):
                 "MAT_crystal_plasticity": {
                     "description": (
                         "Single-crystal plasticity with dislocation-density based hardening and "
-                        "optional deformation twinning.  Lattice families: FCC, BCC, HCP, D019, L10 "
-                        "(LAT key, default FCC).  Slip- and twin-system parameters are given as "
-                        "vectors sized by NUMSLIPSETS / NUMTWINSETS — entries map to system sets "
-                        "via SLIPSETMEMBERS / TWINSETMEMBERS."
+                        "optional deformation twinning.  Lattice families accepted by the runtime: "
+                        "FCC, BCC, D019, L10 (LAT key, default FCC).  The input parser's own "
+                        "description string advertises HCP as well, but the constructor sanity "
+                        "check rejects 'HCP' with FOUR_C_THROW — use D019 for hexagonal lattices."
                     ),
                     "parameters": (
                         # elastic + Newton tolerance
                         "TOL, YOUNG, NUE, DENS, "
                         # crystal lattice
                         "LAT, CTOA, ABASE, "
-                        # slip-system definition (vector sizes follow NUMSLIPSETS)
+                        # slip-system definition
                         "NUMSLIPSYS, NUMSLIPSETS, SLIPSETMEMBERS, SLIPRATEEXP, GAMMADOTSLIPREF, "
                         "DISDENSINIT, DISGENCOEFF, DISDYNRECCOEFF, TAUY0, MFPSLIP, SLIPHPCOEFF, "
                         "SLIPBYTWIN, "
@@ -292,12 +292,20 @@ class SolidMechanicsGenerator(BaseGenerator):
                         "slip-twin and twin-twin coupling, multiple lattice types"
                     ),
                     "pitfalls": (
-                        "Vector parameters must have exact size NUMSLIPSETS (or NUMTWINSETS) — "
-                        "wrong size triggers a 4C input parser error.  SLIPSETMEMBERS uses "
-                        "1-based indices into NUMSLIPSETS.  Twinning is optional: leave "
-                        "NUMTWINSYS=NUMTWINSETS=0 and omit the TWIN* / GAMMADOTTWINREF / TAUT0 / "
-                        "MFPTWIN / TWINHPCOEFF / TWINBYSLIP / TWINBYTWIN vectors (their "
-                        "default is the empty vector) for pure slip plasticity."
+                        "Vector-size rule depends on the parameter (two distinct sizing axes):\n"
+                        "  - one entry per physical *system* (size = NUMSLIPSYS or NUMTWINSYS): "
+                        "SLIPSETMEMBERS, TWINSETMEMBERS — these are 1-based indices into the "
+                        "set table (range 1..NUMSLIPSETS or 1..NUMTWINSETS) saying which set "
+                        "each individual slip/twin system belongs to.\n"
+                        "  - one entry per *set* (size = NUMSLIPSETS or NUMTWINSETS): every "
+                        "other slip/twin vector (SLIPRATEEXP, GAMMADOTSLIPREF, DISDENSINIT, "
+                        "DISGENCOEFF, DISDYNRECCOEFF, TAUY0, MFPSLIP, SLIPHPCOEFF, SLIPBYTWIN "
+                        "and their TWIN-side counterparts TWINRATEEXP, GAMMADOTTWINREF, TAUT0, "
+                        "MFPTWIN, TWINHPCOEFF, TWINBYSLIP, TWINBYTWIN).\n"
+                        "Mixing these two sizes is a common error — NUMSLIPSYS usually exceeds "
+                        "NUMSLIPSETS (e.g. FCC has 12 systems often in 1 set).  Twinning is "
+                        "optional: leave NUMTWINSYS=NUMTWINSETS=0 and omit every TWIN-side "
+                        "vector (they all have parser defaults) for pure slip plasticity."
                     ),
                 },
             },

--- a/src/backends/fourc/generators/solid_mechanics.py
+++ b/src/backends/fourc/generators/solid_mechanics.py
@@ -265,9 +265,40 @@ class SolidMechanicsGenerator(BaseGenerator):
                     "kinematics": "linear only",
                 },
                 "MAT_crystal_plasticity": {
-                    "description": "Crystal plasticity with slip/twinning systems (FCC/BCC/HCP)",
+                    "description": (
+                        "Single-crystal plasticity with dislocation-density based hardening and "
+                        "optional deformation twinning.  Lattice families: FCC, BCC, HCP, D019, L10 "
+                        "(LAT key, default FCC).  Slip- and twin-system parameters are given as "
+                        "vectors sized by NUMSLIPSETS / NUMTWINSETS — entries map to system sets "
+                        "via SLIPSETMEMBERS / TWINSETMEMBERS."
+                    ),
+                    "parameters": (
+                        # elastic + Newton tolerance
+                        "TOL, YOUNG, NUE, DENS, "
+                        # crystal lattice
+                        "LAT, CTOA, ABASE, "
+                        # slip-system definition (vector sizes follow NUMSLIPSETS)
+                        "NUMSLIPSYS, NUMSLIPSETS, SLIPSETMEMBERS, SLIPRATEEXP, GAMMADOTSLIPREF, "
+                        "DISDENSINIT, DISGENCOEFF, DISDYNRECCOEFF, TAUY0, MFPSLIP, SLIPHPCOEFF, "
+                        "SLIPBYTWIN, "
+                        # twin-system definition (all optional; NUMTWINSYS/SETS default 0)
+                        "NUMTWINSYS, NUMTWINSETS, TWINSETMEMBERS, TWINRATEEXP, GAMMADOTTWINREF, "
+                        "TAUT0, MFPTWIN, TWINHPCOEFF, TWINBYSLIP, TWINBYTWIN"
+                    ),
                     "kinematics": "nonlinear",
-                    "features": "Dislocation density evolution, Hall-Petch, multiple lattice types",
+                    "features": (
+                        "Dislocation-density evolution (generation + dynamic recovery), "
+                        "Hall-Petch via MFPSLIP/MFPTWIN with HP coefficients, "
+                        "slip-twin and twin-twin coupling, multiple lattice types"
+                    ),
+                    "pitfalls": (
+                        "Vector parameters must have exact size NUMSLIPSETS (or NUMTWINSETS) — "
+                        "wrong size triggers a 4C input parser error.  SLIPSETMEMBERS uses "
+                        "1-based indices into NUMSLIPSETS.  Twinning is optional: leave "
+                        "NUMTWINSYS=NUMTWINSETS=0 and omit the TWIN* / GAMMADOTTWINREF / TAUT0 / "
+                        "MFPTWIN / TWINHPCOEFF / TWINBYSLIP / TWINBYTWIN vectors (their "
+                        "default is the empty vector) for pure slip plasticity."
+                    ),
                 },
             },
             "plasticity_pitfalls": [


### PR DESCRIPTION
## Summary
- The `MAT_crystal_plasticity` catalog entry previously declared *no* parameter keys at all, leaving an agent that asks the MCP for guidance on single-crystal plasticity inputs with nothing to work from.
- This PR adds all 29 keys 4C actually reads, plus the parameters' semantic grouping (elastic vs lattice vs slip-system vector vs twin-system vector), Hall–Petch coupling notes, and the optional-twinning pitfall (set `NUMTWINSYS=NUMTWINSETS=0` and omit the TWIN* vectors).
- Cross-checked against two upstream sources:
  - `src/mat/4C_mat_crystal_plasticity.cpp` — the 29 `matdata.parameters.get<…>("KEY")` calls in the `PAR::CrystalPlasticity` ctor.
  - `src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp` — the input-parser group definition with each key's description, default, and required/optional status.

Closes the only remaining `OFA_STRICT_CATALOG=1` failure in `TestFourcMaterialParameters::test_required_keys_present_in_catalog`.

## Test plan
- [x] `OFA_STRICT_CATALOG=1 pytest tests/test_catalog_consistency.py::TestFourcMaterialParameters -v` — both tests now pass under strict mode.
- [x] `pytest tests/test_catalog_consistency.py` — 10 passed (2 skipped, FEniCSx + DUNE-fem not importable in this env, expected).
- [ ] CI on push reruns the same suite against the merged branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)