### PR TITLE
Cover the remaining 28 deal.II FE_* classes in the catalog

### DIFF
--- a/data/dealii_knowledge.py
+++ b/data/dealii_knowledge.py
@@ -107,10 +107,21 @@ DEALII_KNOWLEDGE = {
             "FE_SimplexP_Bubbles(p)": "Simplex Lagrange + bubble enrichment",
         },
         "H1_enriched": {
-            "FE_Q_Bubbles(p)": "Q + cell-interior bubble enrichment (caveat: condition number grows fast for p>3)",
-            "FE_Q_DG0(p)": "Lagrange Qp plus the space of cell-wise constant functions (Qp+DG0)",
-            "FE_Q_iso_Q1(p)": "Piecewise (bi-/tri-)linear functions on a macro-element of p^dim sub-cells",
-            "FE_RannacherTurek(0)": "Classical nonconforming first-order element (degree fixed to 0 upstream)",
+            "_note": (
+                "Strictly H1-conforming enrichments — safe to pick when the "
+                "formulation requires H1 continuity."
+            ),
+            "FE_Q_Bubbles(p)": "Q + cell-interior bubble enrichment (bubble vanishes on cell boundary; H1 preserved). Caveat: condition number grows fast for p>3",
+            "FE_Q_iso_Q1(p)": "Piecewise (bi-/tri-)linear functions on a macro-element of p^dim sub-cells; globally continuous so H1-conforming",
+        },
+        "nonconforming_and_qp_dg0": {
+            "_note": (
+                "These are NOT H1-conforming.  Do NOT pick them for an "
+                "H1-conforming formulation — they are listed here only so "
+                "the agent recognises them when reading existing decks."
+            ),
+            "FE_Q_DG0(p)": "Lagrange Qp PLUS cell-wise constants (Qp+DG0); the added piecewise-constant mode is discontinuous across element boundaries",
+            "FE_RannacherTurek(0)": "Classical first-order nonconforming element; continuity enforced only at face midpoints, not pointwise (degree fixed to 0 upstream)",
         },
         "DG_discontinuous": {
             "FE_DGQ(p)": "Tensor-product DG, equidistant points",

--- a/data/dealii_knowledge.py
+++ b/data/dealii_knowledge.py
@@ -106,15 +106,32 @@ DEALII_KNOWLEDGE = {
             "FE_SimplexP(p)": "Lagrange on simplices (triangles/tetrahedra)",
             "FE_SimplexP_Bubbles(p)": "Simplex Lagrange + bubble enrichment",
         },
+        "H1_enriched": {
+            "FE_Q_Bubbles(p)": "Q + cell-interior bubble enrichment (caveat: condition number grows fast for p>3)",
+            "FE_Q_DG0(p)": "Lagrange Qp plus the space of cell-wise constant functions (Qp+DG0)",
+            "FE_Q_iso_Q1(p)": "Piecewise (bi-/tri-)linear functions on a macro-element of p^dim sub-cells",
+            "FE_RannacherTurek(0)": "Classical nonconforming first-order element (degree fixed to 0 upstream)",
+        },
         "DG_discontinuous": {
             "FE_DGQ(p)": "Tensor-product DG, equidistant points",
             "FE_DGQLegendre(p)": "DG with Legendre basis (orthogonal, good for L2 projection)",
             "FE_DGQHermite(p)": "DG Hermite-like (optimal for matrix-free, sum factorization)",
+            "FE_DGQArbitraryNodes(quadrature)": "DG_Q on a user-chosen node set (Gauss-Lobatto/Gauss/equispaced) for matrix-free / spectral-element style discretisations",
             "FE_DGP(p)": "Complete polynomial DG (fewer DOFs than DGQ for same order)",
+            "FE_DGPMonomial(p)": "DG using the monomial polynomial basis rather than the standard nodal basis",
+            "FE_DGPNonparametric(p)": "DG with a non-parametric mapping (polynomials defined in physical space)",
             "FE_SimplexDGP(p)": "DG on simplices",
+        },
+        "DG_vector_valued": {
+            "FE_DGVector<PolynomialsType>": "Class template in fe_dg_vector.h that wraps a vector-valued polynomial space into a DG element. The three concrete instantiations below derive from it",
+            "FE_DGRaviartThomas(k)": "DG element on the RT polynomial space (DG mixed methods)",
+            "FE_DGNedelec(k)": "DG element on the Nédélec polynomial space (discontinuous H(curl)-type)",
+            "FE_DGBDM(k)": "DG element on the Brezzi-Douglas-Marini polynomial space (discontinuous H(div)-type)",
         },
         "Hdiv_conforming": {
             "FE_RaviartThomas(k)": "Raviart-Thomas (normal continuous, for mixed Poisson/Darcy)",
+            "FE_RaviartThomasNodal(k)": "RT with a nodal-DoF representation (alternative to the moment-based default)",
+            "FE_RT_Bubbles(k)": "RT enriched with interior bubble functions for improved approximation order",
             "FE_BDM(k)": "Brezzi-Douglas-Marini (full polynomial H(div))",
             "FE_ABF(k)": "Arnold-Boffi-Falk",
             "FE_BernardiRaugel(1)": "Inf-sup stable with DGP(0) for Stokes",
@@ -122,6 +139,18 @@ DEALII_KNOWLEDGE = {
         "Hcurl_conforming": {
             "FE_Nedelec(k)": "Nédélec edge elements for Maxwell/electromagnetics",
             "FE_NedelecSZ(k)": "Schoeberl-Zaglmayr ordering variant",
+            "FE_NedelecNodal(k)": "Nédélec with nodal-interpolation DoF setup (alternative to the default)",
+        },
+        "trace_and_face": {
+            "FE_FaceQ(p)": "Q-polynomial face element for hybridised DG interface unknowns (HDG, step-51)",
+            "FE_FaceP(p)": "P-polynomial face element, simplex analogue of FE_FaceQ",
+            "FE_TraceQ(p)": "Trace of FE_Q on element faces (Lagrange-multiplier / HDG stabilisations)",
+        },
+        "pyramid_and_wedge_3d": {
+            "FE_PyramidP(p)": "Continuous P element on pyramidal (square-base) 3D cells — hex<->tet transition",
+            "FE_PyramidDGP(p)": "DG counterpart of FE_PyramidP",
+            "FE_WedgeP(p)": "Continuous P element on wedge (triangular-prism) 3D cells — hex<->tet transition",
+            "FE_WedgeDGP(p)": "DG counterpart of FE_WedgeP",
         },
         "special": {
             "FE_FaceQ(p)": "DOFs on faces only (for HDG trace systems, step-51)",
@@ -130,6 +159,21 @@ DEALII_KNOWLEDGE = {
             "FE_P1NC": "Nonconforming P1 (Crouzeix-Raviart analogue)",
             "FESystem": "Combine multiple FE into vector/tensor systems",
             "hp::FECollection": "Collection of different FE for hp-adaptivity",
+        },
+        "internal_polynomial_bases": {
+            "_note": (
+                "Abstract polynomial base classes that the concrete elements "
+                "above are templated on (FE_Q is an FE_Q_Base; FE_PyramidP is "
+                "an FE_PyramidPoly; etc.).  No public stand-alone constructor "
+                "— do NOT propose these as user-facing element choices."
+            ),
+            "FE_Poly": "Base class for polynomial-based scalar elements",
+            "FE_PolyFace": "Face-only polynomial base class",
+            "FE_PolyTensor": "Tensor-product polynomial base class",
+            "FE_Q_Base": "Base of the FE_Q family (FE_Q, FE_Q_Hierarchical, FE_Q_Bubbles, ...)",
+            "FE_SimplexPoly": "Base of the FE_SimplexP family",
+            "FE_PyramidPoly": "Base of the FE_PyramidP / FE_PyramidDGP family",
+            "FE_WedgePoly": "Base of the FE_WedgeP / FE_WedgeDGP family",
         },
     },
 

--- a/src/backends/dealii/generators/poisson.py
+++ b/src/backends/dealii/generators/poisson.py
@@ -635,21 +635,32 @@ GENERAL_KNOWLEDGE = {
     "element_types": {
         "H1": "FE_Q(p), FE_Q_Hierarchical(p), FE_Bernstein(p), FE_Hermite(p), FE_SimplexP(p)",
         "H1_enriched": (
+            "Strictly H1-conforming enrichments — safe to use anywhere "
+            "the formulation needs H1 continuity:  "
             "FE_Q_Bubbles(p) — Q with cell-interior bubble enrichment "
-            "(adds one bubble per cell on top of the standard Q basis).  "
-            "Upstream caveat: condition number grows quickly for p > 3; "
-            "use the lowest applicable degree.  "
-            "FE_SimplexP_Bubbles(p) — simplex analogue of FE_Q_Bubbles "
-            "(P basis on triangles/tetrahedra plus a cell-interior bubble); "
-            "FE_Q_DG0(p) — Lagrange Qp **plus** the space of cell-wise "
-            "constant functions (Qp+DG0), continuous in the Lagrange part "
-            "and discontinuous in the added piecewise-constant part; "
+            "(the bubble vanishes on the cell boundary, so inter-element "
+            "continuity is preserved).  Upstream caveat: condition number "
+            "grows quickly for p > 3; use the lowest applicable degree.  "
+            "FE_SimplexP_Bubbles(p) — simplex analogue of FE_Q_Bubbles.  "
             "FE_Q_iso_Q1(p) — piecewise (bi-/tri-)linear functions on a "
-            "macro-element of p^dim sub-cells: the cell is conceptually "
+            "macro-element of p^dim sub-cells; the cell is conceptually "
             "split into p subdivisions per coordinate direction and a Q1 "
-            "basis is laid down on the resulting subcells; "
-            "FE_RannacherTurek(0) — classical nonconforming first-order "
-            "element (degree argument is fixed to 0 in upstream)."
+            "basis is laid down on the resulting subcells (still globally "
+            "continuous, so H1-conforming)."
+        ),
+        "nonconforming_and_qp_dg0": (
+            "NOT H1-conforming — agent should NOT pick these for an "
+            "H1-conforming formulation:  "
+            "FE_Q_DG0(p) — Lagrange Qp **plus** the space of cell-wise "
+            "constant functions (Qp+DG0).  The added piecewise-constant "
+            "part is discontinuous across element boundaries; only the "
+            "Lagrange part is continuous.  Used in mixed/stabilised "
+            "discretisations that explicitly want the extra discontinuous "
+            "mode.  "
+            "FE_RannacherTurek(0) — classical first-order *nonconforming* "
+            "element (degree argument fixed to 0 in upstream).  Continuity "
+            "is enforced only at edge/face midpoints, not pointwise across "
+            "faces."
         ),
         "DG": "FE_DGQ(p), FE_DGQLegendre(p), FE_DGQHermite(p), FE_DGP(p), FE_SimplexDGP(p)",
         "DG_advanced": (

--- a/src/backends/dealii/generators/poisson.py
+++ b/src/backends/dealii/generators/poisson.py
@@ -634,10 +634,77 @@ GENERAL_KNOWLEDGE = {
     "description": "deal.II general capabilities",
     "element_types": {
         "H1": "FE_Q(p), FE_Q_Hierarchical(p), FE_Bernstein(p), FE_Hermite(p), FE_SimplexP(p)",
+        "H1_enriched": (
+            "FE_Q_Bubbles(p) — Q with cell-interior bubble enrichment, useful "
+            "for stabilised Stokes-like saddle-point problems where extra "
+            "interior dofs cure inf-sup issues; "
+            "FE_SimplexP_Bubbles(p) — simplex P with bubble enrichment for "
+            "the same purpose on triangular/tetrahedral meshes; "
+            "FE_Q_DG0(p) — continuous Q with one discontinuous mode, "
+            "used for enriched-pressure stabilisations; "
+            "FE_Q_iso_Q1(p) — isoparametric subdivision of Q(p) into Q1 "
+            "patches, kept for multilevel/coarse-grid constructions; "
+            "FE_RannacherTurek(0) — rotated-bilinear nonconforming Q1, "
+            "the classical Rannacher-Turek element for Stokes."
+        ),
         "DG": "FE_DGQ(p), FE_DGQLegendre(p), FE_DGQHermite(p), FE_DGP(p), FE_SimplexDGP(p)",
+        "DG_advanced": (
+            "FE_DGQArbitraryNodes(quadrature) — DG_Q on a user-chosen node "
+            "set (Gauss-Lobatto, Gauss, equispaced) for matrix-free / "
+            "spectral-element style discretisations; "
+            "FE_DGPMonomial(p) — DG using the monomial polynomial basis "
+            "rather than the standard nodal basis (kept for legacy "
+            "comparison and analytic-coefficient access); "
+            "FE_DGPNonparametric(p) — DG with a non-parametric mapping, "
+            "i.e. polynomials defined in physical (not reference) space; "
+            "FE_DGVector — generic vector-valued DG wrapper around any "
+            "scalar DG family; "
+            "FE_DGBDM(k) — DG version of FE_BDM (Brezzi-Douglas-Marini) "
+            "for H(div) without inter-element continuity; "
+            "FE_DGRaviartThomas(k) — DG analogue of FE_RaviartThomas, "
+            "used in DG mixed methods; "
+            "FE_DGNedelec(k) — DG analogue of FE_Nedelec for H(curl) "
+            "discontinuous discretisations."
+        ),
         "H(div)": "FE_RaviartThomas(k), FE_BDM(k), FE_ABF(k), FE_BernardiRaugel(1)",
+        "H(div)_advanced": (
+            "FE_RaviartThomasNodal(k) — RT with a nodal degree-of-freedom "
+            "representation (alternative to the moment-based default), "
+            "convenient when interpolating from a nodal velocity field; "
+            "FE_RT_Bubbles(k) — RT enriched with interior bubble functions "
+            "for improved approximation order on a fixed mesh."
+        ),
         "H(curl)": "FE_Nedelec(k), FE_NedelecSZ(k)",
+        "H(curl)_advanced": (
+            "FE_NedelecNodal(k) — Nédélec element with a nodal-interpolation "
+            "DoF setup, useful when coupling against nodal H(curl) data."
+        ),
+        "trace_and_face": (
+            "FE_FaceQ(p) — Q-polynomial face element used for "
+            "hybridised DG (HDG) interface unknowns; "
+            "FE_FaceP(p) — P-polynomial face element, the simplex "
+            "analogue of FE_FaceQ; "
+            "FE_TraceQ(p) — trace of FE_Q on element faces, used by "
+            "Lagrange-multiplier and HDG stabilisations."
+        ),
+        "pyramid_and_wedge_3d": (
+            "FE_PyramidP(p) — continuous P element on pyramidal (square-base) "
+            "3D cells, used in transition meshes between hex and tet regions; "
+            "FE_PyramidDGP(p) — DG counterpart of FE_PyramidP; "
+            "FE_PyramidPoly — generic polynomial base for pyramid cells "
+            "(template scaffolding the two above sit on top of); "
+            "FE_WedgeP(p) — continuous P element on wedge (triangular-prism) "
+            "3D cells, the second transition shape between hex and tet; "
+            "FE_WedgeDGP(p) — DG counterpart of FE_WedgeP; "
+            "FE_WedgePoly — generic polynomial base for wedge cells."
+        ),
         "special": "FE_FaceQ(p), FE_Nothing, FE_Enriched, FE_P1NC, FESystem, hp::FECollection",
+        "internal_polynomial_bases": (
+            "FE_Poly, FE_PolyFace, FE_PolyTensor, FE_Q_Base, FE_SimplexPoly — "
+            "abstract base classes that the concrete elements above are "
+            "templated on.  Listed here only so the agent does not propose "
+            "them in user code; these classes are not directly instantiated."
+        ),
     },
     "mesh_generators": [
         "hyper_cube, hyper_rectangle, hyper_L, hyper_ball, hyper_shell",

--- a/src/backends/dealii/generators/poisson.py
+++ b/src/backends/dealii/generators/poisson.py
@@ -635,17 +635,21 @@ GENERAL_KNOWLEDGE = {
     "element_types": {
         "H1": "FE_Q(p), FE_Q_Hierarchical(p), FE_Bernstein(p), FE_Hermite(p), FE_SimplexP(p)",
         "H1_enriched": (
-            "FE_Q_Bubbles(p) — Q with cell-interior bubble enrichment, useful "
-            "for stabilised Stokes-like saddle-point problems where extra "
-            "interior dofs cure inf-sup issues; "
-            "FE_SimplexP_Bubbles(p) — simplex P with bubble enrichment for "
-            "the same purpose on triangular/tetrahedral meshes; "
-            "FE_Q_DG0(p) — continuous Q with one discontinuous mode, "
-            "used for enriched-pressure stabilisations; "
-            "FE_Q_iso_Q1(p) — isoparametric subdivision of Q(p) into Q1 "
-            "patches, kept for multilevel/coarse-grid constructions; "
-            "FE_RannacherTurek(0) — rotated-bilinear nonconforming Q1, "
-            "the classical Rannacher-Turek element for Stokes."
+            "FE_Q_Bubbles(p) — Q with cell-interior bubble enrichment "
+            "(adds one bubble per cell on top of the standard Q basis).  "
+            "Upstream caveat: condition number grows quickly for p > 3; "
+            "use the lowest applicable degree.  "
+            "FE_SimplexP_Bubbles(p) — simplex analogue of FE_Q_Bubbles "
+            "(P basis on triangles/tetrahedra plus a cell-interior bubble); "
+            "FE_Q_DG0(p) — Lagrange Qp **plus** the space of cell-wise "
+            "constant functions (Qp+DG0), continuous in the Lagrange part "
+            "and discontinuous in the added piecewise-constant part; "
+            "FE_Q_iso_Q1(p) — piecewise (bi-/tri-)linear functions on a "
+            "macro-element of p^dim sub-cells: the cell is conceptually "
+            "split into p subdivisions per coordinate direction and a Q1 "
+            "basis is laid down on the resulting subcells; "
+            "FE_RannacherTurek(0) — classical nonconforming first-order "
+            "element (degree argument is fixed to 0 in upstream)."
         ),
         "DG": "FE_DGQ(p), FE_DGQLegendre(p), FE_DGQHermite(p), FE_DGP(p), FE_SimplexDGP(p)",
         "DG_advanced": (
@@ -657,14 +661,16 @@ GENERAL_KNOWLEDGE = {
             "comparison and analytic-coefficient access); "
             "FE_DGPNonparametric(p) — DG with a non-parametric mapping, "
             "i.e. polynomials defined in physical (not reference) space; "
-            "FE_DGVector — generic vector-valued DG wrapper around any "
-            "scalar DG family; "
-            "FE_DGBDM(k) — DG version of FE_BDM (Brezzi-Douglas-Marini) "
-            "for H(div) without inter-element continuity; "
-            "FE_DGRaviartThomas(k) — DG analogue of FE_RaviartThomas, "
-            "used in DG mixed methods; "
-            "FE_DGNedelec(k) — DG analogue of FE_Nedelec for H(curl) "
-            "discontinuous discretisations."
+            "FE_DGVector<PolynomialsType> — class template defined in "
+            "fe_dg_vector.h that wraps a vector-valued polynomial space "
+            "(PolynomialsRaviartThomas, PolynomialsNedelec, PolynomialsBDM) "
+            "into a DG element.  The three concrete instantiations are: "
+            "FE_DGRaviartThomas(k) — DG element built on the RT polynomial "
+            "space (used in DG mixed methods); "
+            "FE_DGNedelec(k) — DG element on the Nédélec polynomial space "
+            "(discontinuous H(curl)-type approximation); "
+            "FE_DGBDM(k) — DG element on the Brezzi-Douglas-Marini "
+            "polynomial space (discontinuous H(div)-type approximation)."
         ),
         "H(div)": "FE_RaviartThomas(k), FE_BDM(k), FE_ABF(k), FE_BernardiRaugel(1)",
         "H(div)_advanced": (
@@ -691,19 +697,19 @@ GENERAL_KNOWLEDGE = {
             "FE_PyramidP(p) — continuous P element on pyramidal (square-base) "
             "3D cells, used in transition meshes between hex and tet regions; "
             "FE_PyramidDGP(p) — DG counterpart of FE_PyramidP; "
-            "FE_PyramidPoly — generic polynomial base for pyramid cells "
-            "(template scaffolding the two above sit on top of); "
             "FE_WedgeP(p) — continuous P element on wedge (triangular-prism) "
             "3D cells, the second transition shape between hex and tet; "
-            "FE_WedgeDGP(p) — DG counterpart of FE_WedgeP; "
-            "FE_WedgePoly — generic polynomial base for wedge cells."
+            "FE_WedgeDGP(p) — DG counterpart of FE_WedgeP."
         ),
         "special": "FE_FaceQ(p), FE_Nothing, FE_Enriched, FE_P1NC, FESystem, hp::FECollection",
         "internal_polynomial_bases": (
-            "FE_Poly, FE_PolyFace, FE_PolyTensor, FE_Q_Base, FE_SimplexPoly — "
-            "abstract base classes that the concrete elements above are "
-            "templated on.  Listed here only so the agent does not propose "
-            "them in user code; these classes are not directly instantiated."
+            "FE_Poly, FE_PolyFace, FE_PolyTensor, FE_Q_Base, FE_SimplexPoly, "
+            "FE_PyramidPoly, FE_WedgePoly — abstract polynomial base classes "
+            "that the concrete elements above are templated on (e.g. FE_Q is "
+            "an FE_Q_Base; FE_PyramidP is an FE_PyramidPoly; FE_SimplexP is "
+            "an FE_SimplexPoly).  Listed here only so the agent does not "
+            "propose them in user code; these classes have no public "
+            "stand-alone constructor and are not directly instantiated."
         ),
     },
     "mesh_generators": [


### PR DESCRIPTION
## Summary
- deal.II's `element_types` knowledge dict listed 20 of the 48 `FE_*` classes shipped under upstream `dealii/include/deal.II/fe/`. The other 28 were never mentioned anywhere in the catalog — so the agent could not propose them, and the strict-mode test hard-failed on this gap.
- Every missing class now appears in an appropriate subsection of `element_types` with a one-line description of its purpose. The five abstract base classes (`FE_Poly`, `FE_PolyFace`, `FE_PolyTensor`, `FE_Q_Base`, `FE_SimplexPoly`) are grouped under `internal_polynomial_bases` and explicitly flagged as "not directly instantiated", so the agent knows to NOT propose them in user code.

After this PR the `OFA_STRICT_CATALOG=1` suite passes 10 / 12 (the two skips are FEniCSx + DUNE-fem probes that need the respective Python modules importable in the local pytest env — expected, not gaps).

## Test plan
- [x] `OFA_STRICT_CATALOG=1 pytest tests/test_catalog_consistency.py::TestDealiiFiniteElementClasses -v` — both subtests pass.
- [x] `OFA_STRICT_CATALOG=1 pytest tests/test_catalog_consistency.py` — full suite green (10 passed, 2 skipped).
- [ ] CI on push reruns the same suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)