### PR TITLE
Kratos linear-elasticity: real KM.Model solves replacing scipy stubs (+ harness accepts .vtk)

### DIFF
--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -521,30 +521,48 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
                           error=(job.error or "")[:300])
 
     # ── extract scalar from the LAST output snapshot (final time step /
-    # converged state).  We accept every format
-    # `core.post_processing.read_mesh()` knows how to load:
+    # converged state).  Accept every format
+    # `core.post_processing.read_mesh()` knows how to load *except*
+    # `.pvtu`:
     #   .vtu    — modern XML unstructured (FEniCSx, skfem, fourc, ...)
     #   .vtk    — legacy unstructured (KratosMultiphysics `VtkOutput`)
-    #   .pvtu   — parallel-partitioned VTU
     #   .pvd    — ParaView collection / time-series index
     #   .xdmf   — XDMF (dolfinx alternative)
-    # If the set here diverges from `read_mesh`'s, working backends
-    # silently get reported as "no output" by the sweep.
+    # `.pvtu` (parallel-partitioned VTU wrapper) is intentionally
+    # excluded — it can hang PyVista when the per-rank `.vtu`
+    # partials are accessed (see the matching policy at
+    # src/tools/consolidated.py: "skip .pvtu (parallel wrappers
+    # that can hang PyVista)").  The per-rank `.vtu` partials
+    # themselves are accepted directly.
+    #
+    # Suffix matching is case-insensitive: some backends and
+    # filesystems emit upper-case (`.VTU`) and `read_mesh` itself
+    # lower-cases the suffix before dispatching.
     #
     # Sort numerically by trailing step index, NOT lexicographically:
     # backends like Kratos emit `Structure_0_1.vtk, Structure_0_2.vtk,
     # ..., Structure_0_10.vtk`, where lexicographic sort would place
     # `_10` *before* `_9` and pick the wrong snapshot as "the last".
+    # Within the same step, prefer the most-PyVista-stable format
+    # (`.vtu` > `.vtk` > `.xdmf` > `.pvd`) so two formats emitted
+    # for the same step never pick a less-supported container.
     import re as _re
-    _OUTPUT_SUFFIXES = (".vtu", ".vtk", ".pvtu", ".pvd", ".xdmf")
+    _OUTPUT_SUFFIXES = (".vtu", ".vtk", ".pvd", ".xdmf")
+    _SUFFIX_PRIORITY = {".vtu": 0, ".vtk": 1, ".xdmf": 2, ".pvd": 3}
+
     def _step_key(p):
-        # Extract the last contiguous integer run in the stem; fall back
-        # to 0 for files with no digits so they sort first.
         m = _re.findall(r"\d+", p.stem)
-        return (int(m[-1]) if m else 0, p.stem)
+        return (
+            int(m[-1]) if m else 0,
+            # Negate so higher-priority sorts AFTER lower-priority on
+            # the same step (sorted() ascending → key[-1] is "last").
+            -_SUFFIX_PRIORITY.get(p.suffix.lower(), 99),
+            p.stem,
+        )
+
     output_files = sorted(
         (f for f in backend.get_result_files(job)
-         if f.suffix in _OUTPUT_SUFFIXES),
+         if f.suffix.lower() in _OUTPUT_SUFFIXES),
         key=_step_key,
     )
     scalar = None

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -282,11 +282,13 @@ MATRIX: dict[str, list[Cell]] = {
         # skfem's `linear_elasticity/2d` template has two stacked
         # problems: (a) it constructs a tensor-product mesh with no
         # boundary tags and then calls `ib.get_dofs("left")`, which
-        # raises; and (b) even if (a) is fixed, the template writes a
-        # `results_summary.json` only, never a .vtu, so the sweep would
-        # then transition from `failed` to `no_output_file`.  Both are
-        # template bugs to address upstream.  The cell is kept so the
-        # matrix surfaces the gap on every run.
+        # raises; and (b) even if (a) is fixed, the template writes
+        # only a `results_summary.json` — no mesh output file in any
+        # of the formats this harness accepts (`_OUTPUT_SUFFIXES`:
+        # `.vtu` / `.vtk` / `.xdmf`) — so the sweep would then
+        # transition from `failed` to `no_output_file`.  Both are
+        # template bugs to address upstream.  The cell is kept so
+        # the matrix surfaces the gap on every run.
         Cell("skfem",   "linear_elasticity", "2d", {"E": 1000, "nu": 0.3},
              field="displacement", expected=None, rtol=0.5),
         # ngsolve and fenics write the displacement field as
@@ -366,9 +368,10 @@ MATRIX: dict[str, list[Cell]] = {
         # points` because the Taylor-Hood mixed basis is assembled
         # with mismatched quadrature orders between velocity P2 and
         # pressure P1; and (b) even with (a) fixed, the template
-        # writes only a `results_summary.json` and never a `.vtu`,
-        # so the cell would still report `no_vtu_output` until VTU
-        # export is added.  Both are template-side gaps.
+        # writes only a `results_summary.json` and no mesh output in
+        # any of the accepted `_OUTPUT_SUFFIXES`, so the cell would
+        # still report `no_output_file` until VTU export is added.
+        # Both are template-side gaps.
         Cell("skfem",   "stokes", "2d", {"nx": 32, "ny": 32},
              field="velocity", expected=None, rtol=0.5),
         # NGSolve's `stokes/2d` template runs to the solver step then
@@ -445,8 +448,9 @@ MATRIX: dict[str, list[Cell]] = {
 
         # skfem `hyperelasticity/2d` raises during the Newton loop.
         # Root cause is not investigated here — the cell records the
-        # observed failure mode (Newton-loop exception, no .vtu);
-        # template-side fix tracked separately.
+        # observed failure mode (Newton-loop exception, no mesh
+        # output file in any accepted format); template-side fix
+        # tracked separately.
         Cell("skfem",   "hyperelasticity", "2d", {"E": 1000, "nu": 0.3},
              field="displacement", expected=None, rtol=0.5),
         # NGSolve `hyperelasticity/2d` raises during the Newton loop

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -551,9 +551,18 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
     _SUFFIX_PRIORITY = {".vtu": 0, ".vtk": 1, ".xdmf": 2, ".pvd": 3}
 
     def _step_key(p):
-        m = _re.findall(r"\d+", p.stem)
+        # Use the *full tuple* of integer groups in the stem, not just
+        # the last one.  Per-rank output files use a `<name>-<step>-<rank>`
+        # naming convention (e.g. 4C writes `structure-00001-0.vtu` and
+        # Kratos writes `Structure_0_5.vtk` for rank 0 / step 5).  If we
+        # only looked at the last integer we would treat the rank as the
+        # step on 4C (selecting the wrong "final" snapshot when steps
+        # exceed nine and rank stays zero).  An int-tuple key sorts
+        # naturally across both layouts: (step=10, rank=0) > (step=9,
+        # rank=0), and (rank=0, step=10) > (rank=0, step=5).
+        ints = tuple(int(x) for x in _re.findall(r"\d+", p.stem))
         return (
-            int(m[-1]) if m else 0,
+            ints,
             # Negate so higher-priority sorts AFTER lower-priority on
             # the same step (sorted() ascending → key[-1] is "last").
             -_SUFFIX_PRIORITY.get(p.suffix.lower(), 99),

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -521,19 +521,36 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
                           error=(job.error or "")[:300])
 
     # ── extract scalar from the LAST output snapshot (final time step /
-    # converged state).  Accept every format
-    # `core.post_processing.read_mesh()` knows how to load *except*
-    # `.pvtu`:
-    #   .vtu    — modern XML unstructured (FEniCSx, skfem, fourc, ...)
-    #   .vtk    — legacy unstructured (KratosMultiphysics `VtkOutput`)
-    #   .pvd    — ParaView collection / time-series index
-    #   .xdmf   — XDMF (dolfinx alternative)
-    # `.pvtu` (parallel-partitioned VTU wrapper) is intentionally
-    # excluded — it can hang PyVista when the per-rank `.vtu`
-    # partials are accessed (see the matching policy at
-    # src/tools/consolidated.py: "skip .pvtu (parallel wrappers
-    # that can hang PyVista)").  The per-rank `.vtu` partials
-    # themselves are accepted directly.
+    # converged state).  We accept a *subset* of what
+    # `core.post_processing.read_mesh()` knows how to load — the
+    # subset whose reads return a flat `pyvista.DataSet` with a
+    # `.point_data` API.  Concretely:
+    #
+    #   .vtu    accepted — modern XML unstructured (FEniCSx, skfem, fourc, ...)
+    #   .vtk    accepted — legacy unstructured (KratosMultiphysics `VtkOutput`)
+    #   .xdmf   accepted — XDMF (dolfinx alternative)
+    #
+    #   .pvtu   excluded — parallel-partitioned VTU wrapper that can
+    #           hang PyVista when the per-rank `.vtu` partials are
+    #           accessed (matching policy at
+    #           `src/tools/consolidated.py`: "skip .pvtu (parallel
+    #           wrappers that can hang PyVista)").  The per-rank
+    #           `.vtu` partials themselves are accepted via the
+    #           `.vtu` entry above.
+    #
+    #   .pvd    excluded — `pv.read("*.pvd")` returns a `MultiBlock`,
+    #           not a flat `DataSet`.  `post_process_file()` assumes
+    #           the flat shape, so accepting `.pvd` here would turn
+    #           every cell that writes a `.pvd` index into a
+    #           `postproc_failed` even when a perfectly good `.vtu`
+    #           partial sits next to it.  Re-enabling `.pvd` is
+    #           blocked on `core/post_processing.py` learning to
+    #           pick a block / time-step from a MultiBlock.
+    #
+    # Keep `_OUTPUT_SUFFIXES` below as the single source of truth
+    # for what is actually accepted.  This comment block describes
+    # *why* — never re-add a suffix here without verifying that
+    # `post_process_file` can read it as a flat DataSet.
     #
     # Suffix matching is case-insensitive: some backends and
     # filesystems emit upper-case (`.VTU`) and `read_mesh` itself

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -580,9 +580,11 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
     scalar = None
     field_used = None
     if cell.field is not None:
-        # A cell that asked for a scalar but received no VTU/VTK is a
-        # failure of the run even if the backend exited 0 — surface it
-        # instead of quietly returning status=completed with scalar=None.
+        # A cell that asked for a scalar but received no output file
+        # in any of the formats in `_OUTPUT_SUFFIXES` (currently
+        # .vtu / .vtk / .xdmf / .pvd) is a failure of the run even if
+        # the backend exited 0 — surface it instead of quietly
+        # returning status=completed with scalar=None.
         if not output_files:
             return CellResult(
                 cell, status="no_output_file", elapsed_s=elapsed,

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -303,16 +303,19 @@ MATRIX: dict[str, list[Cell]] = {
              field="displacement", expected=None, rtol=0.5),
         Cell("fenics",  "linear_elasticity", "2d", {"E": 1000, "nu": 0.3},
              field="displacement", expected=None, rtol=0.5),
-        # Kratos's `linear_elasticity/2d_nonlinear` is the only variant
-        # that imports KratosMultiphysics (the plain `linear_elasticity/2d`
-        # is one of the 8 known scipy stubs), but the script body is a
-        # placeholder that prints "StructuralMechanicsApplication
-        # available" and writes a JSON summary instead of actually running
-        # a structural analysis.  The cell completes but produces no .vtu,
-        # so the sweep reports "no_output_file" — which is precisely the
-        # right signal: validation passes superficially, runtime does
-        # nothing useful.  Replacement with a real Kratos cantilever
-        # analysis is a follow-up.
+        # Kratos `linear_elasticity/2d_nonlinear` was a placeholder
+        # stub until the same PR that widened this harness to accept
+        # legacy `.vtk` — it is now a real KratosMultiphysics
+        # TotalLagrangianElement2D4N cantilever with
+        # LinearElasticPlaneStrain2DLaw, prescribed-displacement BC at
+        # the tip mid-node, and `KM.VtkOutput` writing a real
+        # `Structure_0_*.vtk` containing `DISPLACEMENT` + `REACTION`
+        # node fields.  The cell scores max|u| = 0.50884 (the
+        # prescribed tip displacement is 0.5 in -y; the magnitude is
+        # slightly larger because the Newton solve picks up some
+        # bending-induced x-displacement near the tip).  Plain
+        # `linear_elasticity/2d` has also been rewritten as a real
+        # SmallDisplacement Newton solve.
         Cell("kratos",  "linear_elasticity", "2d_nonlinear", {"E": 1000, "nu": 0.3},
              field="DISPLACEMENT", expected=None, rtol=0.5),
         # deal.II's `linear_elasticity/2d` template needs the same
@@ -518,19 +521,22 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
                           error=(job.error or "")[:300])
 
     # ── extract scalar from the LAST output snapshot (final time step /
-    # converged state).  We accept both the modern XML format (`.vtu`)
-    # and the legacy unstructured-grid format (`.vtk`) — pyvista reads
-    # both equally well, and KratosMultiphysics's `VtkOutput` writes
-    # the legacy form by default (no parameter to switch).  Without
-    # this widening, every Kratos template that *does* solve and
-    # produce an output would be silently scored as "no output" by
-    # the harness.
+    # converged state).  We accept every format
+    # `core.post_processing.read_mesh()` knows how to load:
+    #   .vtu    — modern XML unstructured (FEniCSx, skfem, fourc, ...)
+    #   .vtk    — legacy unstructured (KratosMultiphysics `VtkOutput`)
+    #   .pvtu   — parallel-partitioned VTU
+    #   .pvd    — ParaView collection / time-series index
+    #   .xdmf   — XDMF (dolfinx alternative)
+    # If the set here diverges from `read_mesh`'s, working backends
+    # silently get reported as "no output" by the sweep.
     #
     # Sort numerically by trailing step index, NOT lexicographically:
     # backends like Kratos emit `Structure_0_1.vtk, Structure_0_2.vtk,
     # ..., Structure_0_10.vtk`, where lexicographic sort would place
     # `_10` *before* `_9` and pick the wrong snapshot as "the last".
     import re as _re
+    _OUTPUT_SUFFIXES = (".vtu", ".vtk", ".pvtu", ".pvd", ".xdmf")
     def _step_key(p):
         # Extract the last contiguous integer run in the stem; fall back
         # to 0 for files with no digits so they sort first.
@@ -538,7 +544,7 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
         return (int(m[-1]) if m else 0, p.stem)
     output_files = sorted(
         (f for f in backend.get_result_files(job)
-         if f.suffix in (".vtu", ".vtk")),
+         if f.suffix in _OUTPUT_SUFFIXES),
         key=_step_key,
     )
     scalar = None
@@ -550,7 +556,8 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
         if not output_files:
             return CellResult(
                 cell, status="no_output_file", elapsed_s=elapsed,
-                error=("backend reported completed but produced no .vtu / .vtk in "
+                error=("backend reported completed but produced no "
+                       f"{'/'.join(_OUTPUT_SUFFIXES)} output in "
                        f"{work_dir}; expected field {cell.field!r}"),
             )
         try:

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -517,30 +517,44 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
         return CellResult(cell, status=job.status, elapsed_s=elapsed,
                           error=(job.error or "")[:300])
 
-    # ── extract scalar from the LAST VTU (final time step / converged
-    # state).  We accept both the modern XML format (`.vtu`) and the
-    # legacy unstructured-grid format (`.vtk`) — pyvista reads both
-    # equally well, and KratosMultiphysics's `VtkOutput` writes the
-    # legacy form by default (no parameter to switch).  Without this
-    # widening, every Kratos template that *does* solve and produce
-    # an output would be silently scored as "no output" by the
-    # harness.
-    vtu_files = sorted([f for f in backend.get_result_files(job)
-                        if f.suffix in (".vtu", ".vtk")])
+    # ── extract scalar from the LAST output snapshot (final time step /
+    # converged state).  We accept both the modern XML format (`.vtu`)
+    # and the legacy unstructured-grid format (`.vtk`) — pyvista reads
+    # both equally well, and KratosMultiphysics's `VtkOutput` writes
+    # the legacy form by default (no parameter to switch).  Without
+    # this widening, every Kratos template that *does* solve and
+    # produce an output would be silently scored as "no output" by
+    # the harness.
+    #
+    # Sort numerically by trailing step index, NOT lexicographically:
+    # backends like Kratos emit `Structure_0_1.vtk, Structure_0_2.vtk,
+    # ..., Structure_0_10.vtk`, where lexicographic sort would place
+    # `_10` *before* `_9` and pick the wrong snapshot as "the last".
+    import re as _re
+    def _step_key(p):
+        # Extract the last contiguous integer run in the stem; fall back
+        # to 0 for files with no digits so they sort first.
+        m = _re.findall(r"\d+", p.stem)
+        return (int(m[-1]) if m else 0, p.stem)
+    output_files = sorted(
+        (f for f in backend.get_result_files(job)
+         if f.suffix in (".vtu", ".vtk")),
+        key=_step_key,
+    )
     scalar = None
     field_used = None
     if cell.field is not None:
         # A cell that asked for a scalar but received no VTU/VTK is a
         # failure of the run even if the backend exited 0 — surface it
         # instead of quietly returning status=completed with scalar=None.
-        if not vtu_files:
+        if not output_files:
             return CellResult(
                 cell, status="no_vtu_output", elapsed_s=elapsed,
                 error=("backend reported completed but produced no .vtu / .vtk in "
                        f"{work_dir}; expected field {cell.field!r}"),
             )
         try:
-            pp = post_process_file(vtu_files[-1], plot_dir=work_dir, plot_fields=False)
+            pp = post_process_file(output_files[-1], plot_dir=work_dir, plot_fields=False)
             available = [f.name for f in pp.fields]
             for f in pp.fields:
                 if f.name == cell.field or f.name.lower() == cell.field.lower():

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -547,8 +547,11 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
     # (`.vtu` > `.vtk` > `.xdmf` > `.pvd`) so two formats emitted
     # for the same step never pick a less-supported container.
     import re as _re
-    _OUTPUT_SUFFIXES = (".vtu", ".vtk", ".pvd", ".xdmf")
-    _SUFFIX_PRIORITY = {".vtu": 0, ".vtk": 1, ".xdmf": 2, ".pvd": 3}
+    # Listed in preference order so the error message text and the
+    # `_SUFFIX_PRIORITY` tiebreaker share a single, internally-
+    # consistent ordering: `.vtu` > `.vtk` > `.xdmf` > `.pvd`.
+    _OUTPUT_SUFFIXES = (".vtu", ".vtk", ".xdmf", ".pvd")
+    _SUFFIX_PRIORITY = {suf: i for i, suf in enumerate(_OUTPUT_SUFFIXES)}
 
     def _step_key(p):
         # Use the *full tuple* of integer groups in the stem, not just

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -544,13 +544,24 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
     # ..., Structure_0_10.vtk`, where lexicographic sort would place
     # `_10` *before* `_9` and pick the wrong snapshot as "the last".
     # Within the same step, prefer the most-PyVista-stable format
-    # (`.vtu` > `.vtk` > `.xdmf` > `.pvd`) so two formats emitted
-    # for the same step never pick a less-supported container.
+    # (`.vtu` > `.vtk` > `.xdmf`) so two formats emitted for the
+    # same step never pick a less-supported container.
     import re as _re
     # Listed in preference order so the error message text and the
     # `_SUFFIX_PRIORITY` tiebreaker share a single, internally-
-    # consistent ordering: `.vtu` > `.vtk` > `.xdmf` > `.pvd`.
-    _OUTPUT_SUFFIXES = (".vtu", ".vtk", ".xdmf", ".pvd")
+    # consistent ordering: `.vtu` > `.vtk` > `.xdmf`.
+    # `.pvd` is intentionally NOT accepted here: PyVista reads a `.pvd`
+    # collection into a `MultiBlock`, not a single `DataSet`, and
+    # `core.post_processing.post_process_file()` assumes a flat
+    # `mesh.point_data` API.  Including `.pvd` in this set would
+    # silently turn every cell that emits a `.pvd` index into a
+    # `postproc_failed` even though a perfectly good `.vtu` partial
+    # sits next to it.  Re-enabling `.pvd` here is blocked on
+    # post-processing learning to pick a block / time-step from a
+    # MultiBlock collection (a separate piece of work in
+    # core/post_processing.py).  Individual `.vtu` partials referenced
+    # by a `.pvd` are still picked up via the `.vtu` entry below.
+    _OUTPUT_SUFFIXES = (".vtu", ".vtk", ".xdmf")
     _SUFFIX_PRIORITY = {suf: i for i, suf in enumerate(_OUTPUT_SUFFIXES)}
 
     def _step_key(p):
@@ -582,7 +593,7 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
     if cell.field is not None:
         # A cell that asked for a scalar but received no output file
         # in any of the formats in `_OUTPUT_SUFFIXES` (currently
-        # .vtu / .vtk / .xdmf / .pvd) is a failure of the run even if
+        # .vtu / .vtk / .xdmf — see comment block above) is a failure of the run even if
         # the backend exited 0 — surface it instead of quietly
         # returning status=completed with scalar=None.
         if not output_files:

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -517,18 +517,26 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
         return CellResult(cell, status=job.status, elapsed_s=elapsed,
                           error=(job.error or "")[:300])
 
-    # ── extract scalar from the LAST VTU (final time step / converged state)
-    vtu_files = sorted([f for f in backend.get_result_files(job) if f.suffix == ".vtu"])
+    # ── extract scalar from the LAST VTU (final time step / converged
+    # state).  We accept both the modern XML format (`.vtu`) and the
+    # legacy unstructured-grid format (`.vtk`) — pyvista reads both
+    # equally well, and KratosMultiphysics's `VtkOutput` writes the
+    # legacy form by default (no parameter to switch).  Without this
+    # widening, every Kratos template that *does* solve and produce
+    # an output would be silently scored as "no output" by the
+    # harness.
+    vtu_files = sorted([f for f in backend.get_result_files(job)
+                        if f.suffix in (".vtu", ".vtk")])
     scalar = None
     field_used = None
     if cell.field is not None:
-        # A cell that asked for a scalar but received no .vtu is a failure
-        # of the run even if the backend exited 0 — surface it instead of
-        # quietly returning status=completed with scalar=None.
+        # A cell that asked for a scalar but received no VTU/VTK is a
+        # failure of the run even if the backend exited 0 — surface it
+        # instead of quietly returning status=completed with scalar=None.
         if not vtu_files:
             return CellResult(
                 cell, status="no_vtu_output", elapsed_s=elapsed,
-                error=("backend reported completed but produced no .vtu in "
+                error=("backend reported completed but produced no .vtu / .vtk in "
                        f"{work_dir}; expected field {cell.field!r}"),
             )
         try:

--- a/benchmarks/sweep_layer3.py
+++ b/benchmarks/sweep_layer3.py
@@ -284,7 +284,7 @@ MATRIX: dict[str, list[Cell]] = {
         # boundary tags and then calls `ib.get_dofs("left")`, which
         # raises; and (b) even if (a) is fixed, the template writes a
         # `results_summary.json` only, never a .vtu, so the sweep would
-        # then transition from `failed` to `no_vtu_output`.  Both are
+        # then transition from `failed` to `no_output_file`.  Both are
         # template bugs to address upstream.  The cell is kept so the
         # matrix surfaces the gap on every run.
         Cell("skfem",   "linear_elasticity", "2d", {"E": 1000, "nu": 0.3},
@@ -309,7 +309,7 @@ MATRIX: dict[str, list[Cell]] = {
         # placeholder that prints "StructuralMechanicsApplication
         # available" and writes a JSON summary instead of actually running
         # a structural analysis.  The cell completes but produces no .vtu,
-        # so the sweep reports "no_vtu_output" — which is precisely the
+        # so the sweep reports "no_output_file" — which is precisely the
         # right signal: validation passes superficially, runtime does
         # nothing useful.  Replacement with a real Kratos cantilever
         # analysis is a follow-up.
@@ -549,7 +549,7 @@ async def run_cell(cell: Cell, work_dir: Path) -> CellResult:
         # instead of quietly returning status=completed with scalar=None.
         if not output_files:
             return CellResult(
-                cell, status="no_vtu_output", elapsed_s=elapsed,
+                cell, status="no_output_file", elapsed_s=elapsed,
                 error=("backend reported completed but produced no .vtu / .vtk in "
                        f"{work_dir}; expected field {cell.field!r}"),
             )

--- a/src/backends/kratos/generators/linear_elasticity.py
+++ b/src/backends/kratos/generators/linear_elasticity.py
@@ -2,104 +2,278 @@
 
 
 def _elasticity_2d_kratos(params: dict) -> str:
-    """FORMAT TEMPLATE — values are defaults, determine appropriate values for your specific problem.
+    """Real Kratos plane-strain linear elasticity on a rectangular beam.
 
-    Linear elasticity on rectangular domain — Kratos (manual assembly)."""
-    nx = params.get("nx", 40)
+    Uses StructuralMechanicsApplication with `SmallDisplacementElement2D4N`
+    on a structured quad grid, `LinearElasticPlaneStrain2DLaw`, and a
+    Newton-Raphson static strategy.  The left edge is clamped; the
+    mid-tip node is given a prescribed y-displacement so the cell
+    produces a finite, deterministic displacement field without
+    needing a separate Condition for the point load.  Output is
+    written via `KM.VtkOutput` (legacy `.vtk` — Kratos's VtkOutput
+    does not write `.vtu`; the sweep harness accepts both).
+    """
+    nx = params.get("nx", 32)
     ny = params.get("ny", 4)
     E = params.get("E", 1000.0)
     nu = params.get("nu", 0.3)
     lx = params.get("lx", 10.0)
     ly = params.get("ly", 1.0)
-    mu = E / (2 * (1 + nu))
-    lam = E * nu / ((1 + nu) * (1 - 2 * nu))
+    tip_uy = params.get("tip_uy", -0.5)  # prescribed tip displacement
     return f'''\
-"""Linear elasticity: rectangular domain, fixed left — Kratos (manual assembly)"""
-import numpy as np
-from scipy.sparse import lil_matrix
-from scipy.sparse.linalg import spsolve
+"""Linear elastic 2D cantilever (plane strain) — Kratos StructuralMechanicsApplication.
+
+Clamped left edge, prescribed y-displacement at the mid-tip node.
+Writes the converged DISPLACEMENT and REACTION fields as `Structure_0_1.vtk`.
+"""
 import json
+import KratosMultiphysics as KM
+import KratosMultiphysics.StructuralMechanicsApplication as SMA
 
-nx, ny, lx, ly = {nx}, {ny}, {lx}, {ly}
-nid = 1; node_map = {{}}; coords = {{}}
-for j in range(ny+1):
-    for i in range(nx+1):
-        coords[nid] = (i*lx/nx, j*ly/ny)
-        node_map[(i,j)] = nid; nid += 1
-n_nodes = nid - 1
+# Problem geometry / material (template parameters at file generation time)
+nx, ny = {nx}, {ny}
+L,  h  = {lx}, {ly}
+E,  nu = {E}, {nu}
+tip_uy = {tip_uy}
 
-elements = []
+# Linear interpolation in x and y produces a structured quad grid.
+def node_id(i, j):
+    return 1 + j * (nx + 1) + i
+
+model = KM.Model()
+mp = model.CreateModelPart("Structure")
+mp.ProcessInfo[KM.DOMAIN_SIZE] = 2
+mp.SetBufferSize(2)
+for v in (KM.DISPLACEMENT, KM.REACTION, KM.VOLUME_ACCELERATION):
+    mp.AddNodalSolutionStepVariable(v)
+
+# Nodes
+for j in range(ny + 1):
+    yj = -h / 2.0 + j * h / ny
+    for i in range(nx + 1):
+        xi = i * L / nx
+        mp.CreateNewNode(node_id(i, j), xi, yj, 0.0)
+
+# Properties: plane-strain linear elastic
+prop = mp.CreateNewProperties(1)
+prop.SetValue(KM.YOUNG_MODULUS, E)
+prop.SetValue(KM.POISSON_RATIO, nu)
+prop.SetValue(KM.DENSITY, 0.0)
+prop.SetValue(KM.CONSTITUTIVE_LAW, SMA.LinearElasticPlaneStrain2DLaw())
+
+# Quad elements (CCW orientation)
+eid = 1
 for j in range(ny):
     for i in range(nx):
-        n1,n2,n3,n4 = node_map[(i,j)],node_map[(i+1,j)],node_map[(i+1,j+1)],node_map[(i,j+1)]
-        elements.append((n1,n2,n4)); elements.append((n2,n3,n4))
+        mp.CreateNewElement(
+            "SmallDisplacementElement2D4N", eid,
+            [node_id(i, j), node_id(i + 1, j),
+             node_id(i + 1, j + 1), node_id(i, j + 1)],
+            prop,
+        )
+        eid += 1
 
-ndof = 2 * n_nodes
-K = lil_matrix((ndof, ndof))
-F = np.zeros(ndof)
-mu, lam = {mu}, {lam}
+# Add DOFs.  SmallDisplacementElement2D4N inherits SolidElementCheck which
+# requires the Z dof in every node (Kratos uses 3-component vectors
+# internally); we add it everywhere and Dirichlet-pin Z = 0.
+for node in mp.Nodes:
+    node.AddDof(KM.DISPLACEMENT_X, KM.REACTION_X)
+    node.AddDof(KM.DISPLACEMENT_Y, KM.REACTION_Y)
+    node.AddDof(KM.DISPLACEMENT_Z, KM.REACTION_Z)
+    node.Fix(KM.DISPLACEMENT_Z)
+    node.SetSolutionStepValue(KM.DISPLACEMENT_Z, 0.0)
 
-for tri in elements:
-    ids = [t-1 for t in tri]
-    x = np.array([coords[t][0] for t in tri])
-    y = np.array([coords[t][1] for t in tri])
-    area = 0.5 * abs((x[1]-x[0])*(y[2]-y[0]) - (x[2]-x[0])*(y[1]-y[0]))
-    b = np.array([y[1]-y[2], y[2]-y[0], y[0]-y[1]]) / (2*area)
-    c = np.array([x[2]-x[1], x[0]-x[2], x[1]-x[0]]) / (2*area)
+# Clamp left edge (i = 0)
+for j in range(ny + 1):
+    n = mp.Nodes[node_id(0, j)]
+    n.Fix(KM.DISPLACEMENT_X)
+    n.Fix(KM.DISPLACEMENT_Y)
+    n.SetSolutionStepValue(KM.DISPLACEMENT_X, 0.0)
+    n.SetSolutionStepValue(KM.DISPLACEMENT_Y, 0.0)
 
-    B = np.zeros((3, 6))
-    for a in range(3):
-        B[0, 2*a] = b[a]; B[1, 2*a+1] = c[a]
-        B[2, 2*a] = c[a]; B[2, 2*a+1] = b[a]
-    D = np.array([[lam+2*mu, lam, 0], [lam, lam+2*mu, 0], [0, 0, mu]])
-    Ke = area * B.T @ D @ B
+# Prescribe tip mid-node y-displacement
+j_mid = ny // 2
+tip_node = mp.Nodes[node_id(nx, j_mid)]
+tip_node.Fix(KM.DISPLACEMENT_Y)
+tip_node.SetSolutionStepValue(KM.DISPLACEMENT_Y, tip_uy)
 
-    dofs = []
-    for a in range(3):
-        dofs.extend([2*ids[a], 2*ids[a]+1])
-    for i in range(6):
-        F[dofs[i]] += -1.0 * area / 3.0 if i % 2 == 1 else 0  # body force — set for your problem
-        for j_idx in range(6):
-            K[dofs[i], dofs[j_idx]] += Ke[i, j_idx]
-K = K.tocsr()
+# Newton-Raphson static solver
+scheme = KM.ResidualBasedIncrementalUpdateStaticScheme()
+builder_and_solver = KM.ResidualBasedBlockBuilderAndSolver(
+    KM.SkylineLUFactorizationSolver()
+)
+conv = KM.ResidualCriteria(1.0e-8, 1.0e-12)
+strat = KM.ResidualBasedNewtonRaphsonStrategy(
+    mp, scheme, conv, builder_and_solver,
+    20, True, False, True,
+)
+strat.SetEchoLevel(0)
+strat.Check()
+mp.CloneTimeStep(1.0)
+mp.ProcessInfo[KM.STEP] = 1
+strat.Solve()
 
-# Fix left edge
-fixed = set()
-for j in range(ny+1):
-    n = node_map[(0,j)] - 1
-    fixed.add(2*n); fixed.add(2*n+1)
-interior = sorted(set(range(ndof)) - fixed)
+# VTK output
+vtk_params = KM.Parameters(json.dumps({{
+    "model_part_name": "Structure",
+    "output_control_type": "step",
+    "output_interval": 1,
+    "file_format": "ascii",
+    "output_path": ".",
+    "output_sub_model_parts": False,
+    "save_output_files_in_folder": False,
+    "nodal_solution_step_data_variables": ["DISPLACEMENT", "REACTION"],
+}}))
+KM.VtkOutput(mp, vtk_params).PrintOutput()
 
-u = np.zeros(ndof)
-u[interior] = spsolve(K[np.ix_(interior, interior)], F[interior])
-
-uy = u[1::2]
-print(f"Max tip displacement: {{uy.min():.6f}}")
-summary = {{"max_displacement_y": float(uy.min()), "n_dofs": ndof}}
-with open("results_summary.json", "w") as _f: json.dump(summary, _f, indent=2)
+# Scalar summary for the layer-3 sweep
+tip = mp.Nodes[node_id(nx, j_mid)]
+summary = {{
+    "tip_ux": float(tip.GetSolutionStepValue(KM.DISPLACEMENT_X)),
+    "tip_uy": float(tip.GetSolutionStepValue(KM.DISPLACEMENT_Y)),
+    "n_nodes": mp.NumberOfNodes(),
+    "n_elements": mp.NumberOfElements(),
+}}
+print(f"tip displacement: ux={{summary['tip_ux']:.6f}}  uy={{summary['tip_uy']:.6f}}")
+with open("results_summary.json", "w") as _f:
+    json.dump(summary, _f, indent=2)
 '''
 
 
 def _elasticity_nonlinear_kratos(params: dict) -> str:
-    """FORMAT TEMPLATE — values are defaults, determine appropriate values for your specific problem.
+    """Geometrically-nonlinear plane-strain elasticity — Kratos SMA.
 
-    Nonlinear elasticity via Kratos StructuralMechanicsApplication."""
+    Uses `TotalLagrangianElement2D4N` (large-rotation kinematics) with
+    `LinearElasticPlaneStrain2DLaw` as the small-strain constitutive
+    law.  The pip-installed Kratos wheel does NOT ship a Neo-Hookean
+    2D law (those live in `ConstitutiveLawsApplication`, not in the
+    base StructuralMechanicsApplication on PyPI), so "nonlinear" here
+    means geometric nonlinearity only.  Switching to a hyperelastic
+    material is straightforward once `ConstitutiveLawsApplication`
+    is available — replace the SetValue on KM.CONSTITUTIVE_LAW with
+    e.g. `CLA.HyperElasticIsotropicNeoHookeanPlaneStrain2DLaw()`.
+    """
+    nx = params.get("nx", 16)
+    ny = params.get("ny", 4)
+    E = params.get("E", 1000.0)
+    nu = params.get("nu", 0.3)
+    lx = params.get("lx", 4.0)
+    ly = params.get("ly", 1.0)
+    tip_uy = params.get("tip_uy", -0.5)
+    n_substeps = params.get("n_substeps", 5)
     return f'''\
-"""Nonlinear structural mechanics — Kratos StructuralMechanicsApplication"""
+"""Geometrically-nonlinear plane-strain elasticity — Kratos SMA.
+
+TotalLagrangianElement2D4N + LinearElasticPlaneStrain2DLaw on a
+structured quad grid.  Clamped left edge; tip y-displacement applied
+in `n_substeps` Newton-Raphson load steps.  Writes the converged
+DISPLACEMENT and REACTION fields as `Structure_0_*.vtk`.
+"""
 import json
-try:
-    import KratosMultiphysics as KM
-    import KratosMultiphysics.StructuralMechanicsApplication as SMA
-    print("StructuralMechanicsApplication available")
-    # Full Kratos structural analysis would use:
-    # from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
-    # with ProjectParameters.json + mesh.mdpa
-    summary = {{"note": "Kratos SMA available — use ProjectParameters.json workflow for full analysis"}}
-except ImportError:
-    print("StructuralMechanicsApplication not installed")
-    print("Install: pip install KratosStructuralMechanicsApplication")
-    summary = {{"note": "KratosStructuralMechanicsApplication not installed"}}
-with open("results_summary.json", "w") as _f: json.dump(summary, _f, indent=2)
+import KratosMultiphysics as KM
+import KratosMultiphysics.StructuralMechanicsApplication as SMA
+
+nx, ny = {nx}, {ny}
+L,  h  = {lx}, {ly}
+E,  nu = {E}, {nu}
+tip_uy = {tip_uy}
+n_substeps = {n_substeps}
+
+
+def node_id(i, j):
+    return 1 + j * (nx + 1) + i
+
+
+model = KM.Model()
+mp = model.CreateModelPart("Structure")
+mp.ProcessInfo[KM.DOMAIN_SIZE] = 2
+mp.SetBufferSize(2)
+for v in (KM.DISPLACEMENT, KM.REACTION, KM.VOLUME_ACCELERATION):
+    mp.AddNodalSolutionStepVariable(v)
+
+for j in range(ny + 1):
+    yj = -h / 2.0 + j * h / ny
+    for i in range(nx + 1):
+        mp.CreateNewNode(node_id(i, j), i * L / nx, yj, 0.0)
+
+prop = mp.CreateNewProperties(1)
+prop.SetValue(KM.YOUNG_MODULUS, E)
+prop.SetValue(KM.POISSON_RATIO, nu)
+prop.SetValue(KM.DENSITY, 0.0)
+prop.SetValue(KM.CONSTITUTIVE_LAW, SMA.LinearElasticPlaneStrain2DLaw())
+
+eid = 1
+for j in range(ny):
+    for i in range(nx):
+        mp.CreateNewElement(
+            "TotalLagrangianElement2D4N", eid,
+            [node_id(i, j), node_id(i + 1, j),
+             node_id(i + 1, j + 1), node_id(i, j + 1)],
+            prop,
+        )
+        eid += 1
+
+for node in mp.Nodes:
+    node.AddDof(KM.DISPLACEMENT_X, KM.REACTION_X)
+    node.AddDof(KM.DISPLACEMENT_Y, KM.REACTION_Y)
+    node.AddDof(KM.DISPLACEMENT_Z, KM.REACTION_Z)
+    node.Fix(KM.DISPLACEMENT_Z)
+    node.SetSolutionStepValue(KM.DISPLACEMENT_Z, 0.0)
+
+for j in range(ny + 1):
+    n = mp.Nodes[node_id(0, j)]
+    n.Fix(KM.DISPLACEMENT_X)
+    n.Fix(KM.DISPLACEMENT_Y)
+
+j_mid = ny // 2
+tip_node = mp.Nodes[node_id(nx, j_mid)]
+tip_node.Fix(KM.DISPLACEMENT_Y)
+
+scheme = KM.ResidualBasedIncrementalUpdateStaticScheme()
+builder_and_solver = KM.ResidualBasedBlockBuilderAndSolver(
+    KM.SkylineLUFactorizationSolver()
+)
+conv = KM.ResidualCriteria(1.0e-8, 1.0e-12)
+strat = KM.ResidualBasedNewtonRaphsonStrategy(
+    mp, scheme, conv, builder_and_solver,
+    50, True, False, True,
+)
+strat.SetEchoLevel(0)
+
+vtk_params = KM.Parameters(json.dumps({{
+    "model_part_name": "Structure",
+    "output_control_type": "step",
+    "output_interval": 1,
+    "file_format": "ascii",
+    "output_path": ".",
+    "output_sub_model_parts": False,
+    "save_output_files_in_folder": False,
+    "nodal_solution_step_data_variables": ["DISPLACEMENT", "REACTION"],
+}}))
+vtk = KM.VtkOutput(mp, vtk_params)
+
+# Ramp the tip displacement in n_substeps load steps.  TotalLagrangian
+# requires sufficiently small increments for Newton convergence at
+# large rotations.
+strat.Check()
+for step in range(1, n_substeps + 1):
+    mp.CloneTimeStep(float(step))
+    mp.ProcessInfo[KM.STEP] = step
+    tip_node.SetSolutionStepValue(KM.DISPLACEMENT_Y, tip_uy * step / n_substeps)
+    strat.Solve()
+vtk.PrintOutput()
+
+tip = mp.Nodes[node_id(nx, j_mid)]
+summary = {{
+    "tip_ux": float(tip.GetSolutionStepValue(KM.DISPLACEMENT_X)),
+    "tip_uy": float(tip.GetSolutionStepValue(KM.DISPLACEMENT_Y)),
+    "n_steps": n_substeps,
+    "n_nodes": mp.NumberOfNodes(),
+    "n_elements": mp.NumberOfElements(),
+}}
+print(f"tip ux={{summary['tip_ux']:.6f}}  uy={{summary['tip_uy']:.6f}}  (target uy={{tip_uy}})")
+with open("results_summary.json", "w") as _f:
+    json.dump(summary, _f, indent=2)
 '''
 
 

--- a/src/backends/kratos/generators/linear_elasticity.py
+++ b/src/backends/kratos/generators/linear_elasticity.py
@@ -224,6 +224,15 @@ for j in range(ny + 1):
     n = mp.Nodes[node_id(0, j)]
     n.Fix(KM.DISPLACEMENT_X)
     n.Fix(KM.DISPLACEMENT_Y)
+    # Set the Dirichlet value explicitly to 0.0 alongside the Fix()
+    # call.  Kratos's `Fix(...)` flags the DOF as constrained but
+    # does not by itself prescribe the value (the solution-step
+    # value defaults to 0.0 for fresh nodes, but for nodes that have
+    # already participated in an earlier solve step on the same
+    # ModelPart the prior value persists — a real bug when the
+    # template is re-used inside a larger workflow).
+    n.SetSolutionStepValue(KM.DISPLACEMENT_X, 0.0)
+    n.SetSolutionStepValue(KM.DISPLACEMENT_Y, 0.0)
 
 j_mid = ny // 2
 tip_node = mp.Nodes[node_id(nx, j_mid)]


### PR DESCRIPTION
## Summary
Two of the 8 known Kratos scipy-stub templates rewritten as real KratosMultiphysics solves.  Each one builds an in-memory `KM.Model()`, attaches a structured (nx+1)*(ny+1) quad ModelPart with `SmallDisplacementElement2D4N` (linear) or `TotalLagrangianElement2D4N` (geometric-nonlinear), drives a Newton-Raphson static solve with `SkylineLUFactorizationSolver`, and writes a real `Structure_0_*.vtk` with the `DISPLACEMENT` and `REACTION` fields via `KM.VtkOutput`.

Sweep impact on the ELASTICITY row:

| Backend  | before               | after                                  |
|----------|----------------------|----------------------------------------|
| skfem    | failed               | failed                                 |
| NGSolve  | completed 12.008     | completed 12.008                       |
| FEniCSx  | completed 12.989     | completed 12.989                       |
| **Kratos** | **no_vtu_output**  | **completed 0.50884 DISPLACEMENT**     |
| deal.II  | failed (build)       | failed (build)                         |
| 4C       | failed               | failed (WALL element)                  |

The harness needed one supporting change: accept legacy `.vtk` files alongside `.vtu` because Kratos's `KM.VtkOutput` writes the legacy form (no parameter switches it to `.vtu`).  `pyvista` reads both equally well; without this extension every working Kratos template that uses `VtkOutput` would have been silently classified as "no output".

Two stubs down, six more Kratos stubs to follow as separate PRs (one per physics, each rewritten properly against the actual Kratos APIs — no shortcuts).

## Test plan
- [x] `python benchmarks/sweep_layer3.py --only ELASTICITY` — Kratos cell now completes with max|u| = 0.50884 in 5.3 s.
- [x] Direct backend probe — both `linear_elasticity/2d` and `linear_elasticity/2d_nonlinear` complete with VTK output containing `DISPLACEMENT` and `REACTION` arrays.
- [ ] CI on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)