### PR TITLE
Verification-gate hardening: corrupt result files flip the verdict (F1); broader stdout NaN scan (F2)

### DIFF
--- a/src/core/quality_checks.py
+++ b/src/core/quality_checks.py
@@ -206,7 +206,10 @@ def check_result_files_finite(paths, max_files: int = 25) -> list[str]:
         for name, blocks in list(getattr(m, "cell_data", {}).items()):
             for i, arr in enumerate(blocks):
                 w += check_finite(arr, label=f"{p.name}:{name}[{i}]")
-    if considered and not scannable_format_seen:
+    if considered and not scannable_format_seen and not w:
+        # `not w`: when a hard corrupt-file finding was already emitted, the
+        # note below would be misleading (the format IS scannable here — the
+        # file is corrupt) and redundant (the hard finding flips the verdict).
         # Not a NaN finding — an honesty note: no output file was in a
         # format scannable in this environment (e.g. only .xplt, or .bp
         # without adios2), so finiteness is NOT asserted by the gate.

--- a/src/core/quality_checks.py
+++ b/src/core/quality_checks.py
@@ -140,7 +140,14 @@ def _scan_bp_finite(path) -> tuple[list[str], bool]:
                 w += check_finite(arr, label=f"{getattr(path, 'name', path)}:{name}")
         return w, True
     except BaseException:
-        return [], False
+        # adios2 IS present but could not read the dataset: that is a CORRUPT
+        # result file, not an unscannable format — report it as hard evidence
+        # failure (verdict-flipping), unlike the missing-adios2 case above.
+        return [
+            f"{getattr(path, 'name', path)}: unreadable/corrupt result file — "
+            "the gate could not read it to assert finiteness; the output "
+            "cannot serve as verified run evidence."
+        ], False
 
 
 def check_result_files_finite(paths, max_files: int = 25) -> list[str]:
@@ -180,9 +187,16 @@ def check_result_files_finite(paths, max_files: int = 25) -> list[str]:
             m = meshio.read(str(p))
         except BaseException:
             # A best-effort scan must NEVER take down the run — some meshio
-            # readers even raise SystemExit on malformed input. Leave
-            # scannable_format_seen False so the honesty note still fires: we
-            # did NOT actually assert finiteness for this file.
+            # readers even raise SystemExit on malformed input. But a file with
+            # a SCANNABLE suffix that fails to parse is a CORRUPT result file,
+            # not an unscannable format (stress audit F1: a garbage-only .vtu
+            # was stamped VERIFIED with the honesty note relegated to
+            # 'validation'). Report it as a hard, verdict-flipping finding —
+            # a result the gate cannot read is not verified run evidence.
+            w.append(
+                f"{p.name}: unreadable/corrupt result file — the gate could "
+                "not read it to assert finiteness; the output cannot serve as "
+                "verified run evidence.")
             continue
         # Only mark as scanned AFTER a successful read — otherwise an unreadable
         # .vtu would suppress the honesty note without any check having run.
@@ -223,7 +237,11 @@ def _walk_nonfinite(obj, label: str) -> list[str]:
 # stdout NaN/Inf only where it clearly denotes a numeric RESULT (after = or :,
 # optionally bracketed), so prose/paths can't trigger a false downgrade.
 import re as _re
-_STDOUT_NONFINITE = _re.compile(r"[=:]\s*[\[(]?\s*-?(?:nan|inf|infinity)\b", _re.I)
+# Also matches arrow ("max(u) -> nan") and copula ("residual is nan") headline
+# forms (stress audit F2) — still anchored to a result-introducing token so
+# prose ("infinite domain", "information") cannot false-trigger.
+_STDOUT_NONFINITE = _re.compile(
+    r"(?:[=:]|->|→|\bis\b)\s*[\[(]?\s*[+-]?(?:nan|inf|infinity)\b", _re.I)
 
 
 def check_summary_finite(work_dir, stdout_text: str = "") -> list[str]:

--- a/src/tools/consolidated.py
+++ b/src/tools/consolidated.py
@@ -1656,7 +1656,10 @@ def register_consolidated_tools(mcp: FastMCP):
                       "so no reported number is backed by run evidence")
         elif nonfinite:
             reason = ("the result contains non-finite (NaN/Inf) values, so it is "
-                      "numerically invalid")
+                      "numerically invalid"
+                      if any("non-finite" in x for x in nonfinite)
+                      else "a result file is unreadable/corrupt, so the gate "
+                           "could not assert the output's integrity")
         else:
             reason = ""
         _stamp_verification(result,
@@ -1778,7 +1781,10 @@ def register_consolidated_tools(mcp: FastMCP):
                       "so no reported number is backed by run evidence")
         elif nonfinite:
             reason = ("the result contains non-finite (NaN/Inf) values, so it is "
-                      "numerically invalid")
+                      "numerically invalid"
+                      if any("non-finite" in x for x in nonfinite)
+                      else "a result file is unreadable/corrupt, so the gate "
+                           "could not assert the output's integrity")
         else:
             reason = ""
         _stamp_verification(result,

--- a/tests/test_verification_gate.py
+++ b/tests/test_verification_gate.py
@@ -106,12 +106,23 @@ def test_nan_inf_output_is_flagged(tmp_path):
 
 def test_scan_never_raises_on_garbage(tmp_path):
     bad = tmp_path / "junk.vtu"; bad.write_text("not a real vtu at all")
-    # A best-effort scan must NEVER raise (incl. SystemExit). An unreadable file
-    # yields the HONESTY NOTE (finiteness could not be asserted) — never a false
-    # NaN finding and never a crash.
+    # A best-effort scan must NEVER raise (incl. SystemExit). A file with a
+    # SCANNABLE suffix that fails to parse is a CORRUPT result file (stress
+    # audit F1): a hard, verdict-flipping finding — never a false NaN finding
+    # and never a crash.
     w = check_result_files_finite([bad])
-    assert all("non-finite" not in x for x in w)   # no false NaN finding
-    assert any("not asserted" in x for x in w)     # honesty note present
+    assert all("non-finite" not in x for x in w)          # no false NaN finding
+    assert any("unreadable/corrupt" in x for x in w)      # hard corrupt finding
+
+
+def test_unscannable_format_keeps_honesty_note_only(tmp_path):
+    # A genuinely UNSCANNABLE format (e.g. FEBio .xplt) is a coverage gap, not
+    # corruption: only the informational honesty note fires, no hard finding —
+    # so a legitimate FEBio run is not wrongly flipped to NOT VERIFIED.
+    xplt = tmp_path / "result.xplt"; xplt.write_bytes(b"\x00\x01\x02")
+    w = check_result_files_finite([xplt])
+    assert any("not asserted" in x for x in w)            # honesty note
+    assert all("unreadable/corrupt" not in x for x in w)  # no hard finding
 
 
 # ── Headline-number scan: results_summary.json + stdout (P2) ─────────────
@@ -136,8 +147,17 @@ def test_stdout_nonfinite_result_flagged(tmp_path):
 
 def test_stdout_prose_nan_does_not_false_trigger(tmp_path):
     # 'information'/'nanometer'/a bare word must NOT trigger a false downgrade;
-    # only a NaN/Inf presented as a numeric result (after = or :) counts.
+    # only a NaN/Inf presented as a numeric result counts.
     assert check_summary_finite(tmp_path, "computed 42 nanometers of information") == []
+    # ... including prose around the anchor tokens (F2 hardening must stay
+    # anchored: 'infinite domain' / 'this is fine' are not findings).
+    assert check_summary_finite(tmp_path, "solved on an infinite domain, all is fine") == []
+
+
+def test_stdout_arrow_and_copula_nonfinite_flagged(tmp_path):
+    # Stress audit F2: arrow / copula headline forms evaded the =/: anchor.
+    assert check_summary_finite(tmp_path, "max(u) -> nan")
+    assert check_summary_finite(tmp_path, "residual is inf")
 
 
 # ── Call-site wiring: the tools must actually apply the verdict ───────────
@@ -219,6 +239,18 @@ def test_run_simulation_nan_output_not_verified_even_if_critic_approved(tmp_path
     assert d["trustworthy_result"] is False   # attestation beats critic
     assert d["verification"].startswith("NOT VERIFIED")
     assert any("non-finite" in v for v in d.get("validation", []))
+
+
+def test_run_simulation_corrupt_output_not_verified_even_if_critic_approved(tmp_path):
+    # Stress audit F1: a garbage/unreadable .vtu as the ONLY output used to be
+    # stamped VERIFIED with the honesty note buried in 'validation'. A result
+    # the gate cannot read is not verified run evidence — verdict must flip.
+    f = tmp_path / "out.vtu"; f.write_text("%%% not a vtu at all")
+    d = _run_sim(_Backend([f]), critic_approved=True)
+    assert d["status"] == "completed"          # the run itself still returns
+    assert d["trustworthy_result"] is False
+    assert d["verification"].startswith("NOT VERIFIED")
+    assert any("unreadable/corrupt" in v for v in d.get("validation", []))
 
 
 def test_run_simulation_no_output_is_completed_unverified(tmp_path):


### PR DESCRIPTION
Follow-up hardening from the post-merge adversarial stress round on #46 (13 attack families, all held; two soft spots found and closed here).

## F1 — corrupt result files must flip the verdict
A file with a **scannable** suffix (`.vtu`, …) that **fails to parse** was treated like an unscannable format: the "finiteness not asserted" honesty note fired, but the verdict stayed VERIFIED — a garbage-only output carried a stamp that overstates what was checked. Now a corrupt scannable file (incl. a `.bp` that adios2 cannot read) is a hard, verdict-flipping finding. Genuinely unscannable formats (FEBio `.xplt`, `.bp` without adios2) keep the informational note only, so legitimate runs are not wrongly flipped.

## F2 — broader stdout NaN scan
The headline scan required `=`/`:` before `nan`/`inf`, so `max(u) -> nan` or `residual is nan` evaded it. The pattern now also anchors on `->` / `→` / `is`, while prose ("infinite domain", "information") still cannot false-trigger.

## Verification
- New tests: corrupt-`.vtu` unit + tool-level (the critic cannot rescue it), unscannable `.xplt` stays note-only, arrow/copula stdout forms flagged, prose clean.
- Full suite: **590 passed / 0 failed**.
- End-to-end: a real FEniCSx run writing only a garbage `.vtu` now returns NOT VERIFIED with the corrupt-file reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
