### PR TITLE
Fix DUNE python-env resolution + SPARTA data-file staging (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ conda create -n ofa-dune -c conda-forge dune-fem
 sudo apt install libdeal.ii-dev
 ```
 
+Conda envs are auto-detected (envs whose name contains `fenics`/`dolfinx`
+or `dune` are preferred). For non-standard layouts point OASiS at the
+interpreter explicitly — both discovery **and** execution use it:
+
+```bash
+export FENICS_PYTHON=/path/to/env/bin/python   # or FENICS_CONDA_PREFIX=/path/to/env
+export DUNE_PYTHON=/path/to/env/bin/python     # or DUNE_CONDA_PREFIX=/path/to/env
+```
+
 ### Verify
 
 ```bash

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -10,6 +10,7 @@
         "FOURC_BINARY": "${HOME}/4C/build/4C",
         "LD_LIBRARY_PATH": "/opt/4C-dependencies/lib",
         "FENICS_PYTHON": "${HOME}/miniconda3/envs/fenics/bin/python",
+        "DUNE_PYTHON": "${HOME}/miniconda3/envs/ofa-dune/bin/python",
         "PYVISTA_OFF_SCREEN": "true"
       }
     }

--- a/src/backends/dune/backend.py
+++ b/src/backends/dune/backend.py
@@ -11,6 +11,7 @@ interchangeable. Different backend (DUNE C++ infrastructure vs PETSc).
 
 import asyncio
 import logging
+import os
 import shutil
 import time
 import uuid
@@ -27,6 +28,129 @@ from .generators import GENERATORS, KNOWLEDGE
 
 logger = logging.getLogger("oasis.dune")
 
+# Cache for the verified dune.fem interpreter. Probing candidates spawns a
+# subprocess per candidate (`import dune.fem`, up to 30 s each), so we only
+# resolve once per server lifetime. Cleared via _reset_dune_python_cache()
+# (used by tests).
+_DUNE_PYTHON_CACHE: dict = {}
+
+_DUNE_INSTALL_HINT = (
+    "dune.fem not importable in any candidate Python. "
+    "Try: conda create -n ofa-dune -c conda-forge dune-fem\n"
+    "Or point OASiS at an existing install:\n"
+    "  DUNE_PYTHON=/path/to/env/bin/python   (explicit interpreter)\n"
+    "  DUNE_CONDA_PREFIX=/path/to/env        (conda env root)")
+
+
+def _reset_dune_python_cache():
+    """Clear the cached interpreter (tests / env changes)."""
+    _DUNE_PYTHON_CACHE.clear()
+
+
+def _find_dune_python() -> Optional[str]:
+    """Locate and VERIFY the Python interpreter that can import dune.fem.
+
+    This is the single source of truth for interpreter resolution — used by
+    BOTH check_availability() and run(). (Issue #40: run() previously used
+    the server's own venv Python unconditionally, so a dune.fem found in a
+    conda env by check_availability() was ignored at execution time.)
+
+    DUNE-fem is heavy enough that users typically install it into a
+    dedicated conda env (ofa-dune is the convention mirroring
+    ofa-fenicsx / ofa-dealii). The MCP server runs in the oasis .venv
+    which usually does NOT have dune.fem.
+
+    Resolution order:
+      * DUNE_PYTHON env var (explicit interpreter, verified too)
+      * DUNE_CONDA_PREFIX env var (conda env root)
+      * priority 0 — any conda env with "dune" in its name (ofa-dune,
+        dune, dune-fem, ...) — the most likely place.
+      * priority 1 — any other conda env (covers dune.fem installed
+        alongside fenicsx in a single shared env).
+      * priority 99 — the active interpreter (.venv) — checked last
+        because dune.fem in the harness's own .venv is rare and probing
+        it first would slow down the common case.
+
+    Every candidate is verified with a subprocess `import dune.fem`
+    before being returned; the first success is cached.
+    """
+    import subprocess
+
+    if "python" in _DUNE_PYTHON_CACHE:
+        return _DUNE_PYTHON_CACHE["python"]
+
+    candidates: list[tuple[int, str]] = []
+
+    # Explicit overrides first (mirrors FENICS_PYTHON / FENICS_CONDA_PREFIX).
+    env_python = os.environ.get("DUNE_PYTHON", "")
+    if env_python and Path(env_python).is_file():
+        candidates.append((-2, env_python))
+    env_prefix = os.environ.get("DUNE_CONDA_PREFIX", "")
+    if env_prefix:
+        p = Path(env_prefix) / "bin" / "python"
+        if p.is_file():
+            candidates.append((-1, str(p)))
+
+    for conda_base in (
+            Path.home() / "miniconda3" / "envs",
+            Path.home() / "anaconda3" / "envs",
+            Path.home() / "miniforge3" / "envs"):
+        if not conda_base.is_dir():
+            continue
+        for env_dir in sorted(conda_base.iterdir()):
+            py = env_dir / "bin" / "python"
+            if py.is_file():
+                # Prioritise *dune* envs but accept any
+                name = env_dir.name.lower()
+                priority = 0 if "dune" in name else 1
+                candidates.append((priority, str(py)))
+
+    active = get_python_executable()
+    if active:
+        candidates.append((99, active))
+
+    # De-dup while preserving the best (lowest) priority per interpreter.
+    seen = set()
+    ordered = []
+    for priority, py in sorted(candidates, key=lambda x: x[0]):
+        if py in seen:
+            continue
+        seen.add(py)
+        ordered.append(py)
+
+    for python in ordered:
+        try:
+            result = subprocess.run(
+                [python, "-c", "import dune.fem; print('OK')"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if result.returncode == 0:
+                _DUNE_PYTHON_CACHE["python"] = python
+                return python
+        except Exception:
+            continue
+    return None
+
+
+def _dune_subprocess_env(python: str) -> dict:
+    """Environment for running dune scripts with the resolved interpreter.
+
+    dune-fem JIT-compiles C++ modules at run time; its CMake needs to
+    find the dune-* package configs that live under the interpreter's
+    prefix (<prefix>/lib/cmake/dune-*). When the interpreter comes from
+    a conda env that the server never activated, CMAKE_PREFIX_PATH does
+    not contain that prefix and the very first JIT build fails with
+    "Could not find ... dune-commonConfig.cmake" (issue #40 follow-up:
+    picking the right python is necessary but not sufficient).
+    """
+    env = os.environ.copy()
+    prefix = str(Path(python).resolve().parent.parent)
+    existing = env.get("CMAKE_PREFIX_PATH", "")
+    if prefix not in existing.split(os.pathsep):
+        env["CMAKE_PREFIX_PATH"] = (
+            prefix + (os.pathsep + existing if existing else ""))
+    return env
+
 
 class DuneBackend(SolverBackend):
 
@@ -37,66 +161,13 @@ class DuneBackend(SolverBackend):
         return "DUNE-fem"
 
     def check_availability(self) -> tuple[BackendStatus, str]:
-        # DUNE-fem is heavy enough that users typically install it
-        # into a dedicated conda env (ofa-dune is the convention
-        # mirroring ofa-fenicsx / ofa-dealii). The MCP server runs
-        # in the oasis .venv which usually does NOT have
-        # dune.fem.
-        #
-        # Search order (priority lowest-first):
-        #   0 — any conda env with "dune" in its name (ofa-dune,
-        #       dune, dune-fem, etc.) — the most likely place.
-        #   1 — any other conda env (covers the case where dune.fem
-        #       was installed alongside fenicsx in a single shared
-        #       env).
-        #   99 — the active interpreter (.venv) — checked last
-        #       because dune.fem in the harness's own .venv is rare
-        #       and probing it first would slow down the common
-        #       case. Still checked so an unusual install layout
-        #       gets picked up.
-        # (Audit 2026-06-01; comment corrected 2026-06-02 — the
-        # earlier "Check the active interpreter first" was wrong.)
-        import subprocess
-        candidates = []
-        active = get_python_executable()
-        if active:
-            candidates.append(active)
-        for conda_base in (
-                Path.home() / "miniconda3" / "envs",
-                Path.home() / "anaconda3" / "envs",
-                Path.home() / "miniforge3" / "envs"):
-            if not conda_base.is_dir():
-                continue
-            for env_dir in conda_base.iterdir():
-                py = env_dir / "bin" / "python"
-                if py.is_file():
-                    # Prioritise *dune* envs but accept any
-                    name = env_dir.name.lower()
-                    priority = 0 if "dune" in name else 1
-                    candidates.append((priority, str(py)))
-        # De-dup while preserving order; sort by priority where annotated.
-        seen = set()
-        ordered = []
-        for c in candidates:
-            py = c[1] if isinstance(c, tuple) else c
-            if py in seen:
-                continue
-            seen.add(py)
-            ordered.append((c[0] if isinstance(c, tuple) else 99, py))
-        ordered.sort(key=lambda x: x[0])
-        for _, python in ordered:
-            try:
-                result = subprocess.run(
-                    [python, "-c", "import dune.fem; print('OK')"],
-                    capture_output=True, text=True, timeout=30,
-                )
-                if result.returncode == 0:
-                    return BackendStatus.AVAILABLE, f"DUNE-fem at {python}"
-            except Exception:
-                continue
-        return BackendStatus.NOT_INSTALLED, (
-            "dune.fem not importable in any candidate Python. "
-            "Try: conda create -n ofa-dune -c conda-forge dune-fem")
+        # Interpreter discovery + verification lives in
+        # _find_dune_python() so that run() executes with EXACTLY the
+        # interpreter reported here (issue #40).
+        python = _find_dune_python()
+        if python:
+            return BackendStatus.AVAILABLE, f"DUNE-fem at {python}"
+        return BackendStatus.NOT_INSTALLED, _DUNE_INSTALL_HINT
 
     def input_format(self) -> InputFormat:
         return InputFormat.PYTHON
@@ -232,14 +303,17 @@ class DuneBackend(SolverBackend):
 
     async def run(self, input_content: str, work_dir: Path,
                   np: int = 1, timeout=None) -> JobHandle:
-        python = get_python_executable()
+        # Use the SAME interpreter that check_availability() verified —
+        # NOT the server's own venv Python (issue #40: the venv usually
+        # lacks dune.fem; it lives in a conda env).
+        python = _find_dune_python()
         if not python:
             return JobHandle(
                 job_id=str(uuid.uuid4())[:8],
                 backend_name="dune",
                 work_dir=work_dir,
                 status="failed",
-                error="Python not found",
+                error=_DUNE_INSTALL_HINT,
             )
 
         work_dir = work_dir.resolve()
@@ -262,6 +336,7 @@ class DuneBackend(SolverBackend):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(work_dir),
+                env=_dune_subprocess_env(python),
             )
             # DUNE JIT compiles on first run — can be slow
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)

--- a/src/backends/dune/backend.py
+++ b/src/backends/dune/backend.py
@@ -129,6 +129,9 @@ def _find_dune_python() -> Optional[str]:
                 return python
         except Exception:
             continue
+    # Cache the negative result too, so a missing/misconfigured dune.fem does
+    # not re-probe every candidate (up to 30 s each) on every check/run.
+    _DUNE_PYTHON_CACHE["python"] = None
     return None
 
 

--- a/src/backends/sparta/backend.py
+++ b/src/backends/sparta/backend.py
@@ -98,7 +98,6 @@ def _stage_sparta_data_files(deck: str, work_dir: Path, binary: str):
     `species <file> ...`, `collide vss <mix> <file>`, `read_surf <file>`,
     `read_grid <file>`, `react tce <file>`. Relative ../data/ prefixes in
     the deck are resolved against the distribution dirs."""
-    import re
     wanted: set[str] = set()
     for line in deck.splitlines():
         line = line.strip()
@@ -327,7 +326,10 @@ class SpartaBackend(SolverBackend):
         work_dir.mkdir(parents=True, exist_ok=True)
         script_path = work_dir / "in.sparta"
         script_path.write_text(input_content)
-        _stage_sparta_data_files(input_content, work_dir, binary)
+        try:
+            _stage_sparta_data_files(input_content, work_dir, binary)
+        except Exception as e:
+            logger.warning(f"SPARTA data-file staging failed (continuing): {e}")
 
         job = JobHandle(job_id=job_id, backend_name="sparta",
                         work_dir=work_dir, status="running")

--- a/src/backends/sparta/backend.py
+++ b/src/backends/sparta/backend.py
@@ -57,12 +57,90 @@ def _find_sparta_binary() -> Optional[str]:
         if p:
             return p
     for cand in (
+        str(Path.home() / "sparta" / "src" / "spa_serial"),
+        str(Path.home() / "sparta" / "src" / "spa_mpi"),
         "/home/alexander/Schreibtisch/sparta/src/spa_serial",
         "/home/alexander/Schreibtisch/sparta/src/spa_mpi",
     ):
         if Path(cand).exists():
             return cand
     return None
+
+
+def _sparta_data_dirs(binary: str) -> list[Path]:
+    """Candidate dirs holding SPARTA data files (*.species, *.vss, data.*).
+
+    The bundled example decks reference data files (`species ar.species Ar`,
+    `read_surf data.circle`, `collide vss air air.vss`) that live in the
+    SPARTA distribution's data/ and examples/ trees, NOT in the knowledge
+    JSON. Without staging them the deck dies with e.g.
+    'Cannot open species file ar.species' (verified on macOS build
+    2026-07-14). We locate the distribution relative to the binary
+    (src/spa_serial -> repo root) plus SPARTA_ROOT."""
+    dirs = []
+    root_env = os.environ.get("SPARTA_ROOT", "")
+    if root_env and Path(root_env).is_dir():
+        dirs.append(Path(root_env))
+    try:
+        # <repo>/src/spa_serial -> <repo>
+        repo = Path(binary).resolve().parent.parent
+        if (repo / "data").is_dir() or (repo / "examples").is_dir():
+            dirs.append(repo)
+    except OSError:
+        pass
+    return dirs
+
+
+def _stage_sparta_data_files(deck: str, work_dir: Path, binary: str):
+    """Copy data files referenced by the deck into work_dir (best effort).
+
+    Handles the reference styles used across the bundled decks:
+    `species <file> ...`, `collide vss <mix> <file>`, `read_surf <file>`,
+    `read_grid <file>`, `react tce <file>`. Relative ../data/ prefixes in
+    the deck are resolved against the distribution dirs."""
+    import re
+    wanted: set[str] = set()
+    for line in deck.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        toks = line.split()
+        if toks[0] == "species" and len(toks) >= 2:
+            wanted.add(toks[1])
+        elif toks[0] == "collide" and len(toks) >= 4 and toks[1].startswith("vss"):
+            wanted.add(toks[3])
+        elif toks[0] in ("read_surf", "read_grid", "read_isurf") and len(toks) >= 2:
+            wanted.add(toks[1])
+        elif toks[0] == "react" and len(toks) >= 3:
+            wanted.add(toks[2])
+    if not wanted:
+        return
+    search_dirs = _sparta_data_dirs(binary)
+    for ref in wanted:
+        name = Path(ref).name
+        dest = work_dir / name
+        if dest.exists():
+            continue
+        found = None
+        for base in search_dirs:
+            for cand_dir in (base / "data", base / "examples", base):
+                cand = cand_dir / name
+                if cand.is_file():
+                    found = cand
+                    break
+            if not found:
+                # examples/* subdirs (data.circle lives in examples/circle)
+                hits = list((base / "examples").glob(f"*/{name}")) \
+                    if (base / "examples").is_dir() else []
+                if hits:
+                    found = hits[0]
+            if found:
+                break
+        if found:
+            shutil.copy(found, dest)
+            logger.info(f"Staged SPARTA data file {name} from {found}")
+        else:
+            logger.warning(f"SPARTA data file referenced by deck not found: {ref}")
 
 
 # ── physics capability -> {relevant commands, example template dir, pitfalls} ──
@@ -249,6 +327,7 @@ class SpartaBackend(SolverBackend):
         work_dir.mkdir(parents=True, exist_ok=True)
         script_path = work_dir / "in.sparta"
         script_path.write_text(input_content)
+        _stage_sparta_data_files(input_content, work_dir, binary)
 
         job = JobHandle(job_id=job_id, backend_name="sparta",
                         work_dir=work_dir, status="running")

--- a/src/core/autodiscovery.py
+++ b/src/core/autodiscovery.py
@@ -228,8 +228,16 @@ def discover_backends() -> list[ProbeResult]:
     results.append(_probe_pip_package(
         "KratosMultiphysics", "KratosMultiphysics", "kratos",
         "pip install KratosMultiphysics"))
-    results.append(_probe_pip_package(
-        "dune-fem", "dune.fem", "dune", "pip install dune-fem"))
+
+    # DUNE-fem — like FEniCSx it usually lives in a conda env (ofa-dune),
+    # not the server's venv (issue #40).
+    dune_pip = _probe_pip_package(
+        "dune-fem", "dune.fem", "dune", "pip install dune-fem")
+    if dune_pip.found:
+        results.append(dune_pip)
+    else:
+        dune_conda = _probe_conda_env(["dune"], "dune.fem", "dune")
+        results.append(dune_conda or dune_pip)
 
     # FEniCSx — needs conda usually
     fenics_pip = _probe_pip_package(

--- a/src/core/registry.py
+++ b/src/core/registry.py
@@ -117,6 +117,8 @@ def load_all_backends():
                 loc = info.get("location", "")
                 if backend == "fenics" and loc:
                     os.environ.setdefault("FENICS_PYTHON", loc)
+                elif backend == "dune" and loc:
+                    os.environ.setdefault("DUNE_PYTHON", loc)
                 elif backend == "fourc" and loc:
                     os.environ.setdefault("FOURC_BINARY", loc)
                 src_root = info.get("source_root", "")

--- a/tests/test_python_env_consistency.py
+++ b/tests/test_python_env_consistency.py
@@ -66,11 +66,6 @@ def _write_fake_python(path: Path, script: str = FAKE_PYTHON_SCRIPT) -> Path:
     return path
 
 
-def _clean_dune_env():
-    """Context: DUNE_* overrides removed from os.environ."""
-    return mock.patch.dict(os.environ, {}, clear=False)
-
-
 class _DuneEnvTestCase(unittest.TestCase):
     """Base: isolated cache + env for every test."""
 

--- a/tests/test_python_env_consistency.py
+++ b/tests/test_python_env_consistency.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Regression tests for issue #40: "Python environments ignored".
+
+check_availability() discovered the dune.fem interpreter in a conda env,
+but run() unconditionally used the server's own venv Python (which
+typically lacks dune.fem). Fix: a single resolver (_find_dune_python)
+used by BOTH methods.
+
+This suite verifies:
+1. End-to-end: with a fake conda env, run() executes the SAME interpreter
+   that check_availability() reported (the actual #40 regression).
+2. DUNE_PYTHON / DUNE_CONDA_PREFIX explicit overrides win.
+3. The resolver caches (probing spawns subprocesses; run() must not
+   re-probe after check_availability()).
+4. Negative path: no dune.fem anywhere -> NOT_INSTALLED with actionable
+   hint, and run() fails cleanly with the same hint.
+5. Generic invariant, ALL backends: check_availability() and run() must
+   use the same executable-resolution helpers, so this bug class cannot
+   silently reappear in any backend.
+"""
+
+import asyncio
+import inspect
+import os
+import re
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from backends.dune import backend as dune_mod
+from backends.dune.backend import DuneBackend, _find_dune_python, _reset_dune_python_cache
+from core.backend import BackendStatus
+
+
+# ── helpers ──────────────────────────────────────────────────
+
+FAKE_PYTHON_SCRIPT = """#!/bin/sh
+# Fake dune-fem Python: answers `-c "import dune.fem; ..."` probes with OK
+# and records its own path when executing a script (run() path).
+if [ "$1" = "-c" ]; then
+    case "$2" in
+        *dune.fem*) echo OK; exit 0;;
+        *) exit 1;;
+    esac
+fi
+echo "$0" > "$(pwd)/interpreter_used.txt"
+exit 0
+"""
+
+BROKEN_PYTHON_SCRIPT = """#!/bin/sh
+# Fake Python WITHOUT dune.fem: every import probe fails.
+exit 1
+"""
+
+
+def _write_fake_python(path: Path, script: str = FAKE_PYTHON_SCRIPT) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(script)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _clean_dune_env():
+    """Context: DUNE_* overrides removed from os.environ."""
+    return mock.patch.dict(os.environ, {}, clear=False)
+
+
+class _DuneEnvTestCase(unittest.TestCase):
+    """Base: isolated cache + env for every test."""
+
+    def setUp(self):
+        _reset_dune_python_cache()
+        self._env_patcher = mock.patch.dict(os.environ)
+        self._env_patcher.start()
+        os.environ.pop("DUNE_PYTHON", None)
+        os.environ.pop("DUNE_CONDA_PREFIX", None)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self):
+        _reset_dune_python_cache()
+        self._env_patcher.stop()
+        self._tmp.cleanup()
+
+
+# ── 1. The actual #40 regression, end to end ─────────────────
+
+class TestIssue40DuneCondaEnvRespected(_DuneEnvTestCase):
+    """With dune.fem only in a conda env, run() must use THAT interpreter."""
+
+    def _fake_home_with_dune_env(self, env_name="ofa-dune"):
+        home = self.tmp / "home"
+        return home, _write_fake_python(
+            home / "miniconda3" / "envs" / env_name / "bin" / "python")
+
+    def test_check_availability_finds_conda_env(self):
+        home, fake_py = self._fake_home_with_dune_env()
+        with mock.patch("pathlib.Path.home", return_value=home):
+            status, msg = DuneBackend().check_availability()
+        self.assertEqual(status, BackendStatus.AVAILABLE)
+        self.assertIn(str(fake_py), msg)
+
+    def test_run_uses_the_interpreter_check_availability_found(self):
+        """The core #40 assertion: discovery and execution use ONE interpreter."""
+        home, fake_py = self._fake_home_with_dune_env()
+        work_dir = self.tmp / "job"
+        backend = DuneBackend()
+        with mock.patch("pathlib.Path.home", return_value=home):
+            status, msg = backend.check_availability()
+            self.assertEqual(status, BackendStatus.AVAILABLE)
+            job = asyncio.run(backend.run("import dune.fem\n", work_dir))
+
+        self.assertEqual(job.status, "completed", f"run() failed: {job.error}")
+        marker = work_dir / "interpreter_used.txt"
+        self.assertTrue(marker.is_file(),
+                        "solve.py was not executed by the fake dune python — "
+                        "run() picked a different interpreter than "
+                        "check_availability() (issue #40 regression)")
+        used = marker.read_text().strip()
+        self.assertEqual(used, str(fake_py))
+        # And it must be exactly the interpreter the availability message named.
+        self.assertIn(used, msg)
+        # The server's own venv python must NOT have been used.
+        self.assertNotEqual(used, sys.executable)
+
+    def test_dune_named_env_preferred_over_other_envs(self):
+        """Priority 0 ('dune' in name) must beat priority 1 (any other env)."""
+        home = self.tmp / "home"
+        # 'aaa-shared' sorts before 'ofa-dune' — only priority can win here.
+        _write_fake_python(home / "miniconda3" / "envs" / "aaa-shared" / "bin" / "python")
+        dune_py = _write_fake_python(home / "miniconda3" / "envs" / "ofa-dune" / "bin" / "python")
+        with mock.patch("pathlib.Path.home", return_value=home):
+            self.assertEqual(_find_dune_python(), str(dune_py))
+
+    def test_broken_dune_env_falls_through_to_working_env(self):
+        """A dune-named env whose import fails must not shadow a working one."""
+        home = self.tmp / "home"
+        _write_fake_python(home / "miniconda3" / "envs" / "dune-broken" / "bin" / "python",
+                           BROKEN_PYTHON_SCRIPT)
+        good = _write_fake_python(home / "miniconda3" / "envs" / "shared-env" / "bin" / "python")
+        with mock.patch("pathlib.Path.home", return_value=home):
+            self.assertEqual(_find_dune_python(), str(good))
+
+
+# ── 2. Explicit overrides ────────────────────────────────────
+
+class TestDunePythonOverrides(_DuneEnvTestCase):
+
+    def test_dune_python_env_var_wins_over_conda_env(self):
+        home, _ = TestIssue40DuneCondaEnvRespected._fake_home_with_dune_env(self)
+        override = _write_fake_python(self.tmp / "custom" / "bin" / "python")
+        os.environ["DUNE_PYTHON"] = str(override)
+        with mock.patch("pathlib.Path.home", return_value=home):
+            self.assertEqual(_find_dune_python(), str(override))
+
+    def test_dune_python_env_var_is_verified_not_trusted(self):
+        """A DUNE_PYTHON that cannot import dune.fem must be rejected."""
+        bad = _write_fake_python(self.tmp / "bad" / "bin" / "python", BROKEN_PYTHON_SCRIPT)
+        good = _write_fake_python(
+            self.tmp / "home" / "miniconda3" / "envs" / "ofa-dune" / "bin" / "python")
+        os.environ["DUNE_PYTHON"] = str(bad)
+        with mock.patch("pathlib.Path.home", return_value=self.tmp / "home"):
+            self.assertEqual(_find_dune_python(), str(good))
+
+    def test_dune_conda_prefix(self):
+        env_root = self.tmp / "some-env"
+        py = _write_fake_python(env_root / "bin" / "python")
+        os.environ["DUNE_CONDA_PREFIX"] = str(env_root)
+        with mock.patch("pathlib.Path.home", return_value=self.tmp / "empty-home"):
+            self.assertEqual(_find_dune_python(), str(py))
+
+    def test_run_respects_dune_python(self):
+        override = _write_fake_python(self.tmp / "custom" / "bin" / "python")
+        os.environ["DUNE_PYTHON"] = str(override)
+        work_dir = self.tmp / "job"
+        with mock.patch("pathlib.Path.home", return_value=self.tmp / "empty-home"):
+            job = asyncio.run(DuneBackend().run("pass\n", work_dir))
+        self.assertEqual(job.status, "completed", f"run() failed: {job.error}")
+        self.assertEqual((work_dir / "interpreter_used.txt").read_text().strip(),
+                         str(override))
+
+
+class TestDuneSubprocessEnv(_DuneEnvTestCase):
+    """run() must export the interpreter's prefix via CMAKE_PREFIX_PATH.
+
+    dune-fem JIT-compiles C++ modules at run time; without the conda
+    env's prefix on CMAKE_PREFIX_PATH the first JIT build fails with
+    'Could not find ... dune-commonConfig.cmake' even though run()
+    picked the right interpreter (issue #40 follow-up, verified live
+    with dune-fem 2.12 on macOS).
+    """
+
+    def test_prefix_prepended(self):
+        py = self.tmp / "some-env" / "bin" / "python"
+        py.parent.mkdir(parents=True)
+        py.write_text("")
+        os.environ.pop("CMAKE_PREFIX_PATH", None)
+        env = dune_mod._dune_subprocess_env(str(py))
+        expected = str((self.tmp / "some-env").resolve())
+        self.assertEqual(env["CMAKE_PREFIX_PATH"], expected)
+
+    def test_existing_prefix_path_preserved(self):
+        py = self.tmp / "some-env" / "bin" / "python"
+        py.parent.mkdir(parents=True)
+        py.write_text("")
+        os.environ["CMAKE_PREFIX_PATH"] = "/opt/other"
+        env = dune_mod._dune_subprocess_env(str(py))
+        expected = str((self.tmp / "some-env").resolve())
+        self.assertEqual(
+            env["CMAKE_PREFIX_PATH"],
+            f"{expected}{os.pathsep}/opt/other")
+
+    def test_no_duplicate_when_already_present(self):
+        py = self.tmp / "some-env" / "bin" / "python"
+        py.parent.mkdir(parents=True)
+        py.write_text("")
+        expected = str((self.tmp / "some-env").resolve())
+        os.environ["CMAKE_PREFIX_PATH"] = expected
+        env = dune_mod._dune_subprocess_env(str(py))
+        self.assertEqual(env["CMAKE_PREFIX_PATH"], expected)
+
+
+# ── 3. Caching ───────────────────────────────────────────────
+
+class TestDunePythonCache(_DuneEnvTestCase):
+
+    def test_second_resolution_uses_cache_not_reprobe(self):
+        home = self.tmp / "home"
+        fake_py = _write_fake_python(home / "miniconda3" / "envs" / "ofa-dune" / "bin" / "python")
+        with mock.patch("pathlib.Path.home", return_value=home):
+            first = _find_dune_python()
+        self.assertEqual(first, str(fake_py))
+        # Remove the interpreter: a re-probe would now fail, the cache must hold.
+        fake_py.unlink()
+        with mock.patch("pathlib.Path.home", return_value=home):
+            self.assertEqual(_find_dune_python(), str(fake_py))
+
+    def test_reset_clears_cache(self):
+        home = self.tmp / "home"
+        fake_py = _write_fake_python(home / "miniconda3" / "envs" / "ofa-dune" / "bin" / "python")
+        with mock.patch("pathlib.Path.home", return_value=home):
+            self.assertEqual(_find_dune_python(), str(fake_py))
+        fake_py.unlink()
+        _reset_dune_python_cache()
+        with mock.patch("pathlib.Path.home", return_value=home), \
+             mock.patch.object(dune_mod, "get_python_executable", return_value=None):
+            self.assertIsNone(_find_dune_python())
+
+
+# ── 4. Negative path ─────────────────────────────────────────
+
+class TestDuneNotInstalled(_DuneEnvTestCase):
+
+    def test_not_installed_message_is_actionable(self):
+        with mock.patch("pathlib.Path.home", return_value=self.tmp / "empty-home"), \
+             mock.patch.object(dune_mod, "get_python_executable", return_value=None):
+            status, msg = DuneBackend().check_availability()
+        self.assertEqual(status, BackendStatus.NOT_INSTALLED)
+        self.assertIn("conda create -n ofa-dune", msg)
+        self.assertIn("DUNE_PYTHON", msg)
+
+    def test_run_fails_cleanly_with_same_hint(self):
+        with mock.patch("pathlib.Path.home", return_value=self.tmp / "empty-home"), \
+             mock.patch.object(dune_mod, "get_python_executable", return_value=None):
+            job = asyncio.run(DuneBackend().run("pass\n", self.tmp / "job"))
+        self.assertEqual(job.status, "failed")
+        self.assertIn("DUNE_PYTHON", job.error)
+
+
+# ── 5. Generic invariant across ALL backends ─────────────────
+
+class TestInterpreterResolutionConsistencyAllBackends(unittest.TestCase):
+    """check_availability() and run() must resolve executables identically.
+
+    Guards against the #40 bug class in every backend: extract the
+    executable-resolution helpers referenced by each method's source and
+    require the sets to match. A backend whose discovery uses helper A
+    but whose execution uses helper B ships a discovery/execution split.
+    """
+
+    RESOLVER_RE = re.compile(
+        r"\b(_find_\w+_python|_find_\w+_binary|get_python_executable)\b")
+
+    # dealii resolves via CMake in both methods (check: `shutil.which("cmake")`
+    # + test-compile; run: cmake configure + make). Its _find_dealii helper
+    # locates headers for version reporting only, so the token-set invariant
+    # does not apply. sparta/fourc additionally shell out to mpirun for np>1,
+    # which is not an interpreter/binary *resolution* difference.
+    EXEMPT = {"dealii"}
+
+    @classmethod
+    def setUpClass(cls):
+        from core.registry import load_all_backends, _backends
+        load_all_backends()
+        cls.backends = dict(_backends)
+
+    def test_every_backend_resolves_consistently(self):
+        self.assertGreater(len(self.backends), 0, "no backends registered")
+        for name, backend in self.backends.items():
+            if name in self.EXEMPT:
+                continue
+            with self.subTest(backend=name):
+                check_src = inspect.getsource(backend.check_availability)
+                run_src = inspect.getsource(backend.run)
+                check_resolvers = set(self.RESOLVER_RE.findall(check_src))
+                run_resolvers = set(self.RESOLVER_RE.findall(run_src))
+                self.assertTrue(
+                    check_resolvers,
+                    f"{name}: check_availability() uses no known resolver "
+                    f"helper — extend RESOLVER_RE or EXEMPT with a comment")
+                self.assertEqual(
+                    check_resolvers, run_resolvers,
+                    f"{name}: check_availability() resolves via "
+                    f"{sorted(check_resolvers)} but run() via "
+                    f"{sorted(run_resolvers)} — discovery and execution "
+                    f"would use different interpreters/binaries (issue #40 "
+                    f"bug class)")
+
+    def test_dune_run_does_not_use_server_venv_resolver(self):
+        """Directly pin the #40 fix: run() must not call get_python_executable()."""
+        backend = self.backends.get("dune")
+        self.assertIsNotNone(backend, "dune backend not registered")
+        run_src = inspect.getsource(backend.run)
+        self.assertNotIn("get_python_executable()", run_src)
+        self.assertIn("_find_dune_python()", run_src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes #40. The DUNE backend's `check_availability()` correctly discovered the `dune.fem` interpreter in a conda env, but `run()` ignored it and always used the MCP server's own venv Python (which has no `dune.fem`) — so DUNE jobs failed at execution even though discovery reported the backend as available. This PR makes discovery and execution share one interpreter, and also fixes a SPARTA data-file gap surfaced during the issue #39 work.

## The fixes

- **DUNE (#40):** new `_find_dune_python()` is the single source of truth for interpreter resolution, used by **both** `check_availability()` and `run()`. It verifies each candidate with a subprocess `import dune.fem` before accepting it, prefers `dune`-named conda envs, honours `DUNE_PYTHON` / `DUNE_CONDA_PREFIX` overrides (mirroring the FEniCSx pattern), and caches the result. `run()` now also propagates `CMAKE_PREFIX_PATH` so the dune-py JIT finds the DUNE C++ libraries.
- **SPARTA:** `run()` now stages the data files a deck references (`species ar.species`, `collide vss … air.vss`, `read_surf`, `read_grid`, `react`) into the work dir from the SPARTA distribution, so decks no longer die with `Cannot open species file ar.species`.

## Tests

`tests/test_python_env_consistency.py` — 17 tests incl. 8 subtests:
- discovery and execution use the same interpreter (the core #40 assertion), `dune`-named env preferred, broken env falls through, overrides win and are verified-not-trusted, `CMAKE_PREFIX_PATH` prepend/preserve/no-duplicate, and the interpreter cache.
- a **generic invariant over all backends** asserting `check_availability()` and `run()` resolve executables through the same helper, so this bug class cannot recur silently.

## Verification (Linux; DUNE-fem and SPARTA both installed)

- 17/17 tests pass.
- DUNE end-to-end: `_find_dune_python()` resolves the `dune-fem-env` conda interpreter (distinct from the server venv), and a real 2D Poisson solve **completes** through `run()`.
- SPARTA end-to-end: `ar.species` is staged into the work dir and the `rarefied_flow` run **completes** past the previous "Cannot open species file" failure.

Developed on macOS 26 (arm64) and independently reviewed and re-verified on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
