### PR TITLE
Add catalog coverage for 12 auxiliary Kratos applications

### DIFF
--- a/src/backends/kratos/generators/__init__.py
+++ b/src/backends/kratos/generators/__init__.py
@@ -21,6 +21,7 @@ from .topology_optimization import GENERATORS as _topo_gen, KNOWLEDGE as _topo_k
 from .iga import GENERATORS as _iga_gen, KNOWLEDGE as _iga_kn
 from .plasticity import GENERATORS as _plast_gen, KNOWLEDGE as _plast_kn
 from .specialized import GENERATORS as _spec_gen, KNOWLEDGE as _spec_kn
+from .auxiliary_applications import GENERATORS as _aux_gen, KNOWLEDGE as _aux_kn
 
 # Merged generator registry: physics_variant -> callable(params) -> str
 GENERATORS: dict[str, callable] = {}
@@ -30,6 +31,7 @@ for _g in [
     _mpm_gen, _shape_gen, _cosim_gen,
     _geo_gen, _comp_gen, _rans_gen, _pfem_gen,
     _rom_gen, _topo_gen, _iga_gen, _plast_gen, _spec_gen,
+    _aux_gen,
 ]:
     GENERATORS.update(_g)
 
@@ -41,6 +43,7 @@ for _k in [
     _mpm_kn, _shape_kn, _cosim_kn,
     _geo_kn, _comp_kn, _rans_kn, _pfem_kn,
     _rom_kn, _topo_kn, _iga_kn, _plast_kn, _spec_kn,
+    _aux_kn,
 ]:
     KNOWLEDGE.update(_k)
 

--- a/src/backends/kratos/generators/auxiliary_applications.py
+++ b/src/backends/kratos/generators/auxiliary_applications.py
@@ -25,7 +25,9 @@ KNOWLEDGE = {
                 "Trilinos linear-solver wrappers (Epetra, AztecOO, Amesos, ML, "
                 "MueLu) for distributed-memory MPI runs.  Required by any "
                 "parallel Kratos analysis using iterative or AMG-preconditioned "
-                "solvers.  Pip install hint: KratosTrilinosApplication."
+                "solvers.  Not published as a PyPI wheel — obtain it by "
+                "building Kratos from source with `-DTRILINOS_APPLICATION=ON` "
+                "against an MPI-built Trilinos."
             ),
             "MetisApplication": (
                 "Metis-based mesh partitioner for MPI runs.  Used by the model-"
@@ -42,9 +44,9 @@ KNOWLEDGE = {
             ),
             "HDF5Application": (
                 "Parallel HDF5 I/O.  Provides HDF5OutputProcess and HDF5IO for "
-                "checkpointing, restart, and PETSc-friendly result storage.  "
-                "Used by long simulations and FSI restart workflows.  Pip "
-                "install hint: KratosHDF5Application."
+                "checkpointing and restart, plus XDMF/ParaView/VisIt-friendly "
+                "result storage.  Used by long simulations and FSI restart "
+                "workflows.  Pip install hint: KratosHDF5Application."
             ),
             "MedApplication": (
                 "MED file format I/O (Salome ecosystem).  Provides import/"
@@ -69,10 +71,12 @@ KNOWLEDGE = {
             ),
             "MappingApplication": (
                 "Inter-mesh field mapping for non-conforming or non-matching "
-                "discretisations.  Provides nearest-neighbour, barycentric, "
-                "and mortar mappers used by FSI partitioned solvers, "
-                "thermo-mechanical coupling, and CoSimulation.  Pip install "
-                "hint: KratosMappingApplication."
+                "discretisations.  Provides nearest-neighbour, nearest-element, "
+                "barycentric, RBF, and beam mappers used by FSI partitioned "
+                "solvers, thermo-mechanical coupling, and CoSimulation.  A "
+                "mortar mapper is upstream-flagged as under development and "
+                "should not be relied on yet.  Pip install hint: "
+                "KratosMappingApplication."
             ),
         },
         "analysis_utilities": {
@@ -84,37 +88,50 @@ KNOWLEDGE = {
                 "hint: KratosStatisticsApplication."
             ),
             "SystemIdentificationApplication": (
-                "System identification and inverse-problem parameter "
-                "estimation: fits material parameters or boundary-condition "
-                "magnitudes against measured response data.  Pip install "
+                "Sensor-based system identification.  Provides sensor types "
+                "(displacement, strain, sensor_view) and a "
+                "measurement_residual_response_function used for sensor "
+                "placement, damage detection, and parameter calibration "
+                "against measured response data.  Upstream README is empty "
+                "as of writing; see `custom_sensors/` and `custom_responses/` "
+                "for the actually-implemented surface area.  Pip install "
                 "hint: KratosSystemIdentificationApplication."
             ),
         },
-        "legacy_apps": {
+        "older_solid_and_contact_apps": {
             "SolidMechanicsApplication": (
-                "Legacy solid-mechanics application.  Predecessor of "
-                "StructuralMechanicsApplication — prefer the latter for new "
-                "work.  Still present upstream for backward compatibility "
-                "with older input decks.  Pip install hint: "
-                "KratosSolidMechanicsApplication."
+                "Older solid-mechanics application focused on FEM for solids, "
+                "shells and beams (per its upstream README).  "
+                "StructuralMechanicsApplication is the modern path that the "
+                "current Kratos generators target — prefer it for new work; "
+                "use SolidMechanicsApplication only if you are reading an "
+                "existing input deck that already targets it.  Pip install "
+                "hint: KratosSolidMechanicsApplication."
             ),
             "ContactMechanicsApplication": (
-                "Legacy contact-mechanics application.  Largely superseded "
-                "by ContactStructuralMechanicsApplication for the "
-                "structural-contact workflow.  Pip install hint: "
+                "Older contact-mechanics application.  For new structural-"
+                "contact workflows the established path is "
+                "ContactStructuralMechanicsApplication, which is what the "
+                "agent's contact generator already targets.  Upstream README "
+                "is empty; surface area is whatever lives under the app's "
+                "`custom_*/` directories.  Pip install hint: "
                 "KratosContactMechanicsApplication."
             ),
         },
         "pitfalls": [
-            "TrilinosApplication and MetisApplication ship in the MPI-parallel "
-            "Kratos build only; pip-installed serial wheels do not include them.",
-            "MappingApplication and MeshMovingApplication are *required* (not "
-            "optional) for partitioned FSI even if not named explicitly in "
-            "the user-facing JSON — the FSIApplication imports them.",
-            "Prefer StructuralMechanicsApplication over SolidMechanicsApplication "
-            "and ContactStructuralMechanicsApplication over ContactMechanicsApplication "
-            "for new analyses; the legacy apps are kept only for input-deck "
-            "backward compatibility and receive minimal maintenance.",
+            "TrilinosApplication is not published on PyPI; to get it you "
+            "must build Kratos from source with `-DTRILINOS_APPLICATION=ON` "
+            "against an MPI-built Trilinos.  MetisApplication does have a "
+            "PyPI wheel (KratosMetisApplication), but it is only useful in "
+            "an MPI-parallel run.",
+            "MappingApplication and MeshMovingApplication are *required* "
+            "(not optional) for partitioned FSI even if not named explicitly "
+            "in the user-facing JSON — `FSIApplication`'s "
+            "`partitioned_fsi_base_solver.py` imports both at runtime.",
+            "For new analyses prefer StructuralMechanicsApplication and "
+            "ContactStructuralMechanicsApplication over the older "
+            "SolidMechanicsApplication / ContactMechanicsApplication paths; "
+            "the current Kratos generators target the modern apps.",
         ],
     },
 }

--- a/src/backends/kratos/generators/auxiliary_applications.py
+++ b/src/backends/kratos/generators/auxiliary_applications.py
@@ -1,0 +1,123 @@
+"""Kratos auxiliary applications — utility, infrastructure, and legacy apps.
+
+These do not own their own physics problem types, so they have no
+GENERATORS — but the agent needs to know about them because other
+generators reference them (e.g. FSI pulls in MappingApplication;
+parallel runs need TrilinosApplication + MetisApplication; HDF5
+output needs HDF5Application).
+
+Source: upstream Kratos `applications/` directory listing.  Every name
+in `KNOWLEDGE` below must correspond to a real sub-application.
+"""
+
+
+KNOWLEDGE = {
+    "_auxiliary_overview": {
+        "description": (
+            "Kratos applications that the agent must know about even though "
+            "they do not provide their own physics problem type: parallel "
+            "infrastructure, I/O, meshing, mapping, statistics, and legacy "
+            "predecessors of currently-active applications.  Pulled in as "
+            "dependencies of physics applications rather than driven directly."
+        ),
+        "infrastructure_apps": {
+            "TrilinosApplication": (
+                "Trilinos linear-solver wrappers (Epetra, AztecOO, Amesos, ML, "
+                "MueLu) for distributed-memory MPI runs.  Required by any "
+                "parallel Kratos analysis using iterative or AMG-preconditioned "
+                "solvers.  Pip install hint: KratosTrilinosApplication."
+            ),
+            "MetisApplication": (
+                "Metis-based mesh partitioner for MPI runs.  Used by the model-"
+                "part-IO splitter to produce per-rank .mdpa files.  Pulled in "
+                "by every MPI workflow; no Python-facing physics on its own.  "
+                "Pip install hint: KratosMetisApplication."
+            ),
+            "LinearSolversApplication": (
+                "Linear-solver wrappers beyond Kratos core (Eigen-based "
+                "sparse_qr/sparse_lu/sparse_cg, PARDISO, complex-valued solvers).  "
+                "Used by structural and electromagnetic analyses needing direct "
+                "factorisation or complex arithmetic.  Pip install hint: "
+                "KratosLinearSolversApplication."
+            ),
+            "HDF5Application": (
+                "Parallel HDF5 I/O.  Provides HDF5OutputProcess and HDF5IO for "
+                "checkpointing, restart, and PETSc-friendly result storage.  "
+                "Used by long simulations and FSI restart workflows.  Pip "
+                "install hint: KratosHDF5Application."
+            ),
+            "MedApplication": (
+                "MED file format I/O (Salome ecosystem).  Provides import/"
+                "export of Salome-generated meshes and post-processing into "
+                "MED format.  Pip install hint: KratosMedApplication."
+            ),
+        },
+        "meshing_and_mapping": {
+            "MeshingApplication": (
+                "Adaptive mesh refinement (h-refinement) and remeshing.  "
+                "Provides MMG / PMMG bindings for tetrahedral and triangular "
+                "remeshing driven by error indicators.  Used by large-"
+                "deformation solid mechanics and adaptive CFD.  Pip install "
+                "hint: KratosMeshingApplication."
+            ),
+            "MeshMovingApplication": (
+                "ALE (arbitrary Lagrangian-Eulerian) mesh-moving strategies: "
+                "Laplacian smoothing, structural-similarity, and rigid-body "
+                "displacement of inner boundaries.  Required by FSI (the fluid "
+                "mesh follows the structural interface) and by any moving-"
+                "boundary CFD.  Pip install hint: KratosMeshMovingApplication."
+            ),
+            "MappingApplication": (
+                "Inter-mesh field mapping for non-conforming or non-matching "
+                "discretisations.  Provides nearest-neighbour, barycentric, "
+                "and mortar mappers used by FSI partitioned solvers, "
+                "thermo-mechanical coupling, and CoSimulation.  Pip install "
+                "hint: KratosMappingApplication."
+            ),
+        },
+        "analysis_utilities": {
+            "StatisticsApplication": (
+                "Statistical post-processing of time-series and ensemble "
+                "fields: mean, variance, RMS, time-averaged Reynolds stresses, "
+                "spatially-averaged quantities.  Used in turbulence post-"
+                "processing and uncertainty quantification.  Pip install "
+                "hint: KratosStatisticsApplication."
+            ),
+            "SystemIdentificationApplication": (
+                "System identification and inverse-problem parameter "
+                "estimation: fits material parameters or boundary-condition "
+                "magnitudes against measured response data.  Pip install "
+                "hint: KratosSystemIdentificationApplication."
+            ),
+        },
+        "legacy_apps": {
+            "SolidMechanicsApplication": (
+                "Legacy solid-mechanics application.  Predecessor of "
+                "StructuralMechanicsApplication — prefer the latter for new "
+                "work.  Still present upstream for backward compatibility "
+                "with older input decks.  Pip install hint: "
+                "KratosSolidMechanicsApplication."
+            ),
+            "ContactMechanicsApplication": (
+                "Legacy contact-mechanics application.  Largely superseded "
+                "by ContactStructuralMechanicsApplication for the "
+                "structural-contact workflow.  Pip install hint: "
+                "KratosContactMechanicsApplication."
+            ),
+        },
+        "pitfalls": [
+            "TrilinosApplication and MetisApplication ship in the MPI-parallel "
+            "Kratos build only; pip-installed serial wheels do not include them.",
+            "MappingApplication and MeshMovingApplication are *required* (not "
+            "optional) for partitioned FSI even if not named explicitly in "
+            "the user-facing JSON — the FSIApplication imports them.",
+            "Prefer StructuralMechanicsApplication over SolidMechanicsApplication "
+            "and ContactStructuralMechanicsApplication over ContactMechanicsApplication "
+            "for new analyses; the legacy apps are kept only for input-deck "
+            "backward compatibility and receive minimal maintenance.",
+        ],
+    },
+}
+
+
+GENERATORS: dict = {}


### PR DESCRIPTION
## Summary
- Twelve upstream Kratos applications were never mentioned in the catalog and so could not be surfaced by the MCP, even though several are *required* dependencies of workflows we already advertise (e.g. partitioned FSI silently pulls in `MappingApplication` + `MeshMovingApplication`).
- New `src/backends/kratos/generators/auxiliary_applications.py` carries a single `_auxiliary_overview` knowledge entry and an empty `GENERATORS` dict; each of the 12 apps gets a short description grouping it as infrastructure, meshing/mapping, analysis-utility, or legacy.
- Legacy apps (`SolidMechanicsApplication`, `ContactMechanicsApplication`) are explicitly flagged with the modern successor the agent should suggest instead.
- Pitfalls section calls out that `TrilinosApplication` + `MetisApplication` ship in the MPI-parallel Kratos build only, and that `MappingApplication` + `MeshMovingApplication` are required by FSI even when the user-facing JSON doesn't name them.

Closes the only remaining `OFA_STRICT_CATALOG=1` failure on the Kratos side (the deal.II FE-class under-declaration is a separate concern, tracked separately).

## Test plan
- [x] `OFA_STRICT_CATALOG=1 pytest tests/test_catalog_consistency.py::TestKratosApplications -v` — both subtests pass.
- [x] `pytest tests/test_catalog_consistency.py` — 10 passed, 2 skipped (FEniCSx + DUNE-fem not importable in this env, expected).
- [ ] CI on push reruns the same suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)