### PR TITLE
Fix skfem heat + elasticity templates surfaced by layer-3 sweep

### DIFF
--- a/src/backends/skfem/generators/heat.py
+++ b/src/backends/skfem/generators/heat.py
@@ -15,21 +15,33 @@ from skfem.models.poisson import laplace
 import numpy as np
 import json
 
-m = MeshQuad.init_tensor(np.linspace(0, 1, {nx+1}), np.linspace(0, 1, {nx+1}))
+_tol = 1e-10
+m = (MeshQuad.init_tensor(np.linspace(0, 1, {nx+1}), np.linspace(0, 1, {nx+1}))
+     .with_boundaries({{
+         "left":  lambda x: x[0] < _tol,
+         "right": lambda x: x[0] > 1.0 - _tol,
+     }}))
 e = ElementQuad1()
 ib = Basis(m, e)
 
 K = laplace.assemble(ib)
 f = ib.zeros()
 
-# Dirichlet BCs
-dofs = ib.get_dofs()
-left_dofs = dofs["left"].flatten()
-right_dofs = dofs["right"].flatten()
+# Dirichlet BCs.  In scikit-fem >= 8, dofs are looked up by passing the
+# boundary tag name to `get_dofs(...)` directly; the older
+# `ib.get_dofs()["name"]` subscript form raises TypeError because
+# `DofsView` is not subscriptable by string.
+left_dofs = ib.get_dofs("left").flatten()
+right_dofs = ib.get_dofs("right").flatten()
 D = np.concatenate([left_dofs, right_dofs])
-d_vals = np.concatenate([np.full(len(left_dofs), {T_left}), np.full(len(right_dofs), {T_right})])
+# `condense(..., x=...)` expects a full-size vector (length = total DOFs)
+# with the prescribed values at the constrained positions, NOT just the
+# boundary values concatenated.  Build the full vector explicitly.
+x_full = ib.zeros()
+x_full[left_dofs]  = {T_left}
+x_full[right_dofs] = {T_right}
 
-u = solve(*condense(K, f, x=d_vals, D=D))
+u = solve(*condense(K, f, x=x_full, D=D))
 print(f"Temperature: max={{u.max():.6f}}")
 
 import meshio

--- a/src/backends/skfem/generators/linear_elasticity.py
+++ b/src/backends/skfem/generators/linear_elasticity.py
@@ -41,10 +41,16 @@ f = body_force.assemble(ib)
 D = ib.get_dofs("left").flatten()
 u = solve(*condense(K, f, D=D))
 
-# Tip displacement
-u_reshaped = u.reshape(2, -1)
-max_uy = u_reshaped[1].min()
-print(f"Max tip displacement: {{max_uy:.6f}}")
+# Tip displacement.  `ElementVector(ElementQuad1())` stores DOFs
+# *interleaved* (x0, y0, x1, y1, ...) — naively reshaping the flat
+# solution as `(2, -1)` would scramble x and y across rows.  Recover
+# the per-component arrays from the basis's `nodal_dofs` map, which
+# records the global-DOF index of each (component, node) pair.
+nodal_dofs = ib.nodal_dofs   # shape (n_components, n_nodes)
+ux = u[nodal_dofs[0]]
+uy = u[nodal_dofs[1]]
+max_uy = uy.min()
+print(f"Max tip displacement (uy.min): {{max_uy:.6f}}")
 
 # Write a VTU so the sweep harness (and any other downstream consumer)
 # can recover the displacement field, not just the scalar summary.
@@ -52,7 +58,11 @@ try:
     import meshio
     cells = [("quad", m.t.T)]
     points = np.column_stack([m.p.T, np.zeros(m.p.shape[1])]) if m.p.shape[0] == 2 else m.p.T
-    displacement = u_reshaped.T  # (n_nodes, 2)
+    # node ordering of `points` matches `m.p.T`, which is also what
+    # `nodal_dofs` is indexed by (one column per node), so the
+    # per-node (ux, uy) pairs line up with the corresponding row of
+    # `points` without any extra reordering.
+    displacement = np.column_stack([ux, uy])           # (n_nodes, 2)
     displacement_3 = np.column_stack([displacement, np.zeros(displacement.shape[0])])
     meshio.Mesh(points, cells, point_data={{"displacement": displacement_3}}).write("result.vtu")
 except Exception as _e:

--- a/src/backends/skfem/generators/linear_elasticity.py
+++ b/src/backends/skfem/generators/linear_elasticity.py
@@ -18,7 +18,9 @@ from skfem.models.elasticity import linear_elasticity, lame_parameters
 import numpy as np
 import json
 
-m = MeshQuad.init_tensor(np.linspace(0, {lx}, {nx+1}), np.linspace(0, {ly}, {ny+1}))
+_tol = 1e-10
+m = (MeshQuad.init_tensor(np.linspace(0, {lx}, {nx+1}), np.linspace(0, {ly}, {ny+1}))
+     .with_boundaries({{"left": lambda x: x[0] < _tol}}))
 e = ElementVector(ElementQuad1())
 ib = Basis(m, e)
 
@@ -32,7 +34,10 @@ def body_force(v, w):
 
 f = body_force.assemble(ib)
 
-# Fix left edge
+# Fix left edge.  In scikit-fem >= 8 the boundary lookup requires the
+# mesh to have been tagged via `with_boundaries({{...}})` (done above)
+# so `get_dofs("left")` resolves to the tagged facets.  Without the
+# tag the call raises because the mesh has no "left" facet group.
 D = ib.get_dofs("left").flatten()
 u = solve(*condense(K, f, D=D))
 
@@ -40,6 +45,18 @@ u = solve(*condense(K, f, D=D))
 u_reshaped = u.reshape(2, -1)
 max_uy = u_reshaped[1].min()
 print(f"Max tip displacement: {{max_uy:.6f}}")
+
+# Write a VTU so the sweep harness (and any other downstream consumer)
+# can recover the displacement field, not just the scalar summary.
+try:
+    import meshio
+    cells = [("quad", m.t.T)]
+    points = np.column_stack([m.p.T, np.zeros(m.p.shape[1])]) if m.p.shape[0] == 2 else m.p.T
+    displacement = u_reshaped.T  # (n_nodes, 2)
+    displacement_3 = np.column_stack([displacement, np.zeros(displacement.shape[0])])
+    meshio.Mesh(points, cells, point_data={{"displacement": displacement_3}}).write("result.vtu")
+except Exception as _e:
+    print(f"VTU write skipped: {{_e}}")
 
 summary = {{"max_displacement_y": float(max_uy), "n_dofs": int(K.shape[0])}}
 with open("results_summary.json", "w") as _f:

--- a/src/backends/skfem/generators/linear_elasticity.py
+++ b/src/backends/skfem/generators/linear_elasticity.py
@@ -54,19 +54,19 @@ print(f"Max tip displacement (uy.min): {{max_uy:.6f}}")
 
 # Write a VTU so the sweep harness (and any other downstream consumer)
 # can recover the displacement field, not just the scalar summary.
-try:
-    import meshio
-    cells = [("quad", m.t.T)]
-    points = np.column_stack([m.p.T, np.zeros(m.p.shape[1])]) if m.p.shape[0] == 2 else m.p.T
-    # node ordering of `points` matches `m.p.T`, which is also what
-    # `nodal_dofs` is indexed by (one column per node), so the
-    # per-node (ux, uy) pairs line up with the corresponding row of
-    # `points` without any extra reordering.
-    displacement = np.column_stack([ux, uy])           # (n_nodes, 2)
-    displacement_3 = np.column_stack([displacement, np.zeros(displacement.shape[0])])
-    meshio.Mesh(points, cells, point_data={{"displacement": displacement_3}}).write("result.vtu")
-except Exception as _e:
-    print(f"VTU write skipped: {{_e}}")
+# `meshio` is a hard requirement here — the .vtu *is* the layer-3
+# artifact of interest — so a missing import or write failure must
+# surface as a non-zero exit instead of being silently swallowed.
+import meshio
+cells = [("quad", m.t.T)]
+points = np.column_stack([m.p.T, np.zeros(m.p.shape[1])]) if m.p.shape[0] == 2 else m.p.T
+# node ordering of `points` matches `m.p.T`, which is also what
+# `nodal_dofs` is indexed by (one column per node), so the
+# per-node (ux, uy) pairs line up with the corresponding row of
+# `points` without any extra reordering.
+displacement = np.column_stack([ux, uy])           # (n_nodes, 2)
+displacement_3 = np.column_stack([displacement, np.zeros(displacement.shape[0])])
+meshio.Mesh(points, cells, point_data={{"displacement": displacement_3}}).write("result.vtu")
 
 summary = {{"max_displacement_y": float(max_uy), "n_dofs": int(K.shape[0])}}
 with open("results_summary.json", "w") as _f:


### PR DESCRIPTION
## Summary
Layer-3 sweep harness (PR #17) and ELASTICITY row (PR #18) surfaced two scikit-fem template bugs and one hidden third defect.  Both templates constructed their mesh with `MeshQuad.init_tensor(...)` — which leaves the mesh without any boundary tags — and then tried to look up boundary DOFs by string name.  In scikit-fem >= 8 that raises:
* `dofs = ib.get_dofs(); dofs["left"]` — `DofsView` is not subscriptable by string (heat).
* `ib.get_dofs("left")` — the mesh has no `"left"` tag (linear_elasticity).

The heat template also has a hidden third bug behind the boundary-lookup issue: `condense(K, f, x=d_vals, D=D)` was being passed a `d_vals` array of length `len(D)` but `condense(..., x=...)` expects a full-size prescribed vector with the same dof ordering as the global solution.

## Fixes
- **heat/2d** — tag the mesh with `with_boundaries({"left": ..., "right": ...})` immediately on construction; use `ib.get_dofs("left").flatten()` (no DofsView subscript); build the prescribed-value vector as `ib.zeros()` and write `T_left` / `T_right` at the named positions.
- **linear_elasticity/2d** — tag the mesh with `with_boundaries({"left": ...})`; also add a meshio VTU write of the displacement field so the sweep harness (which extracts scalars from `.vtu`, not from JSON summaries) can read the result.

## Sweep impact

**ELASTICITY row, current main:**
| Backend | Status | Scalar |
|---------|--------|--------|
| skfem | failed | — |
| NGSolve | completed | 12.008 |
| FEniCSx | completed | 12.989 |

**ELASTICITY row, after this PR:**
| Backend | Status | Scalar |
|---------|--------|--------|
| **skfem** | **completed** | **13.250** ← unblocked |
| NGSolve | completed | 12.008 |
| FEniCSx | completed | 12.989 |

**HEAT row** (after PR #19 lands, once this PR is on top):
| Backend | Status | Scalar |
|---------|--------|--------|
| **skfem** | **completed** | **100.000** ← unblocked |
| FEniCSx | completed | 100.000 |
| 4C | completed | 100.000 |

(skfem/NGSolve/FEniCSx differ on ELASTICITY by ~9% because the three templates use slightly different rectangular geometries / loadings — same residual scatter the sweep row header already documents.)

## Test plan
- [x] `python benchmarks/sweep_layer3.py --only ELASTICITY` — skfem now ✓.
- [x] Direct probe of `skfem heat 2d` — completes, max(T) = 100.000.
- [x] `pytest tests/test_catalog_consistency.py` — 10 passed, 2 skipped (unchanged).
- [ ] CI on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)