### PR TITLE
Fix deal.II (and SPARTA) run_with_generator + modern CMake minimum (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ conda create -n ofa-dune -c conda-forge dune-fem
 sudo apt install libdeal.ii-dev
 ```
 
+On macOS, install deal.II from the official `deal.II.app` bundle and point
+`DEAL_II_DIR` at its `Contents/Resources/Libraries`. If a deal.II build then
+fails inside `<complex>`/`<cmath>` (an Xcode SDK header clash baked into the
+app bundle, not an OASiS issue), set the SDK sysroot consistently:
+
+```bash
+export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+```
+
 ### Verify
 
 ```bash

--- a/src/backends/dealii/backend.py
+++ b/src/backends/dealii/backend.py
@@ -510,7 +510,17 @@ class DealiiBackend(SolverBackend):
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
             if proc.returncode != 0:
                 job.status = "failed"
-                job.error = f"Compilation failed:\n{stderr.decode(errors='replace')[-2000:]}"
+                err = stderr.decode(errors='replace')
+                hint = ""
+                import platform
+                if platform.system() == "Darwin" and (
+                        "MacOSX.sdk" in err or "isinf" in err
+                        or ("abs" in err and "ambiguous" in err)):
+                    hint = ("\n\nHint (macOS + deal.II.app): this looks like the Xcode "
+                            "SDK header conflict (a deal.II.app packaging issue, not an "
+                            "OASiS bug). Make the sysroot consistent and re-run:\n"
+                            "    export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk")
+                job.error = f"Compilation failed:\n{err[-2000:]}{hint}"
                 job.elapsed = time.time() - start
                 return job
         except asyncio.TimeoutError:

--- a/src/backends/dealii/backend.py
+++ b/src/backends/dealii/backend.py
@@ -165,7 +165,7 @@ class DealiiBackend(SolverBackend):
 
         test_cpp = '#include <deal.II/base/utilities.h>\nint main(){return 0;}\n'
         test_cmake = (
-            'cmake_minimum_required(VERSION 3.1)\n'
+            'cmake_minimum_required(VERSION 3.13.4)\n'
             'find_package(deal.II REQUIRED)\n'
             'deal_ii_initialize_cached_variables()\n'
             'project(test)\n'
@@ -618,7 +618,7 @@ def _generate_cmakelists(target_name: str) -> str:
     # CMake does not emit a type-mismatch warning.  Use plain
     # `if(NOT DEFINED CMAKE_*_COMPILER)` rather than the `CACHE{}`
     # operand form, which only works on CMake >= 3.14 (the file declares
-    # a minimum of 3.1).  A `-D` from the command line is visible as a
+    # a minimum of 3.13.4).  A `-D` from the command line is visible as a
     # regular variable too, so this still respects user overrides.
     cc = os.environ.get("CC", "")
     cxx = os.environ.get("CXX", "")
@@ -637,7 +637,7 @@ def _generate_cmakelists(target_name: str) -> str:
         )
 
     return f"""\
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13.4)
 {compiler_cache}find_package(deal.II 9.0 REQUIRED
   HINTS ${{DEAL_II_DIR}} ${{deal.II_DIR}}{extra_hints} /usr /usr/local
 )

--- a/src/core/backend.py
+++ b/src/core/backend.py
@@ -32,6 +32,73 @@ class InputFormat(Enum):
     SPARTA = "sparta"       # SPARTA DSMC input script (LAMMPS-style)
 
 
+# Filename patterns a generator script may write for the actual solver input,
+# keyed by the backend's declared input format. Ordered most-specific first.
+# Note: deal.II writes main.cpp and SPARTA writes in.sparta; neither is matched
+# by the old ["*.4C.yaml","*.yaml","input.*","solve.py","MainKratos.py"] glob,
+# which silently broke run_with_generator for those backends (issue #39).
+_GENERATED_INPUT_PATTERNS = {
+    InputFormat.CPP:    ["main.cpp", "*.cpp", "*.cc", "*.cxx"],
+    InputFormat.YAML:   ["*.4C.yaml", "*.yaml", "*.yml"],
+    InputFormat.PYTHON: ["solve.py", "main.py", "*.py"],
+    InputFormat.XML:    ["input.feb", "*.feb", "*.xml"],
+    InputFormat.JSON:   ["MainKratos.py", "*.json"],
+    InputFormat.SPARTA: ["in.sparta", "in.*", "*.sparta"],
+}
+
+# Legacy patterns kept as a fallback so previously-working backends still match.
+_GENERATED_INPUT_LEGACY = ["*.4C.yaml", "*.yaml", "input.*", "solve.py",
+                           "MainKratos.py"]
+
+# Artifacts a generator run leaves behind that are never the input itself.
+_GENERATED_INPUT_EXCLUDE_NAMES = {
+    "generate_input.py", "CMakeLists.txt", "CMakeCache.txt", "Makefile",
+    "cmake_install.cmake", "stdout.log", "stderr.log", "log.sparta",
+}
+_GENERATED_INPUT_EXCLUDE_SUFFIXES = {
+    ".log", ".pyc", ".o", ".obj", ".vtk", ".vtu", ".vtp", ".pvd", ".h5", ".xdmf",
+}
+
+
+def find_generated_input(work_dir, backend=None) -> Optional[Path]:
+    """Locate the solver-input file a generator script wrote in ``work_dir``.
+
+    Backend-aware: prefers the file type matching ``backend.input_format``
+    (e.g. ``main.cpp`` for deal.II, ``in.sparta`` for SPARTA), then falls back
+    to the legacy pattern list, then to any plausible non-script artifact the
+    generator produced. Returns the matching Path, or ``None`` if nothing
+    looks like an input file.
+    """
+    work_dir = Path(work_dir)
+
+    def _ok(p: Path) -> bool:
+        return (p.is_file()
+                and p.name not in _GENERATED_INPUT_EXCLUDE_NAMES
+                and p.suffix not in _GENERATED_INPUT_EXCLUDE_SUFFIXES)
+
+    patterns: list[str] = []
+    if backend is not None:
+        try:
+            # input_format is a method on real backends but may be a plain
+            # attribute on stubs; accept either.
+            fmt = backend.input_format
+            if callable(fmt):
+                fmt = fmt()
+            patterns = list(_GENERATED_INPUT_PATTERNS.get(fmt, []))
+        except Exception:
+            patterns = []
+    patterns += _GENERATED_INPUT_LEGACY
+
+    for pattern in patterns:
+        matches = sorted(m for m in work_dir.glob(pattern) if _ok(m))
+        if matches:
+            return matches[0]
+
+    # Last resort: any file the generator produced that is not a script/aux.
+    leftovers = sorted(f for f in work_dir.iterdir() if _ok(f))
+    return leftovers[0] if leftovers else None
+
+
 def sorted_by_step(paths: list) -> list:
     """Sort result files by NUMERIC step index, not lexicographically.
 

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -1463,12 +1463,8 @@ def register_consolidated_tools(mcp: FastMCP):
                 "work_dir": str(work_dir),
             }, indent=2)
 
-        input_file = None
-        for pattern in ["*.4C.yaml", "*.yaml", "input.*", "solve.py", "MainKratos.py"]:
-            matches = list(work_dir.glob(pattern))
-            if matches:
-                input_file = matches[0]
-                break
+        from core.backend import find_generated_input
+        input_file = find_generated_input(work_dir, backend)
 
         if not input_file:
             _journal.record("tool_error", "run_with_generator", solver=solver,
@@ -1478,6 +1474,7 @@ def register_consolidated_tools(mcp: FastMCP):
                 "status": "failed", "phase": "generator",
                 "error": "Generator did not produce an input file",
                 "work_dir": str(work_dir),
+                "files": [f.name for f in work_dir.iterdir()],
             }, indent=2)
 
         input_content = input_file.read_text()

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -1474,7 +1474,7 @@ def register_consolidated_tools(mcp: FastMCP):
                 "status": "failed", "phase": "generator",
                 "error": "Generator did not produce an input file",
                 "work_dir": str(work_dir),
-                "files": [f.name for f in work_dir.iterdir()],
+                "files": sorted(f.name for f in work_dir.iterdir())[:50],
             }, indent=2)
 
         input_content = input_file.read_text()

--- a/src/tools/examples_search.py
+++ b/src/tools/examples_search.py
@@ -623,7 +623,7 @@ int main()
 
 ## Build (CMakeLists.txt)
 ```cmake
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13.4)
 find_package(deal.II 9.0 REQUIRED)
 deal_ii_initialize_cached_variables()
 project(my_problem)

--- a/src/tools/simulation.py
+++ b/src/tools/simulation.py
@@ -96,13 +96,9 @@ def register_simulation_tools(mcp: FastMCP):
                 "work_dir": str(work_dir),
             }, indent=2)
 
-        # Step 2: Find the generated input file
-        input_file = None
-        for pattern in ["*.4C.yaml", "*.yaml", "input.*", "solve.py", "MainKratos.py"]:
-            matches = list(work_dir.glob(pattern))
-            if matches:
-                input_file = matches[0]
-                break
+        # Step 2: Find the generated input file (backend-aware; see issue #39)
+        from core.backend import find_generated_input
+        input_file = find_generated_input(work_dir, backend)
 
         if not input_file:
             return json.dumps({

--- a/src/tools/simulation.py
+++ b/src/tools/simulation.py
@@ -106,7 +106,7 @@ def register_simulation_tools(mcp: FastMCP):
                 "phase": "generator",
                 "error": "Generator did not produce an input file",
                 "work_dir": str(work_dir),
-                "files": [f.name for f in work_dir.iterdir()],
+                "files": sorted(f.name for f in work_dir.iterdir())[:50],
             }, indent=2)
 
         input_content = input_file.read_text()

--- a/tests/test_generated_input_detection.py
+++ b/tests/test_generated_input_detection.py
@@ -1,0 +1,113 @@
+"""Regression tests for run_with_generator's input-file detection.
+
+Guards against issue #39: deal.II's generator writes ``main.cpp`` and
+SPARTA's writes ``in.sparta``, neither of which was matched by the old
+hardcoded glob ``["*.4C.yaml","*.yaml","input.*","solve.py","MainKratos.py"]``,
+so run_with_generator failed with "Generator did not produce an input file"
+even though the generator succeeded.
+
+These tests need no installed backend — they exercise the pure detection
+helper with a stub backend exposing only ``input_format``.
+"""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from core.backend import find_generated_input, InputFormat
+
+
+class _StubBackend:
+    def __init__(self, fmt):
+        self.input_format = fmt
+
+
+class _MethodStubBackend:
+    """Mimics the real backends, where ``input_format`` is a METHOD."""
+    def __init__(self, fmt):
+        self._fmt = fmt
+
+    def input_format(self):
+        return self._fmt
+
+
+def test_input_format_as_method_takes_priority_over_legacy():
+    """Real backends expose ``input_format`` as a method. The format-specific
+    patterns must still win over the legacy glob: a decoy ``notes.yaml`` in a
+    deal.II dir must not be picked over ``main.cpp`` (would happen if the helper
+    read the bound method instead of calling it)."""
+    with tempfile.TemporaryDirectory() as d:
+        wd = Path(d)
+        (wd / "generate_input.py").write_text("#")
+        (wd / "notes.yaml").write_text("decoy: true")
+        (wd / "main.cpp").write_text("int main(){return 0;}")
+        found = find_generated_input(wd, _MethodStubBackend(InputFormat.CPP))
+        assert found is not None and found.name == "main.cpp"
+
+
+# The canonical file each backend's generator writes, by declared format.
+FORMAT_FILES = [
+    (InputFormat.CPP, "main.cpp", "int main(){return 0;}"),
+    (InputFormat.SPARTA, "in.sparta", "run 0\n"),
+    (InputFormat.PYTHON, "solve.py", "print(1)\n"),
+    (InputFormat.YAML, "sim.4C.yaml", "PROBLEM TYPE: Fluid\n"),
+    (InputFormat.XML, "input.feb", "<febio_spec/>\n"),
+    (InputFormat.JSON, "MainKratos.py", "print(1)\n"),
+]
+
+
+@pytest.mark.parametrize("fmt,fname,content", FORMAT_FILES,
+                         ids=[f.name for f, _, _ in FORMAT_FILES])
+def test_detects_each_format(fmt, fname, content):
+    """Every backend's generator output is detected, and the generator
+    script itself is never mistaken for the input."""
+    with tempfile.TemporaryDirectory() as d:
+        wd = Path(d)
+        (wd / "generate_input.py").write_text("# the generator, must be ignored")
+        (wd / fname).write_text(content)
+        found = find_generated_input(wd, _StubBackend(fmt))
+        assert found is not None, f"{fmt.name}: nothing detected (issue #39 regression)"
+        assert found.name == fname
+
+
+def test_dealii_ignores_cmakelists_and_generator():
+    """deal.II generator writes main.cpp + CMakeLists.txt; must pick main.cpp."""
+    with tempfile.TemporaryDirectory() as d:
+        wd = Path(d)
+        (wd / "generate_input.py").write_text("#")
+        (wd / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.13.4)\n")
+        (wd / "main.cpp").write_text("int main(){return 0;}")
+        found = find_generated_input(wd, _StubBackend(InputFormat.CPP))
+        assert found is not None and found.name == "main.cpp"
+
+
+def test_only_scripts_and_logs_returns_none():
+    """A generator that produced no input file yields None (the honest
+    'did not produce an input file' path)."""
+    with tempfile.TemporaryDirectory() as d:
+        wd = Path(d)
+        (wd / "generate_input.py").write_text("#")
+        (wd / "stderr.log").write_text("boom")
+        (wd / "stdout.log").write_text("")
+        assert find_generated_input(wd, _StubBackend(InputFormat.CPP)) is None
+
+
+def test_fallback_picks_unexpected_filename():
+    """Even a non-standard generator output is found via the last-resort
+    fallback, so a valid run is never dropped on a naming quirk."""
+    with tempfile.TemporaryDirectory() as d:
+        wd = Path(d)
+        (wd / "generate_input.py").write_text("#")
+        (wd / "weird_name.inp").write_text("data")
+        found = find_generated_input(wd, _StubBackend(InputFormat.SPARTA))
+        assert found is not None and found.name == "weird_name.inp"
+
+
+def test_works_without_backend():
+    """Detection must still work if no backend is passed (legacy patterns)."""
+    with tempfile.TemporaryDirectory() as d:
+        wd = Path(d)
+        (wd / "generate_input.py").write_text("#")
+        (wd / "problem.4C.yaml").write_text("x: 1")
+        found = find_generated_input(wd, None)
+        assert found is not None and found.name == "problem.4C.yaml"


### PR DESCRIPTION
## Summary

Fixes #39. deal.II simulations through `run_with_generator` were completely broken. This PR fixes that, a related CMake-version issue, and a second backend (SPARTA) that had the identical detection gap.

## The bugs

1. **`run_with_generator` never detected deal.II output.** The input-file glob `["*.4C.yaml","*.yaml","input.*","solve.py","MainKratos.py"]` (duplicated in `consolidated.py` and `simulation.py`) matches no `.cpp`, so deal.II's `main.cpp` was invisible and a *successful* generator was reported as *"Generator did not produce an input file"*. SPARTA's `in.sparta` had the same problem (`input.*` does not match `in.sparta`).
2. **Generated `CMakeLists.txt` hardcoded `cmake_minimum_required(VERSION 3.1)`.** CMake >= 4 removed support for `< 3.5`, so every deal.II build failed on recent CMake (the reporter's 4.4.0 rejected it outright).

## The fix

- New backend-aware `find_generated_input()` helper in `core/backend.py`, keyed on `InputFormat`, with a legacy-pattern fallback and a last-resort scan so no valid generator output is ever dropped. Both call sites use it.
- `cmake_minimum_required` `3.1 -> 3.13.4` (deal.II's documented minimum) in the three deal.II spots.

## Verification (Linux, deal.II installed)

- A real deal.II program compiled with `3.13.4`, linked deal.II, ran, and returned the correct result.
- The exact issue #39 flow: generator writes `main.cpp` + a stale `3.1` CMakeLists -> detected -> recompiled at `3.13.4` -> ran -> correct result.
- SPARTA `in.sparta` detection now works end-to-end (launches and runs real DSMC steps).
- deal.II passes the full 10-benchmark cross-solver e2e suite; 30 deal.II/generator/backend unit tests are green.
- New regression test `tests/test_generated_input_detection.py` (11 tests): all six input formats plus edge cases (decoy files, `input_format` as method vs attribute, generator-script exclusion, empty dir -> None).

## Notes (out of scope, pre-existing)

- The deal.II.app bundled `mpicxx` SDK conflict (issue #39 item 3) is a third-party-binary / environment problem, not OASiS. The code already honours `CC`/`CXX`, so the reporter's compiler wrapper plugs in via `-DCMAKE_CXX_COMPILER`.
- SPARTA's example decks reference a species file (`ar.species`) the generator does not ship — a separate template gap, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
