### PR TITLE
Installed-version API references (verified) in prepare_simulation

### DIFF
--- a/src/backends/_installed_api.py
+++ b/src/backends/_installed_api.py
@@ -1,0 +1,135 @@
+"""Installed-version API references — VERIFIED by actually running on this machine.
+
+Models repeatedly fail not on the physics but on writing API calls for the WRONG
+version of the installed code (e.g. NGSolve Integrate() signature, deal.II pointing
+DEAL_II_DIR at the source instead of the build tree, the 4C YAML schema). Each entry
+below is a minimal smoke test that was WRITTEN, RUN, and FIXED until it executed
+cleanly on the version installed here, plus the version-specific gotchas observed.
+
+These are GENERAL API references (a trivial -Laplacian(u)=1 / single-cube run), NOT
+solutions to any benchmark — they teach the correct installed-version API so an agent
+adapts a known-good call instead of guessing from (outdated) memory.
+
+Surfaced to agents via prepare_simulation()/knowledge() for the matching backend.
+Keyed by the backend registry name.
+"""
+
+INSTALLED_API = {
+ "ngsolve": {
+  "version": "6.2.2604",
+  "run": "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python <script>.py",
+  "verified_smoke_test": (
+    "from ngsolve import *\n"
+    "from netgen.geom2d import unit_square\n"
+    "mesh = Mesh(unit_square.GenerateMesh(maxh=0.2))\n"
+    "fes = H1(mesh, order=1, dirichlet='.*')\n"
+    "u, v = fes.TnT()\n"
+    "a = BilinearForm(fes); a += grad(u)*grad(v)*dx; a.Assemble()\n"
+    "f = LinearForm(fes); f += 1*v*dx; f.Assemble()\n"
+    "gfu = GridFunction(fes)\n"
+    "gfu.vec.data = a.mat.Inverse(fes.FreeDofs(), inverse='sparsecholesky') * f.vec\n"
+    "print('center value:', gfu(mesh(0.5, 0.5)))   # -> ~0.069\n"),
+  "gotchas": [
+    "Mesh: do NOT call Mesh() on a unit square; use `from netgen.geom2d import unit_square; Mesh(unit_square.GenerateMesh(maxh=0.2))`.",
+    "Dirichlet BC goes on the SPACE: H1(mesh, order=1, dirichlet='.*'); '.*' matches all (unnamed) boundaries robustly.",
+    "Trial/test: `u, v = fes.TnT()`. Forms: `a += grad(u)*grad(v)*dx` then `a.Assemble()` (explicit).",
+    "Solve: `gfu.vec.data = a.mat.Inverse(fes.FreeDofs(), inverse='sparsecholesky') * f.vec` — FreeDofs() enforces the Dirichlet constraint.",
+    "Point eval: `gfu(mesh(0.5,0.5))` — the coords MUST go through mesh(...); `gfu(0.5,0.5)` does NOT work.",
+    "Integrate(cf*dx, mesh) is a SEPARATE functional, not how you assemble forms.",
+  ],
+ },
+ "skfem": {
+  "version": "12.0.1",
+  "run": "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python <script>.py",
+  "verified_smoke_test": (
+    "import numpy as np\n"
+    "from skfem import MeshTri, ElementTriP1, Basis, BilinearForm, LinearForm, asm, condense, solve\n"
+    "from skfem.helpers import dot, grad\n"
+    "mesh = MeshTri().refined(4)          # MeshTri() IS the unit square; .refined returns a NEW mesh\n"
+    "basis = Basis(mesh, ElementTriP1())\n"
+    "@BilinearForm\n"
+    "def stiffness(u, v, w): return dot(grad(u), grad(v))\n"
+    "@LinearForm\n"
+    "def load(v, w): return 1.0 * v\n"
+    "A = stiffness.assemble(basis); b = load.assemble(basis)\n"
+    "D = basis.get_dofs()                  # all boundary dofs\n"
+    "x = solve(*condense(A, b, D=D))\n"
+    "print('max u =', x.max())            # -> ~0.073\n"),
+  "gotchas": [
+    "MeshTri() already IS the unit square; refine with `.refined(n)` (returns a new mesh, not in-place).",
+    "Use generic `Basis(mesh, ElementTriP1())` (element instance required).",
+    "Decorator arities are mandatory: `@BilinearForm def f(u, v, w)` and `@LinearForm def f(v, w)` — the trailing `w` (global params) is required even if unused. Wrong arity is the #1 error.",
+    "Integrand uses skfem.helpers (dot, grad) and returns the pointwise integrand, not an assembled value.",
+    "Assemble via `form.assemble(basis)` or `asm(form, basis)` (equivalent).",
+    "Dirichlet: `D = basis.get_dofs()` (no args = all boundary dofs) then `solve(*condense(A, b, D=D))` (homogeneous by default).",
+  ],
+ },
+ "dealii": {
+  "version": "9.8.0-pre  (build tree at /home/alexander/dealii/build)",
+  "run": "cmake -DDEAL_II_DIR=/home/alexander/dealii/build . && make && LD_LIBRARY_PATH=/opt/4C-dependencies/lib ./<exe>",
+  "verified_smoke_test": (
+    "// CMakeLists.txt:\n"
+    "//   CMAKE_MINIMUM_REQUIRED(VERSION 3.13.4)\n"
+    "//   FIND_PACKAGE(deal.II 9.0 REQUIRED HINTS ${DEAL_II_DIR})\n"
+    "//   DEAL_II_INITIALIZE_CACHED_VARIABLES()   # BEFORE project()\n"
+    "//   PROJECT(poisson CXX)\n"
+    "//   ADD_EXECUTABLE(poisson poisson.cc); DEAL_II_SETUP_TARGET(poisson)\n"
+    "// poisson.cc: standard step-3 Poisson, Q1, refine_global(5), -Laplacian(u)=1, u=0 on bdry.\n"
+    "//   Functions::ZeroFunction<dim>() for the BC; VectorTools::point_value(dof_handler, solution,\n"
+    "//   Point<dim>(0.5,0.5)) -> ~0.0737 ; SolverCG + PreconditionIdentity.\n"),
+  "gotchas": [
+    "CRITICAL: DEAL_II_DIR must be the BUILD tree `/home/alexander/dealii/build` (config at .../build/lib/cmake/deal.II). Pointing at `/home/alexander/dealii` SILENTLY falls back to the OLD system install (9.1.1 at /usr) with no error — check cmake's `-- Using the deal.II-X found at ...` line.",
+    "Runtime needs `LD_LIBRARY_PATH=/opt/4C-dependencies/lib` (shared TBB/etc).",
+    "CMake order: FIND_PACKAGE(deal.II 9.0 REQUIRED HINTS ${DEAL_II_DIR}) -> DEAL_II_INITIALIZE_CACHED_VARIABLES() -> PROJECT() -> DEAL_II_SETUP_TARGET(<tgt>). INITIALIZE must precede PROJECT().",
+    "Use modern idioms: fe_values.quadrature_point_indices(), fe_values.dof_indices(), fe.n_dofs_per_cell() (data member fe.dofs_per_cell is deprecated).",
+    "Functions::ZeroFunction<dim>() (namespaced; bare ZeroFunction removed). Header <deal.II/base/function.h>.",
+    "Sparsity needs both <.../dynamic_sparsity_pattern.h> and <.../sparsity_pattern.h>; BCs need <.../numerics/vector_tools.h> + <.../numerics/matrix_tools.h>.",
+    "Evaluate: VectorTools::point_value(dof_handler, solution, Point<dim>(...)); solution.linfty_norm() for the max.",
+  ],
+ },
+ "fourc": {
+  "version": "build at /home/alexander/4C/build/4C",
+  "run": "LD_LIBRARY_PATH=/opt/4C-dependencies/lib /home/alexander/4C/build/4C <input>.4C.yaml <output_prefix>",
+  "verified_smoke_test": (
+    "# Minimal single HEX8 linear-elastic cube (fixed at x=0, pulled at x=1), Statics, 2 steps.\n"
+    "# Started from /home/alexander/4C/tests/input_files/solid_runtime_material_element_id.4C.yaml\n"
+    "# Runs to completion: stdout ends 'processor 0 finished normally' / EXIT:0; writes <prefix>.control + VTK.\n"
+    "PROBLEM TYPE: {PROBLEMTYPE: 'Structure'}\n"
+    "SOLVER 1: {SOLVER: 'Superlu', NAME: 'Structure_Solver'}\n"
+    "STRUCTURAL DYNAMIC: {DYNAMICTYPE: 'Statics', TIMESTEP: 0.5, NUMSTEP: 2, MAXTIME: 1,\n"
+    "                     TOLDISP: 1e-9, TOLRES: 1e-9, LINEAR_SOLVER: 1}\n"
+    "MATERIALS: [{MAT: 1, MAT_Struct_StVenantKirchhoff: {YOUNG: 100, NUE: 0.3, DENS: 0}}]\n"
+    "FUNCT1: [{SYMBOLIC_FUNCTION_OF_SPACE_TIME: 't'}]\n"
+    "DESIGN SURF DIRICH CONDITIONS: [{E: 1, NUMDOF: 3, ONOFF: [1,1,1], VAL: [0,0,0], FUNCT: [0,0,0]}]\n"
+    "DESIGN SURF NEUMANN CONDITIONS: [{E: 2, NUMDOF: 3, ONOFF: [1,0,0], VAL: [10,0,0], FUNCT: [1,0,0]}]\n"
+    "DSURF-NODE TOPOLOGY: ['NODE 1 DSURFACE 1', ... 'NODE 5 DSURFACE 2', ...]\n"
+    "NODE COORDS: ['NODE 1 COORD 0.0 0.0 0.0', ...8 nodes...]\n"
+    "STRUCTURE ELEMENTS: ['1 SOLID HEX8 1 5 6 2 3 7 8 4 MAT 1 KINEM nonlinear']\n"),
+  "gotchas": [
+    "Run: `LD_LIBRARY_PATH=/opt/4C-dependencies/lib /home/alexander/4C/build/4C <in>.4C.yaml <output_prefix>` — the output prefix is MANDATORY.",
+    "File is one YAML map; keys are section names with spaces/slashes (e.g. 'STRUCTURAL DYNAMIC', 'IO/RUNTIME VTK OUTPUT/STRUCTURE').",
+    "Required minimal: PROBLEM TYPE, SOLVER 1, STRUCTURAL DYNAMIC, MATERIALS, mesh sections, conditions.",
+    "Time integrator references the linear solver via LINEAR_SOLVER: 1 (-> 'SOLVER 1').",
+    "Materials: list, each {MAT: <id>, MAT_Struct_<Model>: {...}}; elements reference it by `MAT <id>`.",
+    "Mesh is INLINE strings: NODE COORDS = ['NODE <id> COORD x y z', ...]; STRUCTURE ELEMENTS = ['<id> SOLID HEX8 <8 ids> MAT <id> KINEM nonlinear', ...] (raw strings, not maps).",
+    "BCs attach to DESIGN entities, not nodes: DSURF-NODE TOPOLOGY maps nodes->surface ids ('NODE n DSURFACE d'); conditions reference d via E: d.",
+    "Dirichlet/Neumann: lists of {E, NUMDOF, ONOFF: [...], VAL: [...], FUNCT: [...]}; ONOFF flags active dofs, FUNCT indexes a FUNCTn (0 = constant).",
+    "Omit the optional RESULT DESCRIPTION section for a pure smoke run so regression asserts can't fail the job.",
+    "Success = stdout 'processor 0 finished normally' / EXIT:0 and a <prefix>.control output file.",
+  ],
+ },
+}
+
+
+def render(backend_name: str) -> str:
+    """Markdown block of the verified installed-version API reference for a backend, or ''."""
+    e = INSTALLED_API.get(backend_name)
+    if not e:
+        return ""
+    out = [f"## Installed-version API reference (VERIFIED by running here) — {backend_name} {e['version']}",
+           f"Run: `{e['run']}`",
+           "Minimal smoke test that ACTUALLY RUNS on this install (adapt this API; do not guess from memory):",
+           "```", e["verified_smoke_test"].rstrip(), "```",
+           "Version-specific gotchas:"]
+    out += [f"- {g}" for g in e["gotchas"]]
+    return "\n".join(out)

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -2150,6 +2150,19 @@ def register_consolidated_tools(mcp: FastMCP):
                 parts.append(
                     f"### Pitfalls ({len(pitfalls_separate)})\n{bullets}\n")
 
+        # 1a. Installed-version API reference (VERIFIED by actually running here).
+        # The dominant failure mode is writing API calls for the WRONG version of the
+        # installed code (NGSolve Integrate signature, deal.II DEAL_II_DIR build-tree,
+        # the 4C YAML schema, ...). Surface a verified smoke test + version gotchas so
+        # the agent adapts a known-good call instead of guessing from memory.
+        try:
+            from backends._installed_api import render as _render_installed_api
+            api_ref = _render_installed_api(backend.name())
+            if api_ref:
+                parts.append(api_ref + "\n")
+        except Exception:
+            pass
+
         # 1b. General input-format pitfalls (ExodusII IDs, FUNCT syntax, etc.)
         # These apply to ALL physics in this solver, not just the current one
         general_k = _strip_pitfalls(backend.get_knowledge("input_format"))


### PR DESCRIPTION
Adds verified, version-correct minimal API references (NGSolve, scikit-fem, deal.II, 4C) surfaced via prepare_simulation, so agents adapt a known-good installed-version API instead of guessing. Each smoke test was actually run-and-fixed on this machine. General API refs, not benchmark solutions. 🤖 Generated with [Claude Code](https://claude.com/claude-code)