### PR TITLE
REVIEW ONLY — the verification tooling from #50, small enough for a machine reviewer

### DIFF
--- a/.github/workflows/knowledge-freshness.yml
+++ b/.github/workflows/knowledge-freshness.yml
@@ -66,9 +66,54 @@ jobs:
         # the failure -- avoiding misleading issues if a second pytest
         # run produces different output (e.g. cache repopulated,
         # network hiccup resolved).
+        #
+        # THE ANTI-FABRICATION GATES BELONG HERE, and until 2026-08-06 none of
+        # them ran anywhere.  Eight of them existed and this job named three
+        # unrelated tests, so every one of them ran only when a human typed it.
+        # That is not a gate, it is a comment: on the day this was noticed the
+        # contamination check was failing on 10 of its 18 patterns, with 19
+        # leaked sites across 9 files -- including measured convergence orders
+        # in served payloads and an exact solution in closed form in the
+        # coupling knowledge, which is precisely what the evaluation grades.
+        # Nobody had disabled anything; the checks were simply never wired in,
+        # and a check nobody runs protects nothing.
+        #
+        # All of these are pure-Python and read only the tree, so they need no
+        # solver install and belong in this fast job:
+        #   contaminated      -- no measured answer / campaign id / exact
+        #                        solution reachable by an agent
+        #   format_contract   -- every pitfall keeps the [Category] tag and
+        #                        Signal: clause that retrieval indexes
+        #   discoverable      -- no knowledge area holds verified content that
+        #                        no surface enumerates
+        #   fixture_keys      -- a fixture's key names a claim that exists, so
+        #                        evidence cannot silently defend nothing
+        #   assembled_payload -- what the tool actually returns is clean
+        #   gate_cannot_see_answers
+        #
+        # test_quoted_diagnostics_are_real is deliberately NOT here: it needs
+        # each backend's own source tree to search, which a CI runner does not
+        # have, and it would report UNKNOWN for everything.  It runs on a
+        # machine with the solvers installed.
         run: |
           set -o pipefail
-          pytest tests/test_catalog_consistency.py tests/test_ingest_session.py tests/test_introspect.py -v -s 2>&1 | tee /tmp/catalog-test.log
+          pytest tests/test_catalog_consistency.py tests/test_ingest_session.py tests/test_introspect.py \
+                 tests/test_knowledge_not_contaminated.py \
+                 tests/test_pitfall_format_contract.py \
+                 tests/test_knowledge_is_discoverable.py \
+                 tests/test_fixture_keys_point_at_real_claims.py \
+                 tests/test_assembled_payload_is_clean.py \
+                 tests/test_gate_cannot_see_answers.py \
+                 tests/test_fixtures_carry_a_mutation_control.py \
+                 tests/test_named_input_keys_exist.py \
+                 -v -s 2>&1 | tee /tmp/catalog-test.log
+        # test_named_input_keys_exist skips every backend whose corpus is not
+        # installed on the runner, and CI has none of the solvers — so here it
+        # asserts almost nothing. That is deliberate and it is not sufficient:
+        # the gate's real work happens on the machine with the solvers, and the
+        # skip messages in this log are the record of how much went unchecked.
+        # Read them; a run where everything skipped is not a run where
+        # everything passed.
         # Only swallow failures on the weekly cron so the auto-issue step
         # can still run.  On PRs and pushes we WANT the workflow to fail
         # so the check is gating.

--- a/docs/CONSOLIDATION.md
+++ b/docs/CONSOLIDATION.md
@@ -1,0 +1,1293 @@
+# Consolidating the branches
+
+Measured 2026-08-06 against base `8cb1d79`, by actually merging into a scratch
+worktree rather than reasoning about it.
+
+## The scale
+
+| branch | commits | files changed |
+|---|---|---|
+| knowledge/fenics-verify | 60 | 390 |
+| feature/anti-fabrication | 52 | 79 |
+| knowledge/setup-and-portability | 37 | 44 |
+| knowledge/4c-extraction | 35 | 571 |
+| knowledge/dealii-verify | 35 | 205 |
+| knowledge/coupling-revision | 35 | 92 |
+| knowledge/ngsolve-skfem-verify | 34 | 247 |
+| feature/coupling-robustness | 30 | 39 |
+| knowledge/febio-extraction | 30 | 181 |
+| knowledge/kratos-sparta | 26 | 284 |
+| knowledge/dune-extraction | 14 | 98 |
+| knowledge/purge-eval-contamination | 6 | 21 |
+
+394 commits, roughly 2250 changed files. **290 distinct non-fixture files**; the
+rest are per-backend fixture directories, which cannot collide with each other
+by construction.
+
+## The conflict surface is small
+
+Merging all twelve in sequence into a scratch worktree:
+
+    clean: 2      feature/anti-fabrication, knowledge/ngsolve-skfem-verify
+    conflicting: 10, between 1 and 11 files each — about 40 files in total
+
+Forty files out of 2250. The work is overwhelmingly additive.
+
+Files touched by three or more branches, which is where the conflicts live:
+
+    10  scripts/run_tier2_fixtures.py
+     9  tests/test_fixtures_cannot_pass_vacuously.py
+     6  src/tools/consolidated.py
+     5  src/tools/knowledge.py
+     5  scripts/verify_signal_clauses.py
+     4  validation/* (transcripts and ledgers)
+
+`run_tier2_fixtures.py` looks alarming at ten branches, but there are only
+**six distinct versions** of it and the three largest branches already share an
+identical blob — the two real fixes (`--write-results` was parsed and never
+read; interpreter resolution assumed a `.venv` inside the repo) propagated by
+hand as each branch hit them.
+
+## What the conflicts actually are
+
+Nearly all of them are **the same correction made twice, independently**. Two
+branches purged the same contaminated payload and wrote equivalent replacement
+text:
+
+    HEAD  "Exercised live on dune-fem 2.10 over a four-level refinement
+           sequence. Expect the coarsest pair at higher order to come in
+           below the asymptotic rate..."
+
+    THEM  "Theory for a conforming Lagrange space of order k...
+           These are the ASYMPTOTIC rates — the coarsest levels of a sweep
+           are commonly pre-asymptotic..."
+
+Both are right, and both say the same thing. That is the easiest class of
+conflict there is: pick either side on the merits, do not re-derive.
+
+## Order to merge in
+
+Infrastructure first, so the gates exist before the content they judge arrives:
+
+1. `feature/anti-fabrication` — merges clean. Brings the gates: contamination,
+   format contract, discoverability, fixture keys, wall-clock, quoted
+   diagnostics, plus the retrieval layer and the claim-attributed coverage
+   metric. Merging it first means every later branch is judged on arrival.
+2. `knowledge/purge-eval-contamination` — the other contamination purge. Take it
+   next while its conflicts are only against the base, and prefer whichever
+   wording is more specific about the MECHANISM.
+3. `knowledge/setup-and-portability` — touches `server.py` and `consolidated.py`;
+   land it before the per-backend branches pile onto the same files.
+4. The per-backend knowledge branches, smallest first: dune, febio, kratos-sparta,
+   ngsolve-skfem-verify, dealii-verify, fenics-verify, 4c-extraction. Each one's
+   fixtures live in its own directory and cannot collide; only its knowledge
+   edits can.
+5. `feature/coupling-robustness` and `knowledge/coupling-revision` last. They
+   both touch `src/tools/knowledge.py` and hold the flagship, so they deserve
+   the most careful eyes and the least merge pressure.
+
+## Rules for resolving
+
+- **Never re-derive a measurement to settle a conflict.** Both sides were
+  executed; pick the clearer text.
+- **Prefer the side that states the mechanism** over the side that states a
+  number, and never resurrect a measured number that a purge removed — the
+  contamination gate will fail the merge, which is the point.
+- **Re-run the gates after every single merge**, not at the end. A merge that
+  reintroduces a leaked payload is silent, and finding it after twelve merges
+  means bisecting twelve merges.
+- **Check fixture keys after merging any two backends.** A collision marks BOTH
+  fixtures FAILED in the runner, and seven working FEniCSx fixtures were sitting
+  red before anyone noticed.
+
+## A trap worth recording
+
+The first attempt at this ran the scratch worktree on the PortableSSD, which is
+exFAT and cannot store git's permission bits. Every file therefore appeared
+modified, and every merge refused with "local changes would be overwritten" —
+which reads exactly like twelve genuine conflicts. Merge testing must happen on
+a real filesystem.
+
+The attempt before that used `git merge-tree --write-tree`, which does not exist
+in git 2.25 (it arrived in 2.38). It reported CONFLICT for all twelve with an
+empty file list. An empty conflict list is the tell that the tool failed, not
+that the merge did.
+
+---
+
+# A checker that was built, failed four times, and withdrawn
+
+Two agents independently found knowledge entries written in another library's
+vocabulary — skfem entries saying "a pressure GridFunction" and "applying a
+DirichletBC", where `hasattr(skfem, "GridFunction")` is False and the 12.x API
+is `condense` / `enforce` / `penalize`. An agent following those reaches for a
+symbol that does not exist and gets an AttributeError unrelated to the pitfall.
+
+That looked mechanically checkable, so it got a checker. It was wrong four
+times, each time in the direction of accusing correct text:
+
+1. **A hard-coded ownership table.** 47 hits, 12 real. `dune.fem.GridFunction`
+   and `dune.ufl.DirichletBC` both EXIST — DUNE shares UFL with FEniCSx and has
+   its own GridFunction — and `condense` is core deal.II
+   (`AffineConstraints::condense`). 35 correct entries would have been rewritten.
+2. **CamelCase treated as an API signal.** 576 hits on skfem alone, flagging
+   CRITICAL, Safer, Downstream, LUMPED, Underlying, Quadrature.
+3. **A trailing paren treated as a call.** `get_quadrature(RefTet, 9) WORKS (45
+   points...)` and `Krylov-Uzawa (skfem example 30)` both put an ordinary word
+   before a paren. Also flagged `NotImplementedError`, a Python builtin, and
+   every entry that CORRECTLY says a symbol is absent — "Don't reach for a
+   skfem.NewtonSolver, it doesn't exist" is the knowledge being right.
+4. **Dependencies excluded.** `meshio._exceptions.WriteError` is real; the probe
+   searched only skfem's own modules.
+
+After all four fixes it still reported 115 on NGSolve: `Curve`, `Cylinder`,
+`Glue`, `gfT.Set`. Every one real. `Curve` is a METHOD on `Mesh`, `Cylinder`
+lives in `netgen.occ`, and `gfT.Set` is a method on an instance. A module-level
+`hasattr` sweep cannot see any of those, and no amount of pattern tuning fixes
+that — the approach is unsound for object-oriented APIs, which is all of them.
+
+**Withdrawn rather than shipped.** A gate at 115 false accusations would be
+switched off within a day, and it would take the trustworthy gates with it.
+
+What survives is the finding itself, which two agents obtained the right way: by
+executing the entry and watching the symbol not exist. Cross-library vocabulary
+is real, it has been found in both directions, and it is worth checking during
+any knowledge pass — by hand, on the entries being touched, not by a sweep.
+
+---
+
+# The defect class, stated exactly
+
+Independently reproduced 2026-08-06, in seven lines of scipy:
+
+    saddle system with a one-dimensional pressure nullspace
+      MatrixRankWarning : NONE
+      isfinite(x).all() : True
+
+    structurally singular matrix
+      MatrixRankWarning : fires
+      isfinite(y).all() : False
+
+Two skfem entries (`hydraulic_resistance#2`, `navier_stokes#3`) told agents to
+guard the Stokes pressure nullspace by catching `MatrixRankWarning: Matrix is
+exactly singular`, with `np.isfinite` as the backstop. **Both halves are blind
+to the case they were written for.** The velocity is not merely finite — it
+matches the pinned solution to 5.5e-14. Only the pressure LEVEL is arbitrary,
+which is precisely why neither check can see anything.
+
+The warning is real. It fires on a structurally zero pivot and on an
+inf-sup-violating equal-order pair, and in both the result is non-finite, which
+is the case `isfinite` was the right partner for. So it is a SUFFICIENT signal
+of rank deficiency and never a NECESSARY one.
+
+This is the shape every backend keeps producing, and it is worth naming because
+it is not "the knowledge is wrong":
+
+  * the CAUTION is correct — an unpinned Stokes system really does have an
+    undetermined pressure level;
+  * the MECHANISM is correct — the block really is rank deficient;
+  * the OBSERVABLE is not produced.
+
+An agent following such an entry writes the prescribed guard, the guard stays
+silent, and the silence is read as success. The entry does not fail to help; it
+manufactures confidence. That is why a fixture must assert on something the run
+actually emits, and why "no measured number in the knowledge" and "the Signal
+must be observable" are the same rule seen from two sides.
+
+The corrected entries now give an observable that IS present: the nullity of the
+condensed block, or two solves with different pins — identical velocity,
+pressure differing by a constant.
+
+Sibling instances of the same shape found the same day:
+
+    scipy cg on an indefinite system   returns info=1000, raises nothing
+    NGSolve CG on a genuinely indefinite matrix   converges in 47 iterations
+                                                  with a block preconditioner
+    dolfinx failing solve              prints ZERO characters on fd 1
+    4C beams/contact/FBI               run to completion where the entry
+                                       promised an abort
+    SPARTA ambipolar_plasma:3          reports "broken" exactly when the deck
+                                       is correct
+
+---
+
+# The largest open risk, sized
+
+440 entries across the corpus state a solver failure as their ONLY observable —
+"Newton diverges", "CG raises", "the run aborts", "NaN appears" — with nothing
+in the entry acknowledging the failure might be silent:
+
+    fourc 132   fenics 72   kratos 54   ngsolve 46   skfem 42
+    dune 32     dealii 30   febio 26    coupling 4   sparta 2
+
+These are candidates, not proven defects. But the sample that has been RUN is
+not encouraging. Every instance executed so far falsified, in five independent
+codebases:
+
+    skfem hyperelasticity#2   "Newton diverges"  -> converges to 8e-16 silently
+                                                    onto a different field
+    skfem stokes#0            "cg returns info!=0" -> info=0 on all 9 RHS tried
+    NGSolve dg_methods#6      "CG raises"        -> exhausts its cap, returns a
+                                                    field with rel. error 208
+    NGSolve contact#3         flipped normals    -> Newton status 0 while the
+                                                    penalty drives bodies together
+    deal.II dg_transport::4   "GMRES NoConvergence
+                               at step 0-1, NaN"  -> converged in 3 steps,
+                                                    last_value 0, no exception
+    deal.II advection_dg::1   "L2 norm diverges" -> error keeps falling, rate
+                                                    stays above 2, CG converges
+    4C fbi#0, ehl#0, fpsi#5   "aborts with X"    -> runs to completion, exits 0,
+                                                    passes every result test
+    FEniCSx (whole backend)   quoted console text -> a FAILING dolfinx solve
+                                                    prints ZERO characters
+
+Two independent codebases produced the SAME wrong claim about DG penalty and
+central flux (NGSolve dg_methods#3/#4, deal.II advection_dg::1 and
+dg_advection_reaction::0) and the same true behaviour on measurement. That
+suggests the errors are inherited from shared folklore rather than invented per
+backend, which is worth knowing: the same wrong sentence will be in other
+people's documentation too.
+
+WHY THIS CANNOT BE GATED, only measured
+---------------------------------------
+Whether a solver actually fails is a property of the run, not of the text. No
+static check can distinguish "Newton diverges" (true here, false there) from
+"Newton diverges" (never). The only instrument is execution, which is exactly
+what a tier-2 fixture is — so the fixture programme IS the remedy, and this
+number is the estimate of how much of it remains meaningful.
+
+The practical rule for anyone writing or reviewing an entry: if the Signal names
+a failure, the entry must also say what happens when the failure does NOT
+appear. Where the honest answer is "it converges cleanly and every internal
+check passes", that sentence is the most valuable one in the entry, because it
+tells the agent its guards cannot help and it must compare against a reference.
+
+---
+
+# Two failure modes that look alike and are opposites
+
+A deal.II pass separated these by measurement, and the distinction refines advice
+that had been circulating in this project in half-form. Newton on a
+hyperelasticity problem, same mesh, same load:
+
+    wrong TANGENT (K_geo sign error)   converges quadratically
+                                       to the SAME answer, 2.2e-16 away
+                                       cost: one extra step (16 vs 15)
+
+    wrong STRESS  (residual is wrong)  converges quadratically
+                                       to a DIFFERENT answer, 7.3% away
+                                       cost: FEWER steps (12 vs 15)
+
+**A wrong tangent costs iterations, not accuracy. A wrong residual costs
+accuracy, not iterations.** The framework differentiates whatever residual it is
+handed, so a consistently-differentiated wrong stress converges beautifully onto
+the wrong solution — and it converges FASTER, because the fabricated problem
+happens to be easier.
+
+The practical consequence is sharp: an agent watching iteration counts to detect
+a stress error will see the count go DOWN. The catalog entry this corrects
+claimed the tangent error is "off by 2x" and blamed the wrong bug for the wrong
+symptom.
+
+Two other backends found the halves independently, which is why they were being
+conflated:
+
+    skfem hyperelasticity#2   PK2 stress in the PK1 slot: entry says "Newton
+                              diverges"; measured, converges to 8e-16 onto a
+                              field 0.45%/1.43% off at 5%/20% stretch
+    NGSolve nonlinear_elasticity#3   factor-2 hand-coded P: entry says linear
+                              convergence; measured, QUADRATIC convergence to a
+                              wrong displacement. Linear convergence needs a
+                              tangent inconsistent with the residual — which is
+                              the OTHER bug
+
+A third measurement completed it, same instrument and same problem, with
+backtracking enabled in both runs (without it the inconsistent tangent does not
+converge slowly — it diverges, and the claim is about a RATE):
+
+    consistent tangent          observed order 1.993, 16 steps
+                                residuals squaring: 5175 -> 69.6 -> 0.995
+                                -> 2.1e-4 -> 1.2e-11
+    geometric term dropped      observed order 0.9996 — first order to four
+                                digits — 29 steps, near-constant contraction,
+                                SAME answer to 2.8e-13
+
+So the full statement is:
+
+    wrong TANGENT  -> right answer, convergence order 2 -> 1, MORE steps
+    wrong STRESS   -> wrong answer, order stays 2,        FEWER steps
+
+An agent watching iteration counts catches the first and is ACTIVELY MISLED by
+the second. Neither bug announces itself, and the only reliable detection is
+comparing the ANSWER against a reference — never watching the solver.
+
+---
+
+# Cannot verify here, versus not done
+
+Some claims cannot be executed on this machine at all. That is a different
+statement from "nobody got to it", and the paper must not blur them — a reader
+who finds a gap will ask which it was.
+
+Measured from the installs themselves, not from documentation:
+
+    deal.II   config.h:  DEAL_II_WITH_MPI      undef
+                         DEAL_II_WITH_P4EST    undef
+                         DEAL_II_WITH_PETSC    undef
+                         DEAL_II_WITH_TRILINOS undef
+                         DEAL_II_WITH_SUNDIALS undef
+                         DEAL_II_WITH_ADOLC    undef
+              -> parallel_poisson (7 claims) unreachable; the SUNDIALS half of
+                 time_dependent_heat#1 unreachable; the AD half of
+                 hyperelasticity#7 unreachable
+
+    FEBio     binary carries no MKL and no Pardiso
+              -> the claims about those solver paths unreachable
+
+    4C        binary carries no ArborX and no preCICE
+              -> beam_interaction geometric search (2 claims) unreachable;
+                 preCICE coupling unreachable, which the coupling fixtures
+                 already pin as a NEGATIVE capability claim rather than a gap
+
+Excluding what cannot be verified, deal.II sits at 103/122 = 84% of its
+reachable surface rather than 76% of its nominal one.
+
+A WARNING ABOUT THIS COLUMN, learned the expensive way. 4C reported four claims
+as blocked and **three of those reports were wrong**:
+
+    beam_interaction:3/:4   reported ArborX-blocked. FOUR_C_WITH_ARBORX=OFF only
+                            rules out `bounding_volume_hierarchy`, which exactly
+                            8 of ~1974 upstream decks select — verified by
+                            counting them. The default bruteforce_with_binning
+                            runs fine; the right deck takes two seconds and
+                            yields 13 coupled segments.
+    multiscale:5            reported as needing a stopwatch. It needed a
+                            COUNTABLE observable instead — macro elements per
+                            rank, 8/24/32 where even splits are 2-3-3.
+    pasi:2                  reported as having no single-run observable. It had
+                            one.
+
+The agent's own diagnosis: "I generalised from one failing deck and stopped
+looking." A blocked claim is a claim nobody will revisit, so it costs more than
+an uncovered one — an uncovered claim is visibly work remaining, while a blocked
+claim looks settled. The bar for this column must therefore be higher than for
+any other: name the exact flag or missing library, and show the check that reads
+it, as deal.II's sentinel fixture does.
+
+TWO REFINEMENTS FOUND BY AGENTS, both worth keeping:
+
+`parallel_poisson::0` is actually REACHABLE despite the six around it, because
+it is a claim about what happens with the features OFF: the distributed header
+compiles, MPI_InitFinalize reports one rank, and
+`parallel::distributed::Triangulation`'s constructor is `= delete`d, so the
+failure is a compile error with no link error and no runtime exception. A
+compile-outcome fixture covers it. Six blocked, not seven.
+
+And the evidence for the blockage is itself in the tree: the sentinel fixture
+`install_feature_flags_visible` reads those config flags, so "cannot verify
+here" is an executed observation rather than an assertion in a report. That is
+the right pattern for every environment limit — the claim that something is
+impossible on this host should be as verifiable as the claims that are.
+
+---
+
+# The flagship argument, in its strongest form
+
+Two coupling mutations, both verified by running the harness, both converging
+cleanly. They are the reason the verification gate compares against a reference
+instead of trusting the coupling's own checks.
+
+**Unit mismatch** — one participant in Celsius, one in Kelvin:
+
+    converged             34 iterations
+    residual              7.782e-09
+    flux balance          6.463e-09
+    validation entries    0
+    balance warnings      0
+    interface T           61.8% from the closed form
+    interface q          1365.8% from the closed form
+    monolithic check      fires
+
+Every internal check green, the answer badly wrong.
+
+**Consistent-conductivity mutation** — both participants 25% away from the
+conductivity the closed form is computed from. This one is strictly harder:
+
+    converges                             yes
+    the two sides agree at the interface  yes
+    flux balance                          untouched
+    interface TEMPERATURE                 DOES NOT CHANGE AT ALL
+    interface flux                        off by the same 25%
+
+The temperature is unmoved because the conductance RATIO is preserved — both
+subdomains moved together. So a reviewer checking the primary output sees the
+right number. Only the flux moves, and only the closed form catches it.
+
+That is the argument. A partitioned coupling can be internally perfect and
+solving a different problem, and every quantity a practitioner would naturally
+check can agree. Convergence, residual, interface agreement, flux balance and
+even the interface temperature are all consistent with a wrong answer at once.
+
+The same conclusion arrives from three independent directions today: 440 entries
+whose only observable is a solver failure that mostly does not occur; a wrong
+Newton residual converging FASTER onto a wrong answer; and these two couplings.
+Watching the solver never suffices. Comparing the answer against a reference
+does.
+
+---
+
+# A second checker withdrawn, and the hazard it failed to catch
+
+THE HAZARD IS REAL. `src/backends/fenics/backend.py` records that for 17 of
+FEniCSx's physics `src/tools/deep_knowledge.py` is CANONICAL, and the matching
+`KNOWLEDGE` dicts in `src/backends/fenics/generators/*.py` are "DEAD CODE and
+may have drifted — do NOT edit them and expect a behaviour change."
+
+I briefed an agent to correct three falsified entries "in src/backends/fenics/".
+Two of the three live in the dead half. It read the ordering comment, noticed,
+and put the corrections where they are served — which is the only reason that
+pass changed anything. A whole verification pass was one wrong assumption away
+from editing files nobody reads, and that failure mode is silent and cheerful:
+the edit applies, the tests pass, the diff looks right, the payload is untouched.
+
+THE CHECKER FOR IT DID NOT WORK. It compared, per physics name, the pitfall
+count written in a generator file against the count actually served. On its
+first real run it reported `boundary_conditions: served 6, generator file 3` —
+and that is not a divergence. `boundary_conditions` is a SUB-KEY that recurs
+under many different physics in the same file, each with its own short list;
+the checker's `max()` took the largest of those (3) and compared it against a
+served list (6) that is the union across physics. Two different things with the
+same name.
+
+Withdrawn rather than tuned. Comparing counts cannot distinguish "the same list
+in two places" from "two different lists that share a key", and the fix would
+need a structural model of how each backend assembles its knowledge — which is
+precisely the thing that differs per backend and defeated the AST reader in the
+coverage metric earlier.
+
+WHAT TO DO INSTEAD, since the hazard stands: name the canonical file in the
+brief. That is now the rule for any knowledge-correction task — establish where
+the served copy lives BEFORE editing, by reading the backend's own source-of-
+truth note or by asking the registry, and say so explicitly in the instruction.
+The agent that caught this did exactly that unprompted, and its report opens
+with the scope correction rather than burying it.
+
+That is two checkers withdrawn this session (the other: cross-library
+vocabulary, unsound for object-oriented APIs) against eight that shipped. Both
+withdrawals came from running the checker against real data and reading the
+first hit rather than the count.
+
+---
+
+# Self-checked retrieval overstates reach
+
+A pass that rewrote 69 catalog entries verified every one was still findable:
+69 queries, 20 misses on the first attempt — exactly the failure mode where the
+words a query would match get deleted along with the wrong number — then
+restored the vocabulary and reached 69/69.
+
+That work was real and the restoration was right. But the check has a ceiling:
+the queries were written by the same agent that wrote the entries, so they share
+its vocabulary. I ran four queries of my own against the corrected catalog and
+one missed:
+
+    "Newton converged but the displacement is wrong"  -> 3 hits, correct entry
+    "the energy grows every step"                     -> 3 hits, correct entry
+    "CG returned but the field is far too large"      -> 1 hit
+    "the field stopped changing after the first step" -> NO MATCH
+
+The missed entry (ngsolve time_dependent_ns#2) is well written and explains the
+mechanism exactly: an Inverse built on FreeDofs writes zero into every
+constrained row, so `gfu.vec.data = inv * rhs` DELETES the prescribed boundary
+velocity. My query described the CONSEQUENCE an agent would actually observe —
+the field stops changing — in words the entry never uses.
+
+So "all my queries hit" means the entries are consistent with their author's
+mental model, not that they are reachable from a symptom an agent would paste.
+The two differ most exactly where it matters: an agent queries from what it SAW,
+an author writes from what they UNDERSTOOD.
+
+The practical rule, and it costs almost nothing: retrieval checks for a
+correction pass should come from someone who did not write the corrections.
+Failing that, phrase every query as an observation with no mechanism in it —
+"the field stopped changing", "the answer got worse when I refined", "it ran but
+the number is wrong" — never as a description of the cause.
+
+---
+
+# A passing fixture that asserted a false statement
+
+This is the failure the whole programme is built to prevent, found inside the
+programme itself, and it deserves to be recorded plainly.
+
+`stokes_lbb_and_pressure_constraints` (DUNE) printed and asserted
+
+    zero_pressure_entry_claim_not_reproduced=True
+
+The claim IS reproduced. The fixture built its inlet mask by interpolating
+`[x[0], x[1], 0]` and slicing the PRESSURE leg, which returns the constant-0
+third component — so every pressure dof tested as lying on x = 0, and the
+"inlet maximum" it compared against was simply the global maximum. The fixture
+ran, passed, and certified the opposite of the truth.
+
+Counting `scheme.dirichletBlocks` instead settles it: both spellings constrain
+the same 264 velocity dofs at 8x8, but `None` constrains **0** pressure dofs
+while `0` constrains **68**, and the boundary pressure is exactly 0.0 versus
+2.0. Fixed, re-executed, sentinel replaced with `zero_entry_pins_the_pressure`.
+
+WHY IT MATTERS MORE THAN ANY SINGLE WRONG ENTRY. A wrong catalog entry misleads
+an agent. A wrong FIXTURE misleads everyone downstream, permanently, and wears
+the badge that is supposed to mean "executed". Coverage counted it. The mutation
+harness would have killed it — the mutation removes the pathology and the
+assertion changes — so even mutation evidence does not catch an assertion that
+is internally consistent and externally false.
+
+Nothing in the gate stack detects this. The only thing that caught it was an
+agent re-reading its own probe and asking what the mask actually selected. That
+is not a process that can be automated, and pretending otherwise would be the
+same error one level up.
+
+What CAN be said: the failure needed a derived quantity (a mask built by
+interpolation and sliced by leg) standing in for the thing being measured. Where
+a fixture can count the thing directly — dirichletBlocks, dof counts, non-zeros
+— it should, and this fixture now does.
+
+---
+
+# Four ways a fixture key misreports coverage
+
+All four were found by execution this session, each in a different backend, and
+each produced a number nobody could have caught by reading.
+
+**1. The key points at nothing.** `structural_dynamics:7` where the list ends at
+6; `stokes:7` where it ends at 3. The fixture is real and defends nothing while
+counting as coverage. Gated by `test_fixture_keys_point_at_real_claims`.
+
+**2. Two fixtures share one key.** The runner marks BOTH failed, so seven
+working FEniCSx fixtures sat red for bookkeeping reasons, and two Kratos IGA
+fixtures likewise. Gated by the same test.
+
+**3. Both agents withdraw the duplicate.** Two agents each found the other's
+fixture for the same claim and each deleted their own — turning a visible
+collision into a silent GAP. Caught only because both mentioned it in their
+reports. Not gated: nothing distinguishes "withdrawn because duplicate" from
+"never written".
+
+**4. The key names a real claim through the wrong axis.** SPARTA attaches 10
+UNIVERSAL_PITFALLS to every physics row, where they occupy slots 9-18. Six
+fixtures covered all ten and declared them `universal:<n>` — correct, and
+invisible to a counter walking `rarefied_flow`, which read 7/19 instead of
+19/19. SPARTA measured 76% and was actually at 98.7%. Verified independently:
+each of slots 9-18 appears in all 10 physics rows.
+
+The fix was to carry BOTH keys — `universal:n` and its positional alias
+`rarefied_flow:9+n` — with the coverage gate collapsing aliases onto the
+identity key so nothing is double-counted, and deduplicating by FIXTURE NAME so
+the collision rule is not weakened: one fixture under two conventions is one
+owner, two fixtures still collide. Verified after the change: 84 claims keyed,
+0 real collisions, all 10 aliases owned by their identity key's fixture.
+
+CHECKED FOR ELSEWHERE, and it is confined. Three backends have `covers` entries
+naming a physics different from their `physics` field — dune (poisson_mms,
+navier_stokes, maxwell, mixed_methods), dealii (dg_transport) and sparta. For
+dune and dealii every one of those IS a registered physics with its own pitfall
+list, so they are legitimate multi-claim fixtures that the identity-keyed metric
+already counts correctly. SPARTA's `universal` was the only axis that exists
+solely as a shared block appended to other rows, and therefore the only one a
+positional walk could miss.
+
+WHAT THESE HAVE IN COMMON. Every one is a disagreement between two ways of
+naming the same claim, and in every case both namings were defensible. That is
+why they survive review: nobody wrote anything wrong. The metric has to be told
+which naming is canonical, and where two exist it has to be told how they map —
+which is exactly what the `covers` list is for, and why an unchecked `covers`
+list would be worse than none.
+
+And the direction of error is not consistent. Case 1 inflates, case 4 deflates
+by 23 points, cases 2 and 3 corrupt without moving the number predictably. A
+coverage figure is only as good as the key hygiene beneath it, and that hygiene
+is now three gates plus one thing no gate catches.
+
+---
+
+# Asserting on a stochastic code without pinning noise
+
+SPARTA is direct-simulation Monte Carlo, so every quantity carries statistical
+scatter and the obvious fixture — "the value is X" — is either pinned noise or a
+tolerance wide enough to pass anything. The design that solved it is worth
+copying wherever a code is stochastic, adaptive, or otherwise not bitwise
+reproducible:
+
+  * measure the noise floor from ONE seed's late windows;
+  * make every assertion against a DIFFERENT seed;
+  * assert a RATIO against that floor, never an absolute value.
+
+Wall-flux fixture: seed B's late windows all inside 3x seed A's floor, both
+first windows more than 10x outside. Surface-flux: floor 0.54%, seed B's ten
+late windows all inside 3x, its first window 26% and tens of times outside. No
+measured value is pinned anywhere, and the assertion is dimensionless.
+
+The shear fixture goes further and removes a CONFOUND rather than tolerating it.
+The occupancy bias of `rarefied_flow:6` pushes the same direction as the effect
+under test, so the fixture routes through `fix ave/grid` to eliminate it, then
+runs three seeds per grid and asks only whether the clusters SEPARATE. They do,
+with no overlap. Its mutation is the best control in the tree: zeroing both wall
+velocities collapses the signal from 4.55% to 0.54% and the clusters stop
+separating — which proves the residual is the shear and not a grid artifact.
+
+That last step is the one usually skipped. A mutation that removes the pathology
+shows the fixture responds to something; a mutation that removes the pathology
+AND lands on the independently measured noise floor shows it responds to the
+right thing.
+
+---
+
+# Mutation evidence is not uniformly persisted
+
+1256 fixtures exist, all parse, all carry a runnable artefact. But the evidence
+that each DETECTS its pathology — the mutation verdict, which is the only thing
+separating a fixture from a script that happens to pass — is recorded in three
+different ways and, for five backends, not at all.
+
+Measured across all worktrees, taking the best version of each fixture:
+
+    surface     fixtures   re-runnable control
+    fourc            373       354   95%   `_mutation` field in fixture.json
+    fenics           200       183   92%   T2_MUTATE env hook in the source
+    dealii           119       104   87%   T2_MUTATE env hook
+    coupling          18        18  100%   `_mutation` field
+    skfem            144         0    0%
+    kratos           131         0    0%
+    ngsolve          115         0    0%   (48 describe it in _comment prose)
+    febio             76         0    0%
+    dune              41         0    0%
+    sparta            35         0    0%
+
+Every one of those agents reported its fixtures mutation-proven, and their
+reports contain the specific mutation and the expectation it removed. There is
+no reason to doubt the runs happened. The problem is that for 401 fixtures the
+evidence lives only in a session transcript: nobody can re-run it, and a
+reviewer asking "show me this fixture detects what it claims" gets prose.
+
+THE T2_MUTATE HOOK IS THE BETTER CONVENTION and it was not mine — FEniCSx and
+deal.II arrived at it independently. The control lives inside the fixture and is
+switched by an environment variable, so re-running the proof is one command and
+needs no harness that stages files, no parent-directory copying, and none of the
+three staging defects that silently voided mutation verdicts earlier today.
+A `_mutation` JSON field describes an edit somebody must reapply; a T2_MUTATE
+hook IS the edit, already written and already tested.
+
+This is not a claim that 401 fixtures are unsound. It is a claim that their
+soundness is currently unauditable, which for this project is the same class of
+problem as an unverified knowledge claim: the assertion may well be true and
+nothing in the tree lets a reader check it.
+
+---
+
+# Would the merged corpus pass the contamination gate? Measured.
+
+Both audits flagged that "0 contamination hits" is branch-local: the gate lives
+on two branches and reports green there, while the campaign branches — where the
+knowledge actually lives — serve the exact class the gate was written against.
+Neither audit could say what the MERGED corpus would do, because it exists
+nowhere. Measured now, in a throwaway worktree off the base:
+
+    all campaign branches, scanned individually        226 hits
+    merged, taking knowledge/purge-eval-contamination
+    FIRST and then seven campaign branches              20 hits
+
+**Purge fixes 206 of 226.** Its work is done and simply has not propagated —
+which is the argument for merging it first, before anything else.
+
+The residual 20 were entirely on `knowledge/ngsolve-skfem-verify`, and the
+reason is exact: that is the one branch which merged CLEANLY, so purge's
+corrections never had occasion to touch it. Clean merges hide unfixed
+contamination; conflicted ones surface it. That is the opposite of the intuition
+and worth remembering during consolidation.
+
+Those 20 are now fixed at source (commit `c1340c79`): four served MMS
+convergence tables plus one served manufactured solution. Six remain on that
+branch, four of them in `kratos/curved_mms.py` and
+`dealii/poisson_mixed_bc.py` — both already fixed on `feature/anti-fabrication`
+earlier the same day. The same correction now exists on three branches and has
+landed on one.
+
+Merge order confirmed by this probe: purge first, then the campaign branches;
+conflicts are 1-4 files each and are purge's decontamination against the same
+file's contaminated version, which resolves by taking the purged side and
+re-applying any genuinely new content on top.
+
+---
+
+# The last merge, and the class of defect it exposed
+
+`knowledge/coupling-revision` was deliberately left for last, and correctly:
+it and `feature/coupling-robustness` rewrote the same iteration loop, the same
+`_aitken`, and the same `couple()` for different reasons. The two rewrites turn
+out to be COMPLEMENTARY where they touch code and CONTRADICTORY where they
+touch text, and separating those two is most of the work.
+
+## The code merged by layering, once the question was asked the right way
+
+The conflict looks like two competing loop bodies. It is not.
+coupling-robustness's loop is the same loop plus evidence collection
+(`returncodes`, per-block residuals, responsiveness digests, the graph, the
+sensitivity probe) plus four refusals (non-zero exit, empty export, changed
+export length, unknown partner name). coupling-revision's `_invoke()` is the
+loop body as it stood BEFORE any of that, factored into a function so the
+noise-floor measurement could drive participants down the same path.
+
+So the resolution is not a side. Keep coupling-robustness's loop whole, keep
+`_invoke` for what it was factored out for, and make `_invoke` reproduce the
+loop's observable behaviour (`sort_keys`, stale-export deletion, non-zero-exit
+refusal) so the floor really is a floor for the residual the loop reports.
+Taking `_invoke` for the loop — which is what "pick a side" would have done —
+deletes every refusal silently.
+
+`tests/test_coupling_robustness.py` decides the `_aitken` half outright:
+`test_aitken_formula_matches_the_hand_computation` pins the recurrence against
+a hand computation and `test_aitken_is_given_the_residual_and_not_the_raw_export`
+pins `theta['residual_norm']`. There is nothing to weigh.
+
+## FIVE served statements were true on one branch and false on the other
+
+This is the shape worth recording, because nothing in the gate stack sees it
+and it is not "the knowledge is wrong". Each of these was measured, correct,
+and carefully written on `knowledge/coupling-revision` — and each describes a
+driver that `feature/coupling-robustness` had already replaced:
+
+    served claim                              measured on the merged driver
+    ---------------------------------------   ---------------------------------
+    "does NOT check your exit code"           refused: "participant A exited
+    (in two places)                           with code 7 ... output of a
+                                              FAILED run"
+    "theta adapts per participant"            199 _aitken calls over 200
+    (on BOTH branches)                        iterations with 2 participants
+    "two fallback paths floor it at 0.1"      theta_prev=0.07 comes back 0.07
+    "NOT the textbook recurrence — feeds      it is handed res_prev;
+     the previous RAW EXPORT"                 residual_norm 6.1e-06, not the
+                                              size of the solution
+    "`data_files` is NOT supported by this    the file arrives in work_dir and
+     tool, silently ignored"                  the participant sees it
+
+Two of those five were the corrections the merge brief specifically asked to
+preserve. They could not be preserved, because preserving them would ship a
+false statement — which is the point: **a correction is only true against the
+code it was measured on, and a merge changes the code.** Any branch that
+CORRECTS documentation is carrying a hidden dependency on its own tree, and
+that dependency is invisible in the diff. The text and the code it describes
+conflict semantically while merging cleanly.
+
+The tell is cheap and should be routine: for every doc correction a branch
+carries, re-run the measurement on the merged tree before believing it. Five
+for five failed here.
+
+## Two fixtures asserted the pre-fix behaviour
+
+Same mechanism one level down, and worse, because a fixture wears the badge
+that means "executed". `driver_invariants_the_contract_asserts` asserted
+`participant_exited_nonzero_and_was_still_accepted=True` and
+`data_files_key_staged_the_file=False`; `aitken_clamp_bounds_theta` asserted
+`theta_adapts_per_participant=True`. All three were true when written.
+
+Turning an assertion round is not enough — the recorded MUTATION usually stops
+discriminating at the same time. The old exit-code mutation (write the export
+under another name) killed the old assertion because the run then failed; it
+cannot kill the new one, because the run fails either way. The replacement
+flips `sys.exit(7)` to `sys.exit(0)`, which isolates the exit code as the cause.
+**When a fixture's direction reverses, its control has to be re-derived, not
+re-pointed.**
+
+## A dead mechanism found by asking who calls it
+
+`knowledge.py` carried `_coupling_failure_modes()`, added on
+coupling-robustness to append the 32-entry failure index to the coupling guide.
+Its call site was the inline payload string, and that string had been replaced
+by the `coupling_knowledge` module — so the helper sat there calling nothing,
+and its docstring still described a call that no longer happened. That is how
+the loss stayed invisible: the function reads as live.
+
+Restoring the append was the obvious repair and the wrong one.
+`test_knowledge_tool_output_matches_the_payload_function` requires the tool to
+serve exactly what `coupling_knowledge()` returns, "not a second copy", so the
+append fails a gate — and on the numbers it deserves to: the block is 38 kB
+against a 35 kB guide, so `knowledge(topic='coupling')` would more than double
+and carry TWO symptom corpora for an agent holding one error message. The guide
+now carries a 900-byte cross-reference instead, inside the payload function, and
+each corpus stays in one place.
+
+## A behaviour difference the merge does not cause and must not hide
+
+Measured on the skfem conduction pair, rho = 4, tol = 1e-4, max_iter = 200:
+
+    accelerator="constant", theta=0.2   CONVERGED, 83 iters, 9.4e-05
+    accelerator="constant", theta=0.5   not converged, 8.2e-01 (above the
+                                        stability limit 2/(1+rho) = 0.4)
+    accelerator="aitken",   theta0=0.5  not converged, STALLS at 3.7e-03
+    accelerator="aitken",   theta0=0.2  not converged, STALLS at 2.4e-03
+
+The Aitken arms do not diverge — the interface value is 3.1e-04 from the closed
+form — the residual stops falling, with theta on the 0.05 floor for 40 of 199
+adaptations. The per-participant Aitken this replaced converged this same case
+inside the same budget, which is why `aitken_clamp_bounds_theta` was written
+against it.
+
+This is a property of `ffb5d1c6`, not of this merge: `_aitken` and the loop are
+taken from coupling-robustness unchanged. It is recorded here because the served
+sweep ("Aitken matched or beat a constant theta almost everywhere, measured
+across rho from 1/4 to 9") was measured on the OTHER driver, and one cell of it
+does not reproduce. The sweep has not been re-run.
+
+## Where this merge left the numbers
+
+The ten coupling / verification / participant test files, run serially with the
+suite's own interpreter, before (`ffb5d1c6`) and after:
+
+    before   3 failed, 282 passed, 3 skipped, 22 subtests passed
+    after    3 failed, 286 passed, 3 skipped, 22 subtests passed
+
+Re-run once more after the four verdict-channel fixes below, unchanged:
+3 failed, 286 passed, 3 skipped, 22 subtests passed, and `diff` of the two
+failure lists is empty.
+
+The failure SET is byte-identical and all three are pre-existing: they are
+`test_signal_verification.py`'s checks against `scan_results/tier2_results.json`,
+which carries no `fixture_fingerprint` and is therefore treated as stale — which
+is that gate working, not a regression. The +4 are the stochastic-branch tests
+`knowledge/coupling-revision` adds to `test_coupling_driver.py`, all passing.
+
+Fixtures re-run individually after the merge, each passing:
+`driver_invariants_the_contract_asserts` (mutations 3/3 KILLED),
+`aitken_clamp_bounds_theta`, `failure_table_reachable_from_a_symptom`,
+`reference_solutions_unreachable_through_the_tools`,
+`sparta_no_native_flux_bc`, `precice_absent_in_fourc_and_febio`,
+`sides_table_backed_by_runs`. Plus the four static fixture-hygiene gates
+(1349 passed, 1 skipped) over the whole fixture tree including the six new
+coupling fixtures.
+
+## The one collision neither branch could have seen
+
+Everything above was found by reading the two sides. This one was only found by
+running the merged tool, and it is the most instructive thing in the merge.
+
+`knowledge/coupling-revision` puts "CONVERGENCE IS AT THE NOISE FLOOR, NOT AT
+tol" into `CouplingResult.warnings`. On its own branch that is harmless, because
+`couple()` there decided trustworthiness with a keyword filter:
+
+    checks_ok = r.converged and not any(
+        ("NOT CONVERGED" in w or "non-finite" in w or "NOT balanced" in w
+         or "NOT COUPLED" in w) for w in val)
+
+and the noise message contains none of those four. `feature/coupling-robustness`
+deleted that filter deliberately — it was silently discarding the findings of
+seven other checks — and replaced it with `checks_ok = r.converged and not val`.
+Both changes are right. Together they stamp NOT VERIFIED on every correct
+stochastic coupling, measured:
+
+    converged        True
+    noise_floor      1.039e-02
+    tol_effective    1.039e-02
+    verification     NOT VERIFIED — the coupling did not converge, or failed
+                     one of OASiS's silent-wrong checks
+
+Neither branch's tests could catch it. coupling-revision's assert on the driver
+result, one level below `couple()`. coupling-robustness's never set
+`noise_replicates`, because the argument does not exist there.
+
+**A merge can be wrong in a way that neither side is wrong, and no test on
+either branch covers.** The only instrument is running the merged surface with
+both features switched on at once — which is a short list per merge and should
+be written down before merging, not discovered after.
+
+The repair is a CHANNEL, not a filter: `CouplingResult.criterion_notes`. The
+criterion a run was held to is neither provenance nor a finding, and the two
+existing lists are both wrong for it. It is reported in `checks_not_run`, which
+is always printed inside the verdict and never flips it. Handed over as its own
+list rather than pattern-matched back out of `warnings`, so a reworded message
+cannot silently start or stop flipping a verdict — which is the failure the
+keyword filter had.
+
+Re-running after that fix found the SAME defect a second time, in a different
+check: `check_residual_blocks` was still judged against the requested `tol`, so
+a run held to 8.3e-03 was faulted for blocks "still changing by more than
+1.0e-08 relative". It now takes `tol_effective`, as `check_convergence` beside
+it already did. **One instance of this shape is rarely the only one** — every
+check that takes a tolerance has to be asked which tolerance it means.
+
+After both: `validation` empty, and with a review on record the same run comes
+back VERIFIED with the floor named in its coverage section.
+
+### The same shape three times, in three different checks
+
+Once found, it kept being found. Every check that judges a coupling had been
+written assuming the residual means what `tol` says it means:
+
+    check_convergence          quoted `tol` in a NOT CONVERGED message on a run
+                               judged at the floor  (fixed on the branch itself)
+    the criterion notice       sat in `warnings`, which `couple` copies into the
+                               findings list  -> NOT VERIFIED
+    check_residual_blocks      compared blocks against `tol`, so a run held to
+                               8.3e-03 was faulted for blocks moving by more
+                               than 1.0e-08  -> NOT VERIFIED
+    check_interface_sensitivity  faulted the participant for being stochastic,
+                               in a branch whose own message says "hidden state
+                               ... OR IT IS STOCHASTIC"  -> NOT VERIFIED
+
+Each was found only by running the merged tool again after fixing the previous
+one, because one finding is enough to stamp NOT VERIFIED and the first one masks
+the rest. **The rule that would have found all four at once: when a feature
+changes what a number MEANS, every consumer of that number is a candidate, and
+the list of consumers is enumerable — grep for the parameter.**
+
+The last of the four is the interesting one, because the honest fix is not to
+silence the check but to move it to the channel that says what it could not
+decide. With a MEASURED floor, "the response cannot be told apart from run-to-
+run drift" is a true statement about the instrument rather than about the
+coupling, and the thing that CAN decide it is the monolithic comparison — which
+is what the coverage note now says. The half that must not weaken does not: a
+participant whose export does not move at all is still a finding, floor or no
+floor. That took a second pass, because signal = 0 also satisfies
+`signal <= noise * margin` and the first guard routed it to coverage.
+
+### And the fourth, which the real coupling caught after the synthetic one passed
+
+Handing `check_residual_blocks` the effective tolerance instead of `tol` looked
+like the same fix as the one beside it, passed on a synthetic noisy pair, and
+was wrong. The real SPARTA coupling said so:
+
+    block(s) gas.normal_fluxes=1.00e+00 are still changing by more than
+    6.9e-01 relative, while the global norm reports convergence
+
+The driver measures the floor of ONE statistic — the global L2 residual over the
+stacked export vector. A block residual is the WORST ENTRY-WISE relative change
+of one block. A DSMC surface flux has entries near zero whose relative change
+between samples is order 1, so the second floor is far larger than the first and
+nothing relates them. **A measured floor belongs to the statistic it was
+measured on and transfers to no other**, which is easy to write down afterwards
+and was not obvious while fixing four instances of "judged against the wrong
+tolerance" in a row.
+
+There is therefore no threshold that means anything here under a floor, and
+choosing one to make a fixture pass would be the softening the branch exists to
+refuse. The check reports coverage instead: scale masking has NOT been ruled out
+on this run, it would take a per-block floor nothing measures, the per-block
+numbers are returned for the reader, and the decisive check remains an
+independent reference.
+
+Twice now the honest answer has been "say what could not be decided" rather than
+"decide it anyway". Both times the alternative was a number chosen to make a
+fixture pass, and both times the coverage note is more informative than the
+verdict would have been.
+
+WHAT WAS DELIBERATELY NOT TOUCHED. `check_interface_balance`,
+`check_interface_flux_profile`, `check_monolithic_consistency` and
+`check_interfaces_are_the_same_surface` also take tolerances, and none of them
+was changed. They judge conservation, geometry and agreement with a reference —
+quantities the residual criterion says nothing about. The rule is about
+consumers of the RESIDUAL, and the enumeration of those is complete:
+`check_convergence`, `check_residual_blocks`, `check_interface_sensitivity`, and
+the criterion notice itself.
+
+### What finally settled it
+
+`stochastic_noise_floor_makes_dsmc_gradable` — the real SPARTA-to-shell coupling
+that is the whole reason the branch exists — is the instrument that found the
+third and fourth instances and the one that confirms the repair. Run against the
+merged tree it FAILED twice before it passed, each time on a different check and
+each time on the same underlying mistake, and both failures were invisible to
+the synthetic noisy pair that passed at every step. **A synthetic participant
+reproduces the mechanism; only the real one reproduces the statistics.** The
+DSMC surface flux has near-zero entries and a genuinely broad sensitivity
+scatter, and neither is something a two-line `random()` participant has.
+
+It passes now, with the arms it was written with, plus one new assertion that is
+the point of all four fixes: `noise_aware_validation_stayed_empty=True`. A
+correct coupling judged at its measured floor must leave the findings block
+empty, because a non-empty one is a NOT VERIFIED verdict, and that verdict on a
+correct stochastic coupling is precisely what the branch was written to remove.
+
+---
+
+# What is NOT done, stated exactly
+
+## The consolidation is not finished — four branch tips are not ancestors
+
+Checked with `git merge-base --is-ancestor <branch> HEAD` after this merge:
+
+    merged:      coupling-revision, coupling-robustness, 4c-extraction,
+                 ngsolve-skfem-verify, kratos-sparta, dune-extraction,
+                 setup-and-portability, purge-eval-contamination
+    NOT merged:  knowledge/fenics-verify        1 commit  (execution ledger)
+                 knowledge/dealii-verify        1 commit  (execution ledger)
+                 knowledge/febio-extraction     1 commit  (execution ledger)
+                 feature/anti-fabrication      10 commits
+
+The three ledger commits are the same additive shape as the one already taken
+from coupling-revision. `feature/anti-fabrication` is real outstanding work,
+and one of its commits adds a GATE — `tests/test_fixtures_carry_a_mutation_
+control.py`, which does not exist in this tree — that would judge every fixture
+in the merged corpus, including the six coupling fixtures this merge brings.
+That gate should land before anyone reports a corpus-wide mutation figure.
+
+Two of its ten commits also edit `docs/CONSOLIDATION.md` (one adds 114 lines),
+so they will conflict with this file. Resolve by keeping both sections: they
+describe different findings and neither supersedes the other.
+
+## The Aitken comparative claim is not backed on this driver
+
+`aitken_beats_constant_on_an_unbalanced_ratio` FAILS against the merged tree
+(`aitken_reached_closed_form` and `aitken_beat_constant` both missing), for the
+same reason as the rho=4 stall recorded above: at rho=6 with theta=0.5 the ONE
+global theta no longer rescues the split that the per-participant theta did.
+The fixture is left failing rather than retuned, because retuning it would be
+choosing a ratio that makes the served sentence true instead of measuring
+whether it is.
+
+What the served knowledge still claims, and what is now behind it:
+
+    "Measured across conductance ratios rho from 1/4 to 9 and theta from 0.1
+     to 1.0 on this driver, Aitken matched or beat a constant theta almost
+     everywhere, and in a quarter of those settings it converged to the right
+     interface value where the SAME constant theta diverged"
+
+That 40-cell sweep was run on the PER-PARTICIPANT accelerator, which no longer
+exists. Two cells have been re-measured on the merged one and neither
+reproduces. The sentence should not be trusted until the sweep is re-run, and
+re-running it is the outstanding work — not editing the sentence to match two
+cells, which would be the same mistake in the other direction.
+
+---
+
+# Defects in the verification machinery itself
+
+Merged from `feature/anti-fabrication`. The sections above record defects in the
+KNOWLEDGE the campaigns produced; the sections below record defects in the TOOLS
+that were judging it. Neither set supersedes the other and both are kept in
+full: a corpus can be wrong while the instrument is right, and the reverse, and
+the two are told apart only by keeping both records.
+
+## Defects found in the verification machinery itself (2026-08-07)
+
+Every entry below is a defect in a tool that was being used as evidence, not in
+the knowledge it was judging. They are collected because they share one shape: a
+check that returns a confident answer while looking at the wrong thing, and
+whose output is indistinguishable from a real result.
+
+**Two matchers that disagreed.** `run_tier2_fixtures` lowercased both sides;
+`build_execution_ledger` compared raw strings. The same fixture with the same
+output got different verdicts depending on which tool ran — a probe printing
+`space_has_Nedelec=False` satisfied one and failed the other. There is now one
+matcher, imported by both.
+
+**That matcher matched prefixes.** `same_name_files=1` stayed green when the
+fixture's own mutation turned the value into `10`. Measured across the merged
+corpus, **5235 of 5951 expectations** were spoofable this way. Fixed in the
+matcher, not in 5235 strings: a needle shaped like `key=value` now requires a
+value boundary after the match. Forbidden strings keep plain substring matching
+on purpose — a tripwire should fire on the widest reading.
+
+**The ledger ran only one of the two kinds of mutation control.** A fixture
+either branches on `T2_MUTATE` in its own source, or declares a `_mutation`
+recipe that `mutate_tier2_fixtures.py` applies in a staged copy. The ledger set
+`T2_MUTATE=1` for both, which does nothing to the second kind. **354 of 395 4C
+fixtures ran byte-identically twice** and were recorded as passing both ways —
+reported as "these prove nothing". They were never vacuous; they were never
+mutated. `MUTATION_STALE` is new and deliberate: a recipe whose `from` text no
+longer appears substitutes nothing, and today that reads exactly like a fixture
+that fails to discriminate.
+
+**A mutated TIMEOUT counted as detection.** `discriminates` was true whenever
+the mutated run was anything other than a pass, so a mutation that merely made
+a fixture slow scored like one the fixture caught. Five rows rested entirely on
+that. Red now means FAIL; TIMEOUT and ERROR are neither evidence nor a defect.
+
+**Invented input keys had no gate at all.** The quoted-diagnostics auditor
+screens error strings; an invented KEY is not a quoted diagnostic and walked
+past it. `SOUNDSPEED` and `SMOOTHING_LENGTH` were served as required 4C SPH
+material parameters, one with the numeric rule "c >= 10 * v_max"; neither
+appears in any file of 4C's source or in any of its 2171 decks. So was `AREA0`,
+in a deck TEMPLATE, while the same generator already carried a warning saying
+4C has no such key. `audit_named_input_keys.py` closes this.
+
+**The key audit read the wrong surface, then the wrong tree, then the wrong
+software.** It scanned only strings containing "Signal:", so deck templates —
+the text actually written into input files — were invisible; `AREA0` was caught
+only because it also appeared in prose. It derived its location from its own
+`__file__`, so it audited whichever checkout it sat in, reporting "SPARTA: 0
+entries" for a project whose SPARTA corpus is 211 pitfalls on another branch.
+And it located backends by IMPORTING them, so Kratos — installed here but
+unimportable (GLIBC) — fell back to scipy and numpy, against which 121 of 139
+real Kratos keys looked invented.
+
+**A corpus that answers "no" to everything is a broken instrument.** FEBio was
+pointed at a directory holding one symlink into the real source tree, and
+`grep -r` does not follow symlinks. A positive control for the literal string
+"febio" returned zero files, and 23 of 23 keys were reported unresolved. Against
+the real tree 13 of those 23 resolve. **Run a positive control before quoting
+any absence.**
+
+**An empty reading reported as a pass.** SPARTA's knowledge lives in JSON, not
+Python string literals, so the collector found nothing and the audit said
+"OK — 0 keys checked, 0 unresolved": a clean bill of health for a backend it had
+not read. Empty readings now return NO_ENTRIES, because a pass ends an
+investigation and an unknown does not.
+
+**A gate whose green covered the half that cannot fail.**
+`catalog_template_executes` records `kratos::dem::2d_rc=0`. The DEM template is
+a file writer: running it emits `input.py` and exits 0, and `input.py` is what
+calls Kratos. Run it and it dies at `entry string : strategy`. The DEM generator
+has never produced a working deck. Screened statically across **255 templates in
+all nine backends, exactly one** is two-stage, so this is one broken generator
+rather than a rot through the catalog — worth measuring, because those two
+findings call for very different responses.
+
+**Two fixtures that passed for reasons unrelated to their claims.**
+`sparta/generators_execute_on_installed_build` was green with no SPARTA binary
+present: its expectations covered only the payload-hygiene half, and the
+no-binary path prints `SKIP:` and exits 0 while `SKIP:` was not forbidden. A
+fixture whose NAME is the claim certified that nothing executed.
+`sparta/per_cell_diagnostics_sentinel_and_resolution` asserted a spread under
+0.2 computed from a SINGLE timestep of a Monte-Carlo run; seed 99991 gives
+0.232. It passed because 12345 was lucky. Fixed by averaging over the run —
+re-pinning a luckier seed would have restored the tick and kept the defect.
+
+## Environment facts that silently corrupt measurements
+
+- **`/media/alexander/PortableSSD` is exFAT.** No symlinks, no permission bits.
+  27 of the 4C `cmd.sh` fixtures call `ln -s` inside `mktemp -d`, so with
+  `TMPDIR` there they abort with rc 134 — a sweep recorded **9 false FAILs**
+  this way. Git worktrees also refuse to merge there. Bulk output belongs on
+  that volume; `TMPDIR` never does.
+- **`stdbuf -oL` is mandatory when capturing a 4C diagnostic.** Without it
+  `MPI_Abort` kills the process before stdout flushes and only the MPI banner
+  survives. An audit run without it is reading silence.
+- **`4C -p` dumps the complete input grammar** — 478 sections, 7383 paths, 2728
+  keys — from the exact binary. Validate it against the upstream decks first
+  (the only gaps are `FUNCT<n>`, `TITLE` and user-chosen function symbols), then
+  it is far better ground truth than grep. Note that a case slip and an outright
+  fabrication produce the SAME 4C message, `Failed to match specification in
+  section 'MATERIALS'`, so the message alone cannot tell them apart.
+- **Kratos needs the 28-application build** at `/mnt/kratos-tier2/kv`. The repo
+  venv's wheel has 3 of ~40 applications and does not import at all;
+  `/usr/bin/python3` can load Kratos but cannot import this repo. Only that
+  build satisfies both.
+- **Load matters.** A campaign run at load 100-156 on 32 cores produced
+  wall-clock false failures in BOTH directions. Measure sequentially.
+
+## The rule these all point at
+
+Before quoting a number, ask what the instrument would report if it were broken.
+Where that answer is the same as the finding — 23 of 23 unresolved, 0 entries
+checked, every claim absent — the finding is not yet evidence. Run the control.
+
+---
+
+# The last four tips, and what happens when a gate meets the whole corpus
+
+Thirteen commits closed the consolidation: ten from `feature/anti-fabrication`
+and one execution ledger each from `knowledge/fenics-verify`,
+`knowledge/dealii-verify` and `knowledge/febio-extraction`. The gates went
+first, deliberately, so that the corpus arriving behind them was judged rather
+than trusted.
+
+## The conflicts, and what decided each one
+
+Four conflicts across the four merges, and not one of them was decided on which
+side looked more reasonable.
+
+`docs/CONSOLIDATION.md` was an append/append at line 718. Both blocks were kept
+whole, and that was checked rather than assumed: the merged file's lines
+721-1057 diff empty against the consolidation branch's own text, and its lines
+1069-1181 diff empty against the anti-fabrication branch's. The two record
+different things — everything above documents defects in the KNOWLEDGE the
+campaigns produced, everything below documents defects in the TOOLS that were
+judging it — and a corpus can be wrong while its instrument is right, or the
+reverse, so collapsing them into one shorter account would have destroyed the
+only way to tell those two cases apart.
+
+`scripts/scan_results/backend_imports.json` and `signal_verification.json` both
+went to ours, on evidence rather than on which run was newer. The entire diff in
+the first is the absolute path of the worktree that ran the scan — 24 lines,
+ofa-consolidate against ofa-meshcheck, no other field — and
+`TestBackendImportSnapshot.setUp` re-runs the audit and reads the file it has
+just written, so the committed bytes are never what the test asserts on. The
+second is read by nothing at all: a grep for the literal filename across
+`tests/`, `scripts/` and `.github/` returns two hits, both in
+`verify_signal_clauses.py`, both writes. It holds one backend's scan and cannot
+hold two.
+
+`scripts/build_execution_ledger.py` conflicted add/add in all three ledger
+merges, which looks alarming and is not. Those three branches forked before the
+file existed, so git had no base to merge against; each one's copy is
+byte-identical to the blob consolidation itself carried until the
+anti-fabrication merge. Taking theirs would have reverted the shared matcher,
+the recipe-driven mutation arm and the TIMEOUT fix in exchange for nothing.
+
+`scripts/run_tier2_fixtures.py` did NOT conflict, which is worth recording
+because it was the file everyone expected trouble in. The two sides edit
+disjoint regions: theirs the matcher at the top and the expect loop, ours the
+deal.II discovery, the conda interpreter probe, the coupling route and the CLI
+filters. Both mechanisms are present and neither is layered on the other,
+because they answer different questions.
+
+## The matcher, verified rather than reasoned about
+
+The defect being closed was two definitions of "is this needle present" that
+disagreed — the runner lowercased both sides, the ledger compared raw strings,
+and the same fixture got different verdicts depending on which tool ran. The end
+state was checked by executing it, not by reading the imports:
+
+    ledger matcher IS runner matcher                              True
+    "same_name_files=1" against output "same_name_files=10"       False
+    expect "space_has_nedelec=False" vs "space_has_Nedelec=False" pass
+
+## Three gates went red, and only the third is a surprise
+
+`test_fixtures_carry_a_mutation_control` fails for five of eleven backends: 61
+of 1306 fixtures ship no control. That number is believable — the fourc figure
+reproduces the campaign branch's exactly, 18 of 395 measured independently on
+both trees. What does NOT survive contact with the data is the story attached to
+it. The 18 were described as legacy pre-campaign fixtures; 8 of them are on
+`main` and the other 10 were written during the campaign itself on 2026-08-03,
+in `2cc29cef`, `c36b91eb` and `05d46402`. Kratos is worse in the same direction:
+9 of its 11 uncontrolled fixtures were written on 2026-08-06. The debt is not
+inherited, it is current, and it is 61 fixtures rather than 18.
+
+`test_named_input_keys_exist` fails for all nine backends. 34 baselined keys had
+been fixed by the merged corpus and were pruned — an entry that outlives its fix
+re-permits the same fabrication later. 121 further candidates were found and
+deliberately NOT baselined; see `named_key_baseline.json` for what they are and
+why triaging them is separate work.
+
+## Four ledger rows credited to a rule this merge deleted
+
+The three execution ledgers merged here — fenics 197 rows, dealii 118, febio 76
+— were produced by the ledger script as it stood on their own branches, which is
+the script the anti-fabrication commits then fixed. So they are records written
+by the instrument the same merge repaired, and the arithmetic does not
+automatically survive. Measured rather than assumed: under the hardened rule,
+where only a mutated FAIL earns credit and a mutated TIMEOUT earns none, febio
+goes from 73 discriminating to 70 (`biphasic_fsi_required_properties`,
+`damage_cdf_scale_saturates_in_cycle_one`, `elastic_damage_property_names`) and
+the sparta ledger already on the tree goes from 49 to 48
+(`surface_flux_needs_steady_state_not_the_first_`). fenics, dealii, fourc,
+kratos, dune and coupling are unaffected — their mutated TIMEOUTs sit on rows
+that were already not being credited.
+
+The files are NOT edited to match. Each is a dated execution record stamped with
+the commit it ran against, and rewriting its numbers in place would fabricate a
+run that never happened. Four rows should read "no verdict" instead of "kills
+its mutant", and the way to make them say so is to run the ledger again.
+
+`test_quoted_diagnostics_are_real` gained two failures, fenics and kratos, and
+this is the case worth reading carefully, because a new red normally means a new
+defect and here it means the opposite. On the pre-merge tree the audit answered
+`UNKNOWN — the backend's own source is not available here` for both, and the
+test's own line 75 turns UNKNOWN into a skip. Running the pre-merge script
+against the same corpus reproduces both UNKNOWNs exactly. The merge gave the
+audit the conda `fenics` env and the 28-application Kratos build, so both now
+return a verdict: fenics 202 entries, 18 quoted fragments present, 57 absent, 19
+unjudgeable. Nothing about the knowledge changed. Two backends stopped being
+invisible, and the count of failing tests went up because of it. A suite whose
+red count is used as a quality signal will read that as a regression, and it is
+the reverse.

--- a/scripts/audit_named_input_keys.py
+++ b/scripts/audit_named_input_keys.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Screen every input key OASiS names against the backend that would consume it.
+
+WHY THIS EXISTS
+---------------
+The 4C particle pass found this being served as knowledge:
+
+    "SOUNDSPEED too low -> fluid compresses unrealistically;
+     rule of thumb c >= 10 * v_max"
+
+`SOUNDSPEED` appears in **zero** files of 4C's source and zero of its 2171
+input decks. So does `SMOOTHING_LENGTH`. Both were listed beside real material
+parameters (`DYN_VISCOSITY`, `BULK_MODULUS`) as things an SPH deck must set, and
+one of them carried a numeric tuning rule. An agent following that advice writes
+a deck 4C refuses to parse, and the rule of thumb is advice about nothing.
+
+Nothing caught it. The quoted-diagnostics auditor screens error strings the
+knowledge puts in quotes; an invented *input key* is not a quoted diagnostic, so
+it walked straight through. This closes that hole: every ALL-CAPS identifier the
+knowledge names is looked up in the backend's own corpus, and the ones that
+resolve nowhere are reported.
+
+WHAT IT REPORTS, AND WHAT IT REFUSES TO REPORT
+----------------------------------------------
+Candidates, not verdicts. Four exclusions keep it from crying wolf, each one
+learned from a false accusation this project already made and had to withdraw:
+
+  * **Retractions are not fabrications.** "There is no SOUNDSPEED key" is the
+    CORRECTED entry. It contains the token precisely because the absence is the
+    knowledge. Reusing `_is_retracted` from the quoted-diagnostics auditor rather
+    than writing a second copy — two implementations of one rule is how the
+    matcher defect happened.
+  * **Prose is not a key.** `CFL`, `MPI`, `VTK`, `YAML` are English-in-caps.
+    Screened by a stopword list plus a shape rule.
+  * **A backend with no resolvable corpus yields UNKNOWN**, never "fabricated".
+    Kratos was once judged against scipy because its own source was not on disk,
+    and every claim looked invented.
+  * **Compiled backends assemble key names at runtime**, so a miss in the source
+    text is weaker evidence there than in a Python backend. Reported with that
+    caveat attached rather than silently equated.
+
+SELF-CONTROL
+------------
+`--selftest` runs the audit against a branch that predates the 4C fix and one
+that follows it. The pre-fix tree must flag SOUNDSPEED; the post-fix tree must
+not. A gate that cannot demonstrate it detects the thing it was built for is
+just another unverified claim.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import pathlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from audit_quoted_diagnostics import (  # noqa: E402
+    _is_retracted, collect_entries, search_roots, signal_of,
+)
+
+# ── what counts as a candidate key ──────────────────────────────────────────
+# Shape: ALL CAPS, may carry digits and underscores. Four characters minimum —
+# below that the false-positive rate from prose swamps the signal.
+_KEY = re.compile(r"\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*\b")
+
+# English-in-caps, format names, physics abbreviations, units and the project's
+# own category tags. None of these are input keys, and every one of them occurs
+# in ordinary warning prose.
+_STOPWORDS = {
+    # category tags used by the warning format itself
+    "NUMERICAL", "API", "INPUT", "SYNTAX", "PHYSICS", "INTEGRATION", "SETUP",
+    "PERFORMANCE", "OUTPUT", "UNITS", "MESH", "VALIDATION", "BC", "CROSS",
+    # formats, tools, protocols
+    "XML", "YAML", "JSON", "HDF5", "VTK", "VTU", "VTP", "CSV", "TXT", "PVD",
+    "MPI", "OPENMP", "CUDA", "GPU", "CPU", "RAM", "OS", "CLI", "API", "URL",
+    "UFL", "PETSC", "MUMPS", "UMFPACK", "SUPERLU", "BLAS", "LAPACK", "GMSH",
+    # physics and numerics in caps
+    "CFL", "PDE", "ODE", "FEM", "DEM", "SPH", "MPM", "PFEM", "DSMC", "DOF",
+    "DOFS", "RHS", "LHS", "FSI", "TSI", "ALE", "DG", "HDG", "CG", "GMRES",
+    "BDF", "RK", "MMS", "SI", "EOS", "PD", "VEM", "AMG", "ILU", "LU", "QR",
+    "SVD", "PCG", "BICGSTAB", "NAN", "INF", "TOL", "ABS", "REL", "MIN", "MAX",
+    # English words that appear capitalised for emphasis
+    "NOT", "NO", "AND", "OR", "BUT", "ALL", "ANY", "ONLY", "MUST", "NEVER",
+    "ALWAYS", "TODO", "NOTE", "WARNING", "ERROR", "FATAL", "OK", "YES",
+    "TRUE", "FALSE", "NONE", "NULL", "ID", "IDS", "II", "III", "IV", "3D",
+    "2D", "1D", "PASS", "FAIL", "SKIP", "THE", "IS", "IT", "IF", "ON", "OFF",
+}
+
+
+# A key can be named in order to say it DOES NOT EXIST — which is the corrected
+# form of exactly the entry this gate was built to catch:
+#
+#     "There is no SOUNDSPEED key. The material is MAT_ParticleSPHFluid ..."
+#
+# The shared `_is_retracted` does not recognise that phrasing, and widening the
+# shared regex would silently change the quoted-diagnostics auditor's results on
+# a corpus that has already been audited against it. So the absence test lives
+# here and is anchored to the TOKEN rather than to the clause: the phrase has to
+# be talking about this identifier, not merely sitting near it.
+_ABSENCE_BEFORE = re.compile(
+    r"(?:there\s+(?:is|are|was|were)\s+no"
+    r"|no\s+such"
+    r"|not\s+a\s+(?:valid|real|recognised|recognized)"
+    r"|does\s+not\s+(?:exist|accept|have)"
+    r"|never\s+(?:existed|accepted))"
+    r"[^.;]{0,40}$", re.I)
+_ABSENCE_AFTER = re.compile(
+    r"^[^.;]{0,40}?(?:does\s+not\s+exist"
+    r"|is\s+not\s+a\s+(?:valid|real|4c|febio|kratos)?\s*(?:key|section|option)"
+    r"|is\s+no\s+such"
+    r"|was\s+invented"
+    r"|appears\s+in\s+(?:zero|no)\b)", re.I)
+
+
+def _absence_asserted(text: str, start: int, end: int) -> bool:
+    """True when the surrounding prose says this identifier does NOT exist."""
+    back = text[max(0, start - 120):start]
+    if _ABSENCE_BEFORE.search(back):
+        return True
+    return bool(_ABSENCE_AFTER.search(text[end:end + 120]))
+
+
+# Words that mark the token beside them as an input key rather than emphasis.
+_KEYISH = re.compile(
+    r"\b(?:key|keys|parameter|parameters|section|sections|option|options|flag|"
+    r"flags|field|fields|attribute|attributes|entry|variable|variables|set|"
+    r"setting|specify|specifies|required|writes?|written)\b", re.I)
+
+
+def _identifier_shaped(tok: str) -> bool:
+    """An underscore or a digit is positive evidence of an identifier."""
+    return "_" in tok or any(c.isdigit() for c in tok)
+
+
+def _in_list_with_identifier(text: str, start: int, end: int) -> bool:
+    """True when the token sits in a comma list containing a real identifier.
+
+    This is the rule that catches the case shape alone cannot. The fabricated
+    entry read
+
+        "... for each particle type (density, DYN_VISCOSITY, BULK_MODULUS,
+         SOUNDSPEED)"
+
+    `SOUNDSPEED` is a plain all-caps word, exactly like the emphasis-caps this
+    gate must ignore (`CHECKERBOARD`, `AUTOMATICALLY`). What distinguishes it is
+    the company it keeps: enumerated alongside `DYN_VISCOSITY` and
+    `BULK_MODULUS`, both underscore-shaped and both real. A word being listed as
+    a peer of confirmed input keys is the claim that it is one.
+    """
+    lo = text.rfind("(", max(0, start - 200), start)
+    seg_start = lo + 1 if lo != -1 else max(0, start - 200)
+    hi = text.find(")", end, end + 200)
+    seg_end = hi if hi != -1 else min(len(text), end + 200)
+    seg = text[seg_start:seg_end]
+    if "," not in seg:
+        return False
+    peers = [p.strip(" '\"`") for p in seg.split(",")]
+    peers = [p for p in peers if p != text[start:end]]
+    return any(_KEY.fullmatch(p) and _identifier_shaped(p) and
+               p not in _STOPWORDS for p in peers)
+
+
+def candidate_keys(text: str) -> list[tuple[str, int, int]]:
+    """ALL-CAPS tokens `text` presents AS input keys, with spans.
+
+    Shape is not enough. `SOUNDSPEED` (invented) and `CHECKERBOARD` (ordinary
+    prose in caps) are the same shape, so a shape rule either misses the
+    fabrication or reports every emphasised word — the first pass over the
+    corpus did the latter, returning 147 "unresolved keys" for Kratos of which
+    the overwhelming majority were English. A gate nobody reads catches nothing.
+
+    So a token has to earn candidacy by evidence that the text is naming a key:
+    identifier shape, quoting, a key-marker word beside it, or membership in a
+    list whose other members are confirmed identifiers.
+    """
+    out = []
+    for m in _KEY.finditer(text):
+        tok, i, j = m.group(0), m.start(), m.end()
+        if tok in _STOPWORDS or len(tok) < 4:
+            continue
+        if text[max(0, i - 1):i] == "[":      # the warning's [Category] tag
+            continue
+        # `-DTRILINOS_APPLICATION=ON` is a CMake flag, not an input key, and the
+        # token match starts one character late — at the D. That produced four
+        # confident false candidates in one Kratos run
+        # (DCONTACT_STRUCTURAL_MECHANICS_APPLICATION and friends), each of them
+        # a real build flag reported as an invented key.
+        if tok.startswith("D") and text[max(0, i - 1):i] == "-":
+            continue
+        quoted = (text[max(0, i - 1):i] in "'\"`"
+                  or text[j:j + 1] in "'\"`")
+        near = bool(_KEYISH.search(text[max(0, i - 60):i])
+                    or _KEYISH.search(text[j:j + 60]))
+        if not (_identifier_shaped(tok) or quoted or near
+                or _in_list_with_identifier(text, i, j)):
+            continue
+        out.append((tok, i, j))
+    return out
+
+
+def key_present(key: str, roots: list[Path]) -> bool:
+    """Does this identifier occur anywhere in the backend's corpus?
+
+    `-a` is not optional: without it grep skips files it decides are binary and
+    reports nothing found. That single flag was the difference between a
+    measured 91% fabrication rate and the true 73% in an earlier pass.
+    """
+    if not roots:
+        return False
+    cmd = ["grep", "-r", "-a", "-l", "-F", "--", key] + [str(r) for r in roots]
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return bool(p.stdout.strip())
+
+
+# A YAML/XML key sitting at the start of a line inside a template string. This
+# is an unambiguous key POSITION — no context heuristic needed, and therefore
+# almost no false positives.
+_TEMPLATE_KEY = re.compile(r"^[ \t]*([A-Z][A-Z0-9_]{2,})[ \t]*:", re.M)
+
+
+def template_keys(backend: str) -> list[tuple[Path, str]]:
+    """Keys the deck TEMPLATES emit — the most dangerous surface in the corpus.
+
+    `collect_entries` only returns strings containing "Signal:", i.e. warning
+    text. Templates carry no Signal clause, so the whole set of keys OASiS
+    actually WRITES INTO INPUT FILES was invisible to this audit. `AREA0` was
+    caught only because it happened to appear in a warning as well as in the
+    arterial-network template; a key that appeared solely in a template would
+    have passed silently.
+
+    That is the same mistake `test_assembled_payload_is_clean` was written to
+    correct one level up — an audit can be rigorous and still be pointed at the
+    wrong surface. A wrong key in prose misleads a reader who can push back. A
+    wrong key in a template is written into the deck verbatim, every run.
+    """
+    be_dir = REPO / "src" / "backends" / backend
+    out: list[tuple[Path, str]] = []
+    if not be_dir.is_dir():
+        return out
+    for py in sorted(be_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(py.read_text(errors="ignore"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)):
+                continue
+            text = node.value
+            # A template is multi-line and has several key-looking lines; a
+            # sentence that merely starts with a capitalised word does not.
+            if text.count("\n") < 2:
+                continue
+            hits = _TEMPLATE_KEY.findall(text)
+            if len(hits) < 2:
+                continue
+            for k in hits:
+                if k not in _STOPWORDS:
+                    out.append((py, k))
+    return out
+
+
+def audit(backend: str, verbose: bool = False) -> dict:
+    src_roots, corpus_roots, notes = search_roots(backend)
+    roots = list(src_roots) + list(corpus_roots)
+    res = {"backend": backend, "roots": [str(r) for r in roots],
+           "notes": notes, "unresolved": [], "checked": 0, "entries": 0}
+    if not roots:
+        res["status"] = "UNKNOWN"
+        res["reason"] = (f"no corpus on disk for {backend}; a missing corpus "
+                         f"cannot distinguish an invented key from a real one")
+        return res
+
+    # THE RULE THIS PROJECT KEEPS RELEARNING. `search_roots` falls back to
+    # whatever scientific-Python packages are installed when the backend's own
+    # module will not import. Judging Kratos knowledge against scipy makes every
+    # real Kratos variable look invented: the first run of this gate reported
+    # 121 of 139 Kratos keys "unresolved", and the roots it actually searched
+    # were scipy, numpy, meshio and mpi4py. Not one Kratos file.
+    #
+    # An audit that cannot see the software it is auditing has no verdict to
+    # give. It says so, and names the interpreter that would fix it.
+    unresolved_primary = [n for n in (notes or [])
+                          if "not importable" in str(n)]
+    if unresolved_primary:
+        res["status"] = "UNKNOWN"
+        res["reason"] = (
+            f"{unresolved_primary[0]} — the roots on hand "
+            f"({', '.join(Path(p).name for p in res['roots'][:4])}) are not "
+            f"{backend}. Re-run with an interpreter where {backend} imports; "
+            f"a fallback corpus can only manufacture false accusations.")
+        return res
+
+    seen: dict[str, list] = {}
+    for path, entry in collect_entries(backend):
+        res["entries"] += 1
+        for tok, i, j in candidate_keys(entry):
+            if _is_retracted(entry, i, j) or _absence_asserted(entry, i, j):
+                continue          # "there is no SOUNDSPEED key" is the fix
+            seen.setdefault(tok, []).append((str(path), signal_of(entry)[:90]))
+
+    # Template keys are added with their own marker: they are the surface that
+    # gets written into a deck, so an unresolved one is strictly more serious
+    # than an unresolved one in prose.
+    for path, tok in template_keys(backend):
+        seen.setdefault(tok, []).append((str(path), "[DECK TEMPLATE]"))
+
+    for tok in sorted(seen):
+        res["checked"] += 1
+        if not key_present(tok, roots):
+            res["unresolved"].append({
+                "key": tok,
+                "occurrences": len(seen[tok]),
+                "first_seen": seen[tok][0][0],
+                "signal": seen[tok][0][1],
+            })
+    if res["entries"] == 0:
+        # "OK, 0 keys checked, 0 unresolved" is the shape of a pass, and it is
+        # what this returned for SPARTA — whose knowledge in this tree is a
+        # 509 KB command reference containing no warnings at all. A green tick
+        # for a backend nobody looked at is the most expensive kind of wrong,
+        # because a pass ends the investigation.
+        res["status"] = "NO_ENTRIES"
+        res["reason"] = (
+            f"no warning text found for {backend}: nothing under "
+            f"src/backends/{backend} carries a 'Signal:' clause, in Python or "
+            f"in JSON. Either this backend has no warnings yet, or its "
+            f"knowledge is stored in a shape the collector does not read. "
+            f"Both are worth knowing; neither is a pass.")
+        return res
+
+    part = corpus_completeness(backend)
+    if part:
+        res["corpus_partial"] = part
+        res["status"] = "PARTIAL_CORPUS"
+        # "Not found" means "not found in what is installed". Kratos ships ~40
+        # applications; this host has three. BIOT_COEFFICIENT lives in
+        # Poromechanics and DEM_SURFACE_LOAD in DEM, so neither can be resolved
+        # here — and neither is thereby shown to be invented. Calling them
+        # fabrications would repeat the scipy mistake one level down.
+        res["unverifiable"] = res.pop("unresolved")
+        return res
+    res["status"] = "OK" if not res["unresolved"] else "CANDIDATES"
+    return res
+
+
+def corpus_completeness(backend: str) -> str:
+    """Describe a corpus known to be a SUBSET of the backend, else ''.
+
+    Only Kratos needs this today: it is distributed as a core plus optional
+    application packages, each a separate wheel, and a key belonging to an
+    application that is not installed is invisible no matter how real it is.
+    """
+    if backend != "kratos":
+        return ""
+    import glob
+    # The full source build, if present, makes the caveat unnecessary: 28
+    # applications is the whole of Kratos as this project uses it, so a key that
+    # does not resolve there really does not resolve.
+    full = glob.glob("/mnt/kratos-tier2/kv/lib/python*/site-packages/"
+                     "KratosMultiphysics")
+    if full:
+        n = len([d for d in Path(full[0]).iterdir()
+                 if d.is_dir() and d.name.lower().endswith("application")])
+        if n >= 20:
+            return ""
+    sp = glob.glob("/home/alexander/Schreibtisch/open-fem-agent/.venv/lib/"
+                   "python*/site-packages")
+    if not sp:
+        return ""
+    apps = sorted({Path(p).name.split("-")[0]
+                   for p in glob.glob(f"{sp[0]}/kratos*application-*.dist-info")})
+    if not apps:
+        return ""
+    return (f"only {len(apps)} Kratos applications installed "
+            f"({', '.join(a.replace('kratos', '').replace('application', '') for a in apps)}"
+            f" + core); keys belonging to any other application "
+            f"(DEM, Poromechanics, CFD, ...) cannot be resolved on this host")
+
+
+def selftest() -> int:
+    """Prove the gate detects what it was built to detect.
+
+    Pre-fix tree must flag SOUNDSPEED; post-fix tree must stay quiet about it.
+    """
+    pre = Path("/home/alexander/Schreibtisch/ofa-verify-ngs")
+    post = Path("/home/alexander/Schreibtisch/ofa-know-4c")
+    print("SELFTEST — the gate must flag the known fabrication and only it\n")
+    ok = True
+    for label, tree, expect in (("pre-fix ", pre, True), ("post-fix", post, False)):
+        f = tree / "src" / "backends" / "fourc" / "backend.py"
+        if not f.is_file():
+            print(f"  {label}: {f} missing — cannot run control")
+            ok = False
+            continue
+        text = f.read_text(errors="ignore")
+        hits = [t for t, i, j in candidate_keys(text)
+                if t == "SOUNDSPEED" and not _is_retracted(text, i, j)
+                and not _absence_asserted(text, i, j)]
+        got = bool(hits)
+        good = got == expect
+        ok &= good
+        print(f"  {'OK ' if good else 'BAD'} {label} tree: SOUNDSPEED "
+              f"{'flagged' if got else 'not flagged'} "
+              f"(expected {'flagged' if expect else 'not flagged'})")
+    print(f"\nselftest {'PASSED' if ok else 'FAILED'}")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("backends", nargs="*")
+    ap.add_argument("--repo", default=None, metavar="DIR",
+                    help="audit ANOTHER checkout's knowledge. The campaign "
+                         "branches hold the current corpus; this worktree is "
+                         "stale for several backends (its SPARTA is the old "
+                         "13-pitfall version against 211 on the consolidation "
+                         "branch), so auditing only what is under this script "
+                         "measures the wrong tree.")
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--json", default=None)
+    args = ap.parse_args()
+
+    if args.repo:
+        import audit_quoted_diagnostics as aqd
+        global REPO
+        REPO = aqd.REPO = pathlib.Path(args.repo).resolve()
+
+    if args.selftest:
+        return selftest()
+
+    names = args.backends or ["fourc", "fenics", "dealii", "ngsolve", "skfem",
+                              "kratos", "dune", "febio", "sparta"]
+    out = []
+    for b in names:
+        r = audit(b)
+        out.append(r)
+        head = f"{b:<10} {r['status']:<11}"
+        if r["status"] == "UNKNOWN":
+            print(f"  {head} {r['reason']}")
+            continue
+        # "unresolved" and "unverifiable" are deliberately different words and
+        # must never be printed under one heading: the first says the corpus was
+        # searched and the key is not in it, the second says the corpus cannot
+        # answer. Collapsing them is how a coverage gap gets read as a fabrication.
+        hits = r.get("unresolved")
+        label = "unresolved"
+        if hits is None:
+            hits, label = r.get("unverifiable", []), "UNVERIFIABLE here"
+        print(f"  {head} {r['checked']:>4} distinct keys checked across "
+              f"{r['entries']} entries -> {len(hits)} {label}")
+        if r.get("corpus_partial"):
+            print(f"        corpus is partial: {r['corpus_partial']}")
+        for u in hits[:8]:
+            print(f"        {u['key']:<28} x{u['occurrences']:<3} {u['signal']}")
+    if args.json:
+        Path(args.json).write_text(json.dumps(out, indent=2))
+        print(f"\n  written to {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_quoted_diagnostics.py
+++ b/scripts/audit_quoted_diagnostics.py
@@ -1,0 +1,689 @@
+#!/usr/bin/env python3
+"""Does the software actually print the error message we quote?
+
+THE DEFECT THIS EXISTS FOR
+--------------------------
+Every verification agent that has executed knowledge rather than reading it has
+come back with the same finding, and it is always the largest category:
+
+    FEBio        25 invented error messages, 11 non-existent material names
+    4C beams/contact/constraint   ~10 quoted diagnostics absent from the source
+    NGSolve      "Newton did not converge after N iterations" — nowhere in
+                 ngsolve/netgen; the real text is "Warning: Newton might not
+                 converge! Error = "
+    skfem        meshio "Cannot write complex array" — never emitted; the real
+                 failure is KeyError: dtype('complex128')
+    Kratos       FREESTREAM_VELOCITY / MACH_INFINITY — neither name exists
+    scipy        "RuntimeError: matrix not positive definite" from cg — scipy
+                 raises nothing at all; it returns info=1000 and a garbage
+                 vector
+
+Why this class is worse than a merely wrong entry: an agent uses the quoted
+string to BUILD ITS GUARD. Told that cg raises, it writes an exception handler
+and treats the absence of an exception as success — so the guard passes and the
+garbage flows through. A fabricated diagnostic does not just fail to help; it
+actively manufactures false confidence, which is the exact failure mode this
+whole project exists to prevent.
+
+The existing `audit_phantom_apis.py` checks API ATTRIBUTES via hasattr. It says
+nothing about quoted message text, which is where the damage has actually been.
+
+HOW THIS CHECKS
+---------------
+For each quoted fragment inside a `Signal:` clause, look for it in the software
+that is supposed to emit it: the C++ source tree for compiled backends, the
+installed package source for Python ones, and — importantly — their dependency
+trees, because plenty of genuine messages come from Trilinos, PETSc, UMFPACK,
+meshio or scipy rather than from the backend itself.
+
+BUILT TO AVOID FALSE ACCUSATIONS, deliberately and at the cost of sensitivity.
+Two earlier guards in this repo cried wolf: a delegation guard flagged `sorted`,
+`dedent` and `format` as suspicious (~20 false accusations), and a disclosure
+guard accused five honest 4C entries because it required a phrase verbatim that
+the entries expressed slightly differently. A checker that is wrong often gets
+ignored, and an ignored gate is worse than none — so this one:
+
+  * searches dependency trees, not just the backend;
+  * matches on the LONGEST STATIC FRAGMENT, since real messages interpolate at
+    runtime ("DPoint 1 not in range [0:0[" is literal only in parts);
+  * requires a fragment to be substantial before judging it at all;
+  * reports UNKNOWN rather than ABSENT when it cannot see the source, because
+    "I could not check" and "it is not there" are different claims and only one
+    of them is an accusation.
+
+Absence of a string from the source is strong evidence but not proof: messages
+can be assembled from pieces, or come from a binary we cannot read. So the exit
+status distinguishes "definitely absent" from "could not verify", and the report
+says which is which.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Where each backend's implementation actually lives. A missing entry means the
+# audit reports UNKNOWN for that backend rather than guessing.
+SOURCE_HINTS: dict[str, list[str]] = {
+    # 4C: the source tree is READ ONLY — we only ever grep it.
+    "fourc": ["/home/alexander/4C/src", "/home/alexander/4C/tests"],
+    # FEBio is installed as a BINARY with no source tree — `/opt/febio` and
+    # `/usr/local/febio` are both absent on this host, so the audit reported
+    # UNKNOWN for every FEBio claim. The real install is below, and a binary is
+    # a perfectly good corpus for checking whether a tag or a message exists:
+    # FEBio's XML element names are compiled into it as literal strings. This
+    # only works with `grep -a`; without it grep skips the file as binary and
+    # answers "not found" for everything in it.
+    # NOT `/home/alexander/FEBio` — that directory holds only `bin/febio4`,
+    # which is a SYMLINK into the tree below, and `grep -r` does not follow
+    # symlinks. Pointed there, the corpus was effectively empty: a positive
+    # control for the literal string "febio" returned zero files, and the audit
+    # duly reported 23 of 23 FEBio keys as unresolved. Against the real tree,
+    # 13 of those 23 resolve immediately. A corpus that answers "no" to
+    # everything is not evidence of fabrication, it is a broken instrument —
+    # which is why every backend here needs a positive control before its
+    # numbers are quoted.
+    "febio": ["/home/alexander/Schreibtisch/febio-src",
+              "/opt/febio", "/usr/local/febio"],
+    # deal.II ships as C++ headers and sources, not a Python package, so the
+    # module probe could never find it. 7125 headers and sources here.
+    #
+    # There are TWO deal.II installs on this host and they disagree: the system
+    # /usr/include/deal.II is 9.1.1 with MPI/P4EST/PETSC/TRILINOS/SLEPC ON,
+    # while the build the C++ fixtures actually compile against has all five
+    # undefined. That difference matters for capability claims and a fixture was
+    # found reading the wrong one. It does NOT matter here — this audit asks
+    # only whether a symbol or message exists anywhere in deal.II — but the
+    # source tree is listed first so answers come from the real thing.
+    "dealii": ["/home/alexander/dealii", "/usr/include/deal.II"],
+    # SPARTA is a C++ code with its own input-command corpus in doc/ and
+    # examples/; both matter, since a command can be documented and exercised
+    # without appearing as a literal in the source.
+    "sparta": ["/home/alexander/Schreibtisch/sparta"],
+    # Kratos: prefer the source-built 28-APPLICATION install over the repo
+    # venv's wheel, which ships only core plus three applications.
+    #
+    # Against the 3-app wheel, 66 Kratos keys did not resolve and the audit
+    # correctly refused to call them invented — a key from DEMApplication or
+    # PoromechanicsApplication is invisible when those applications are not
+    # installed, however real it is. Against this build (70 compiled libraries)
+    # BIOT_COEFFICIENT, DEM_SURFACE_LOAD and COMPUTE_FEM_RESULTS_OPTION all
+    # resolve immediately. They were real the whole time.
+    #
+    # The restraint paid twice over: PARTICLE_FRICTION, served as a required DEM
+    # material key AND written into generated decks, is absent from the full
+    # 28-app build too. Now that the corpus can answer, that absence means
+    # something. The real keys are STATIC_FRICTION / DYNAMIC_FRICTION.
+    "kratos": ["/mnt/kratos-tier2/kv/lib/python3.12/site-packages/"
+               "KratosMultiphysics"],
+}
+
+# Python backends, PRIMARY MODULE FIRST. The first entry must be importable or
+# the audit reports UNKNOWN — the secondary modules are not a substitute.
+#
+# Learned from FEniCSx: dolfinx is not in the repo venv (it lives in a conda
+# env), but ufl, basix and petsc4py are. With a flat list, three of four
+# resolving looked like enough source to judge, and every dolfinx message was
+# reported absent — having been searched for in ufl. The primary module is the
+# one that emits the messages; without it there is nothing to check against.
+PY_MODULES: dict[str, list[str]] = {
+    "fenics": ["dolfinx", "ufl", "basix", "petsc4py"],
+    "ngsolve": ["ngsolve", "netgen"],
+    "skfem": ["skfem"],
+    "kratos": ["KratosMultiphysics"],
+    "dune": ["dune"],
+    "sparta": [],
+}
+
+# Quoted text that is NOT an assertion about what the software prints. Authors
+# legitimately quote code to run, keys to set, and commands to type; demanding
+# that those appear in the source as literals produces accusations against
+# perfectly good entries.
+_NOT_A_DIAGNOSTIC = re.compile(
+    r"^\s*(?:from|import)\s+\w"          # import statements
+    r"|^\s*(?:pip|conda|apt|cmake|make|mpirun|python[0-9.]*)\s"  # commands
+    r"|^\s*[\w.]+\s*=\s*[^=]"            # assignments
+    # An API expression: dotted names with a call somewhere and no sentence
+    # punctuation. `Basis.interpolate(u).grad` is a thing to WRITE, not a thing
+    # the library PRINTS, and requiring it to appear verbatim in the source
+    # accuses an entry that is simply showing correct usage.
+    r"|^[\w.]+(?:\([^)]*\))?(?:\.[\w]+(?:\([^)]*\))?)+$"
+    # A weak-form / expression fragment: arithmetic operators outside of any
+    # sentence. `(sigma*n - sigma.Other()*n) * v * ds(skeleton=True)` is UFL an
+    # author is showing, not text a library prints.
+    r"|^[^A-Z]*[*+]\s*\w+.*\)\s*$",
+    re.IGNORECASE)
+
+# Dependency trees whose messages legitimately surface through a backend.
+SHARED_DEPS = ["scipy", "numpy", "meshio", "petsc4py", "mpi4py"]
+
+_SIGNAL_RE = re.compile(r"Signal:\s*(.*)", re.IGNORECASE | re.DOTALL)
+
+# Quote pairs must be found IN ORDER, consuming both delimiters, with the
+# length filter applied AFTER pairing.
+#
+# The obvious regex — r"'([^']{12,200})'|..." — is wrong, and wrong in the
+# direction that manufactures false accusations. On the real entry
+#
+#     Signal: writing 'SOLID QUAD4' for an ALE mesh raises
+#             'expected ALE element type' from 4C_ale_factory.cpp
+#
+# `SOLID QUAD4` is 11 characters, one below the minimum, so the alternation
+# skipped it and matched the NEXT available pair — which straddled from the
+# closing quote of the first fragment to the opening quote of the second,
+# yielding the prose "for an ALE mesh raises". That prose is of course not in
+# the source, so the checker reported an ABSENT diagnostic while never looking
+# at `expected ALE element type`, the string actually being asserted. Both
+# halves are failures: a fabricated accusation and a missed check.
+_QUOTE_CHARS = "'\"`"
+
+# RETRACTIONS ARE NOT FABRICATIONS. When a verification pass falsifies a quoted
+# diagnostic, the honest correction records what the entry USED to claim so the
+# next reader knows it was checked and why it changed:
+#
+#     beams.py:294  "older quote 'beam element type not supported in Exodus'
+#                    is in no 4C source file; the real message is ..."
+#
+# That string is absent from the source — deliberately, and the entry says so.
+# Flagging it would accuse an author of fabricating precisely where they did the
+# opposite, and a checker that punishes correct behaviour gets switched off. So
+# a quoted fragment sitting within a retraction context is EXPECTED_ABSENT and
+# reported separately: still visible, never counted as a defect.
+_RETRACTION_CUES = re.compile(
+    r"(?:older|earlier|previous|prior|former)\s+(?:quote|claim|wording|text|"
+    r"message|version)"
+    r"|(?:the\s+)?(?:claimed|alleged|purported|supposed)\b"
+    r"|is\s+in\s+no\b|does\s+not\s+exist|do\s+not\s+exist|never\s+appears?"
+    r"|is\s+not\s+emitted|are\s+not\s+emitted|nowhere\s+in\b"
+    r"|no\s+such\s+(?:string|message|error)"
+    r"|(?:was|is)\s+(?:fabricated|invented|falsified|retracted|wrong)"
+    r"|not\s+found\s+anywhere|appears?\s+in\s+neither",
+    re.IGNORECASE)
+
+# A retraction governs only its OWN clause. Both bounds were learned from
+# getting it wrong on the real corpus:
+#
+#   * A plain backward window over-suppressed. In "older quote 'X' is in no 4C
+#     source file; the real message is 'Y'", the cue for X sat within 120 chars
+#     of Y, so Y was excused too — and Y is exactly the string that MUST be
+#     checked. Clause boundaries stop the bleed.
+#   * A backward-only window under-detected. In "'X' does not exist in the
+#     source" the cue follows the quote, so nothing before it looked like a
+#     retraction and a documented absence was reported as a fabrication.
+#
+# So: look back to the nearest clause boundary, and forward a short distance.
+_CLAUSE_BOUNDARY = re.compile(r"[;.]|\s--\s|\s—\s")
+_BACK_WINDOW = 120
+_FORWARD_WINDOW = 60
+
+
+def _is_retracted(text: str, start: int, end: int) -> bool:
+    """Is this quote introduced or immediately marked as NOT emitted?"""
+    back = text[max(0, start - _BACK_WINDOW):start]
+    # Trim to the last clause boundary so a neighbouring clause's retraction
+    # does not excuse this quote.
+    bounds = list(_CLAUSE_BOUNDARY.finditer(back))
+    if bounds:
+        back = back[bounds[-1].end():]
+    if _RETRACTION_CUES.search(back):
+        return True
+    fwd = text[end:end + _FORWARD_WINDOW]
+    m = _CLAUSE_BOUNDARY.search(fwd)
+    if m:
+        fwd = fwd[:m.start()]
+    return bool(_RETRACTION_CUES.search(fwd))
+
+
+def quoted_fragments(text: str) -> list[str]:
+    """Quoted fragments, paired left to right so a pair cannot straddle.
+
+    Scans for an opening delimiter, then its matching close, then continues
+    AFTER that close — so consecutive quoted fragments are read as the author
+    wrote them. Short fragments are dropped after pairing, never during it.
+    """
+    def _is_apostrophe(s: str, k: int) -> bool:
+        """An apostrophe inside a word is contraction/possessive, not a quote.
+
+        Found by an independent adjudicator: several of this screen's flags were
+        prose. In "don't reach for a skfem.NewtonSolver — it doesn't converge",
+        the apostrophes of `don't` and `doesn't` were read as a matching pair
+        and the sentence between them extracted as a diagnostic — which of
+        course is not in any source, so an author's plain English was reported
+        as a fabricated error message.
+        """
+        if s[k] != "'":
+            return False
+        before = s[k - 1] if k > 0 else ""
+        after = s[k + 1] if k + 1 < len(s) else ""
+        return before.isalpha() and after.isalpha()
+
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in _QUOTE_CHARS and not _is_apostrophe(text, i):
+            j = i
+            while True:
+                j = text.find(ch, j + 1)
+                if j == -1 or not _is_apostrophe(text, j):
+                    break
+            if j == -1:
+                break  # unbalanced delimiter: stop rather than guess
+            frag = text[i + 1:j].strip()
+            if 12 <= len(frag) <= 200 and not _is_retracted(text, i, j + 1):
+                out.append(frag)
+            i = j + 1  # resume AFTER the closing delimiter
+            continue
+        i += 1
+    return out
+
+
+def cited_source_files(text: str) -> list[str]:
+    """Source files an entry names as the origin of a diagnostic.
+
+    A separate defect class, found while building this: `ale.py` attributes a
+    message to `4C_ale_factory.cpp`, and no such file exists anywhere in the 4C
+    tree. A citation to a file that does not exist cannot be checked by a
+    reader and cannot be where the message comes from, so it is a fabrication
+    of provenance even when the message itself is real.
+    """
+    return sorted(set(re.findall(r"\b(4C_[\w.]+\.(?:cpp|hpp|H|cc))\b", text)
+                      + re.findall(r"\b([\w/]+\.(?:cpp|hpp|py))\b", text)))
+
+# A fragment must contain this much unbroken literal text to be judged. Below
+# it, absence means nothing — short fragments collide with ordinary prose.
+MIN_STATIC_FRAGMENT = 16
+
+
+def signal_of(entry: str) -> str:
+    m = _SIGNAL_RE.search(entry)
+    return m.group(1) if m else ""
+
+
+def static_parts(fragment: str) -> list[str]:
+    """Split a message on the bits a program fills in at runtime.
+
+    "DPoint 1 not in range [0:0[" is literal only in parts — the numbers come
+    from the run. Matching the whole string would report a genuine message as
+    fabricated, which is the failure mode this checker must not have.
+    """
+    # Split on: numbers, quoted sub-values, paths, angle-bracket placeholders,
+    # ellipses, and the format placeholders the codes use.
+    parts = re.split(
+        r"\d+|<[^>]*>|\{[^}]*\}|%[sdfg]|\.\.\.|'[^']*'|\"[^\"]*\"|/[\w./-]+",
+        fragment)
+    return [p.strip() for p in parts if len(p.strip()) >= MIN_STATIC_FRAGMENT]
+
+
+# Backends do not share an interpreter. dolfinx lives only in the `fenics`
+# conda env, deal.II only in `ofa-dealii`, and the suite runs from a venv that
+# has neither. Probing with `sys.executable` alone therefore returned nothing
+# for four of nine backends, and the audit reported UNKNOWN for all of them —
+# an honest non-answer, but a non-answer covering half the corpus.
+#
+# So each candidate interpreter is tried in turn. The first that can locate the
+# package wins; the search is read-only and nothing from these environments is
+# imported into this process.
+_CANDIDATE_PYTHONS = [
+    sys.executable,
+    "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python",
+    str(Path.home() / "miniconda3" / "envs" / "fenics" / "bin" / "python"),
+    str(Path.home() / "miniconda3" / "envs" / "fenicsc" / "bin" / "python"),
+    str(Path.home() / "miniconda3" / "envs" / "ofa-dealii" / "bin" / "python"),
+    str(Path.home() / "miniconda3" / "envs" / "dune-fem-env" / "bin" / "python"),
+    "/usr/bin/python3",
+]
+
+
+def _py_package_paths(module_names: list[str]) -> list[Path]:
+    paths = []
+    for name in module_names:
+        for _py in _CANDIDATE_PYTHONS:
+            if _py != sys.executable and not Path(_py).is_file():
+                continue
+            if _locate_with(_py, name, paths):
+                break
+    return paths
+
+
+def _locate_with(py: str, name: str, paths: list[Path]) -> bool:
+    """Try one interpreter; append the package dir and return True on success."""
+    for probe in (
+        # First choice: import it and ask where it lives.
+        f"import {name},os;print(os.path.dirname({name}.__file__))",
+        # Fallback: a failed import is not an absent package. Kratos is
+        # INSTALLED on this host and unimportable — `import KratosMultiphysics`
+        # dies on "libc.so.6: version GLIBC_2.32 not found", which is itself one
+        # of the warnings in this corpus. Requiring a working import hid the
+        # entire Kratos source tree from every audit, and the fallback roots
+        # (scipy, numpy) then made real Kratos variables look invented.
+        #
+        # For grepping a corpus we need the FILES, not a live module, and
+        # find_spec locates them without executing any of the package.
+        "import importlib.util as u;"
+        f"s=u.find_spec({name!r});"
+        "print(next(iter(getattr(s,'submodule_search_locations',[]) or []), '')"
+        " if s else '')",
+    ):
+        try:
+            proc = subprocess.run([py, "-c", probe], capture_output=True,
+                                  text=True, timeout=60,
+                                  stdin=subprocess.DEVNULL)
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+        if proc.returncode == 0 and proc.stdout.strip():
+            p = Path(proc.stdout.strip())
+            if p.is_dir():
+                paths.append(p)
+                return True
+    return False
+
+
+def search_roots(backend: str) -> tuple[list[Path], list[Path], list[str]]:
+    """Where to look, split into the backend's OWN source and shared deps.
+
+    The split is not cosmetic — it decides whether a verdict may be issued at
+    all. First version returned one flat list, and Kratos resolved to four
+    roots of which ZERO were Kratos: `KratosMultiphysics` is not importable in
+    the test venv, so only scipy, numpy and meshio were found. A non-empty root
+    list meant the audit considered itself able to judge, and it then reported
+    every Kratos diagnostic as absent — having searched scipy for them. Over
+    200 false accusations, against exactly the backend whose knowledge had just
+    been carefully verified by hand.
+
+    So: shared dependency trees may only ever CONFIRM a message (they hold
+    genuine ones, from PETSc, UMFPACK, meshio, scipy). They can never license
+    an absence verdict. Without the backend's own source, the answer is
+    UNKNOWN.
+    """
+    own: list[Path] = []
+    missing: list[str] = []
+    for hint in SOURCE_HINTS.get(backend, []):
+        p = Path(hint)
+        if p.is_dir():
+            own.append(p)
+        else:
+            missing.append(hint)
+
+    mods = PY_MODULES.get(backend)
+    shared: list[Path] = []
+    if mods:
+        primary = mods[0]
+        found_primary = _py_package_paths([primary])
+        if not found_primary:
+            # Secondary modules cannot stand in for the one that emits the
+            # messages. Report nothing rather than search the wrong package.
+            missing.append(f"primary module {primary!r} not importable here")
+            shared = _py_package_paths(SHARED_DEPS)
+            return own, shared, missing
+        own.extend(found_primary)
+        own.extend(_py_package_paths(mods[1:]))
+        # The vendored *.libs siblings hold the actual compiled library; the
+        # package directory holds only a wrapper.
+        own.extend(vendored_lib_dirs(own))
+        shared = _py_package_paths(SHARED_DEPS)
+        shared.extend(vendored_lib_dirs(shared))
+    return own, shared, missing
+
+
+def longest_found_prefix(fragment: str, roots: list[Path],
+                         floor: int = MIN_STATIC_FRAGMENT) -> str:
+    """The longest leading sub-phrase of this fragment present in the source.
+
+    WHY THIS IS NEEDED, and it is the single biggest limitation of the whole
+    approach. Compiled backends assemble diagnostics at runtime, so the message
+    a user sees never exists as one literal. Two strings that agents captured
+    from REAL NGSolve runs are not greppable at all:
+
+        "Trace of non-matrix called"                  0 hits
+        "does not exist for H1HighOrderFESpace"       0 hits
+                (from: Operator "biharmonic" does not exist for
+                       H1HighOrderFESpace!)
+
+    The second is plainly `"... does not exist for " + type_name + "!"` with the
+    type name supplied by RTTI. Reporting either as fabricated would be a false
+    accusation against a message the agent watched the software print.
+
+    So when a full fragment is absent, look for the longest leading piece that
+    IS present. A substantial hit means "assembled at runtime, consistent with
+    the source" — evidence for the entry, not against it. Only a fragment with
+    no substantial piece anywhere is reported as absent, and even that stays
+    evidence rather than proof.
+    """
+    words = fragment.split()
+    for n in range(len(words), 0, -1):
+        cand = " ".join(words[:n])
+        if len(cand) < floor:
+            break
+        if grep_literal(cand, roots):
+            return cand
+    return ""
+
+
+def grep_literal(needle: str, roots: list[Path]) -> bool:
+    """Is this exact text anywhere under these roots, text OR binary?
+
+    Uses -F (fixed string) so the metacharacters that fill real diagnostics —
+    brackets, parentheses, dots — are taken literally, and -a so COMPILED
+    libraries are searched as text.
+
+    THE -a IS NOT OPTIONAL, and leaving it out invalidated a whole backend's
+    result. grep skips binary content by default, silently: on ngslib.so it
+    reported 0 matches for `FESpace` and `ngcore`, strings that must be in any
+    NGSolve build. Every C++-level NGSolve diagnostic was therefore recorded as
+    fabricated, which produced a measured "89% fabricated" that was itself
+    fabricated. Two strings agents had captured from real runs —
+    `Trace of non-matrix called` and `does not exist for H1HighOrderFESpace` —
+    were among the accused, and both are real:
+
+        libngfem.so   "Trace of non-matrix called"   1
+        libngcomp.so  "does not exist for "          2
+
+    See vendored_lib_dirs() for the other half of that bug.
+    """
+    if not roots:
+        return False
+    try:
+        proc = subprocess.run(
+            ["grep", "-rlaFq", "--", needle, *[str(r) for r in roots]],
+            capture_output=True, text=True, timeout=300,
+            stdin=subprocess.DEVNULL)
+        return proc.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def vendored_lib_dirs(package_dirs: list[Path]) -> list[Path]:
+    """The `*.libs` siblings where wheels vendor their real shared libraries.
+
+    A manylinux wheel ships a thin pybind11 wrapper in the package directory
+    and the actual compiled library next door. For NGSolve, `ngsolve/ngslib.so`
+    is 194 KB of wrapper while the code lives in
+    `netgen_mesher.libs/libngfem.so`, `libngcomp.so`, `libngsolve.so`.
+
+    Searching only the package directory therefore searches the wrapper and
+    misses everything the backend actually says. Combined with grep's silent
+    binary skip, that is what produced an entirely false NGSolve verdict.
+    """
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for d in package_dirs:
+        parent = d.parent
+        if not parent.is_dir():
+            continue
+        try:
+            for sib in parent.iterdir():
+                if (sib.is_dir() and sib.name.endswith(".libs")
+                        and sib not in seen):
+                    seen.add(sib)
+                    out.append(sib)
+        except PermissionError:
+            continue
+    return out
+
+
+def _json_entries(be_dir: Path) -> list[tuple[Path, str]]:
+    """Warnings held in JSON rather than in Python string literals.
+
+    Not every backend keeps its knowledge in code. SPARTA's lives entirely in
+    `sparta_knowledge.json`, so the AST walk below found ZERO entries for it and
+    the audit cheerfully reported "0 keys checked, 0 unresolved" — a clean bill
+    of health for a backend it had not looked at. A gate that reports OK on an
+    empty reading is worse than one that reports UNKNOWN, because nobody
+    investigates a pass.
+    """
+    out: list[tuple[Path, str]] = []
+
+    def walk(node, path: Path) -> None:
+        if isinstance(node, str):
+            if "Signal:" in node:
+                out.append((path, node))
+        elif isinstance(node, dict):
+            for v in node.values():
+                walk(v, path)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v, path)
+
+    for jf in sorted(be_dir.rglob("*.json")):
+        try:
+            walk(json.loads(jf.read_text(errors="ignore")), jf)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return out
+
+
+def collect_entries(backend: str) -> list[tuple[Path, str]]:
+    be_dir = REPO / "src" / "backends" / backend
+    out = []
+    if not be_dir.is_dir():
+        return out
+    out.extend(_json_entries(be_dir))
+    for py in sorted(be_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(py.read_text(errors="ignore"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and "Signal:" in node.value):
+                out.append((py, node.value))
+    return out
+
+
+def audit_backend(backend: str) -> dict:
+    own, shared, missing = search_roots(backend)
+    entries = collect_entries(backend)
+    all_roots = own + shared
+
+    absent, present, unjudgeable = [], 0, 0
+    assembled: list[dict] = []
+    for path, entry in entries:
+        sig = signal_of(entry)
+        if not sig:
+            continue
+        for frag in quoted_fragments(sig):
+            if _NOT_A_DIAGNOSTIC.search(frag):
+                continue  # a command or code snippet, not an asserted message
+            parts = static_parts(frag)
+            if not parts:
+                unjudgeable += 1
+                continue
+            if not own:
+                # No source for THIS backend: a miss would prove nothing, so
+                # do not produce one. See search_roots for what this cost.
+                unjudgeable += 1
+                continue
+            # Present if ANY substantial static part is found in the backend
+            # OR in a shared dependency — genuine messages routinely come from
+            # PETSc, UMFPACK, meshio or scipy rather than from the backend.
+            # Requiring all parts would flag messages assembled from several
+            # literals, which is common.
+            if any(grep_literal(p, all_roots) for p in parts):
+                present += 1
+                continue
+            # Not present whole. Before accusing, look for the longest leading
+            # piece — compiled backends assemble messages at runtime, and a
+            # substantial hit means the entry matches the source's format
+            # string rather than inventing it.
+            prefix = ""
+            for p in parts:
+                prefix = longest_found_prefix(p, all_roots)
+                if prefix:
+                    break
+            if prefix:
+                assembled.append({
+                    "file": str(path.relative_to(REPO)),
+                    "fragment": frag[:160],
+                    "matched_prefix": prefix,
+                })
+                continue
+            absent.append({
+                "file": str(path.relative_to(REPO)),
+                "fragment": frag[:160],
+                "searched_for": parts[:3],
+            })
+    return {
+        "backend": backend,
+        "roots_searched": [str(r) for r in own],
+        "shared_roots": [str(r) for r in shared],
+        "roots_missing": missing,
+        "entries": len(entries),
+        "fragments_present": present,
+        "fragments_absent": absent,
+        "fragments_assembled": assembled,
+        "fragments_unjudgeable": unjudgeable,
+        "verdict": ("UNKNOWN — the backend's own source is not available here"
+                    if not own
+                    else ("CLEAN" if not absent else "ABSENT_STRINGS_FOUND")),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("backends", nargs="*",
+                    help="backends to audit (default: all with a known source)")
+    ap.add_argument("--json", action="store_true", help="machine-readable")
+    args = ap.parse_args()
+
+    names = args.backends or sorted(
+        set(SOURCE_HINTS) | {k for k, v in PY_MODULES.items() if v})
+    results = [audit_backend(b) for b in names]
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        for r in results:
+            print(f"\n=== {r['backend']} — {r['verdict']} ===")
+            print(f"  entries {r['entries']}, quoted fragments present "
+                  f"{r['fragments_present']}, absent {len(r['fragments_absent'])}, "
+                  f"unjudgeable {r['fragments_unjudgeable']}")
+            if r["roots_missing"]:
+                print(f"  could NOT search: {', '.join(r['roots_missing'])}")
+            for a in r["fragments_absent"][:20]:
+                print(f"    ABSENT  {a['file']}")
+                print(f"            {a['fragment']}")
+        total = sum(len(r["fragments_absent"]) for r in results)
+        unknown = [r["backend"] for r in results if r["verdict"].startswith("UNKNOWN")]
+        print(f"\n{total} quoted diagnostics not found in the software that is "
+              f"supposed to emit them.")
+        if unknown:
+            print(f"NOT CHECKED (no source available here): {', '.join(unknown)} "
+                  f"— that is 'could not verify', NOT 'verified clean'.")
+
+    # Exit 2 only for definite absences. An unverifiable backend must not turn
+    # the gate red, or the gate gets disabled on the machines that lack a
+    # source tree — and a disabled gate protects nothing.
+    return 2 if any(r["fragments_absent"] for r in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_two_stage_templates.py
+++ b/scripts/audit_two_stage_templates.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Find templates whose "it executes" evidence stops one step short of the solver.
+
+THE DEFECT
+----------
+`catalog_template_executes` generates a template, runs it, and records the exit
+code. For most backends that is genuinely end to end: the template IS the script
+that builds the problem and solves it.
+
+For some it is not. The Kratos DEM template is a FILE WRITER — running it emits
+`input.py`, `ProjectParameters.json` and an `.mdpa` mesh, then exits 0. The
+emitted `input.py` is the thing that calls Kratos, and it was never run. The
+gate has been recording `kratos::dem::2d_rc=0` for the half that cannot fail;
+run the emitted file and it dies at `entry string : strategy`. The DEM generator
+has never produced a working deck, and a green gate said otherwise.
+
+Verified here rather than taken on report: the template's own text contains
+`input.py`, `ProjectParameters`, `open(` and `write(`.
+
+WHAT THIS DOES
+--------------
+Runs each template in an isolated working directory, then looks at what it left
+behind. If it wrote something runnable, that artefact is run too, and the
+two exit codes are reported separately. A template that exits 0 while the file
+it wrote exits non-zero is the shape being hunted.
+
+WHAT IT WILL NOT CLAIM
+----------------------
+A backend with no usable interpreter is SKIPPED WITH A REASON, never passed.
+The Kratos wheel in the repo venv has 3 of ~40 applications and does not import
+at all (GLIBC); the 28-application source build at /mnt/kratos-tier2/kv does.
+Pointing this at the wrong one produces a confident wrong answer in either
+direction, so the interpreter actually used is recorded in every row.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Artefacts that are themselves runnable, in the order we would try them.
+_RUNNABLE = ("input.py", "run.py", "main.py", "MainKratos.py")
+
+INTERPRETERS = {
+    # The 28-application build. The repo venv's 3-app wheel cannot import
+    # Kratos at all, so using it would report every Kratos row as broken.
+    "kratos": os.environ.get(
+        "KRATOS_PYTHON", "/mnt/kratos-tier2/kv/bin/python"),
+    "skfem": os.environ.get("SKFEM_PYTHON", sys.executable),
+    "ngsolve": os.environ.get("NGSOLVE_PYTHON", sys.executable),
+    "fenics": os.environ.get(
+        "FENICS_PYTHON",
+        str(Path.home() / "miniconda3" / "envs" / "fenics" / "bin" / "python")),
+    "dune": os.environ.get("DUNE_PYTHON", ""),
+}
+
+
+def _interp(backend: str) -> str:
+    p = INTERPRETERS.get(backend, "")
+    return p if p and Path(p).is_file() else ""
+
+
+def check(backend: str, physics: str, variant: str, timeout: int = 120) -> dict:
+    row = {"backend": backend, "physics": physics, "variant": variant}
+    py = _interp(backend)
+    if not py:
+        row["status"] = "SKIPPED"
+        row["reason"] = (f"no interpreter for {backend}; set "
+                         f"{backend.upper()}_PYTHON. Not a pass.")
+        return row
+    row["interpreter"] = py
+
+    gen = (
+        "import sys;sys.path.insert(0,%r)\n"
+        "from core.registry import load_all_backends,get_backend\n"
+        "load_all_backends()\n"
+        "print(get_backend(%r).generate_input(%r,%r,{}))\n"
+        % (str(REPO / "src"), backend, physics, variant))
+    try:
+        g = subprocess.run([py, "-c", gen], capture_output=True, text=True,
+                           timeout=timeout, stdin=subprocess.DEVNULL)
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        row["status"] = "ERROR"
+        row["reason"] = f"could not generate: {exc}"[:160]
+        return row
+    if g.returncode != 0:
+        row["status"] = "GENERATE_FAILED"
+        row["reason"] = (g.stderr or "")[-300:]
+        return row
+    template = g.stdout
+
+    with tempfile.TemporaryDirectory(prefix="tmpl_") as td:
+        script = Path(td) / "template.py"
+        script.write_text(template)
+        before = {p.name for p in Path(td).iterdir()}
+        try:
+            r = subprocess.run([py, str(script)], capture_output=True,
+                               text=True, timeout=timeout, cwd=td,
+                               stdin=subprocess.DEVNULL)
+        except subprocess.TimeoutExpired:
+            row["status"] = "TIMEOUT"
+            return row
+        row["template_rc"] = r.returncode
+        made = sorted({p.name for p in Path(td).iterdir()} - before)
+        row["emitted"] = made
+
+        runnable = [m for m in made if m in _RUNNABLE]
+        if not runnable:
+            # Single-stage: the template did the work itself. Its exit code is
+            # the whole answer, which is what the existing gate assumes.
+            row["status"] = "SINGLE_STAGE"
+            return row
+
+        # Two-stage: the template wrote a script. THAT is the deck the user
+        # would run, and its exit code is the one that matters.
+        row["status"] = "TWO_STAGE"
+        art = runnable[0]
+        row["ran"] = art
+        try:
+            r2 = subprocess.run([py, art], capture_output=True, text=True,
+                                timeout=timeout, cwd=td,
+                                stdin=subprocess.DEVNULL)
+            row["emitted_rc"] = r2.returncode
+            row["emitted_tail"] = ((r2.stdout or "") + (r2.stderr or ""))[-400:]
+        except subprocess.TimeoutExpired:
+            row["emitted_rc"] = 124
+            row["emitted_tail"] = "TIMEOUT"
+        # The finding: green template, red artefact.
+        row["gate_is_shallow"] = (row["template_rc"] == 0
+                                  and row["emitted_rc"] != 0)
+        return row
+
+
+_WRITES_RUNNABLE = (
+    r"""open\(\s*['\"][^'\"]*(input|main|run)[^'\"]*\.py""",
+    r"""['\"](input|MainKratos|run)\.py['\"]""",
+)
+
+
+def screen(repo: Path) -> list[str]:
+    """Cheap static pass over EVERY template, to bound the problem.
+
+    Running each template costs up to a couple of minutes; generating it costs
+    nothing. A template that writes a runnable `.py` is the two-stage shape, and
+    that can be seen in the text.
+
+    Measured across 255 templates in all nine backends: exactly ONE matches,
+    `kratos:dem:2d`. So this defect is a single broken generator, not a rot
+    running through the catalog — which is worth knowing precisely, because
+    "one gate is shallow" and "the gates are shallow" call for very different
+    responses.
+    """
+    import re
+    sys.path.insert(0, str(repo / "src"))
+    from core.registry import get_backend, load_all_backends
+    load_all_backends()
+    hits, total = [], 0
+    for b in ("kratos", "skfem", "ngsolve", "fenics", "dune", "dealii",
+              "fourc", "febio", "sparta"):
+        be = get_backend(b)
+        if not be:
+            continue
+        for p in be.supported_physics():
+            for v in (p.template_variants or ["default"]):
+                total += 1
+                try:
+                    t = be.generate_input(p.name, v, {})
+                except Exception:      # noqa: BLE001 - a generator that cannot
+                    continue           # even generate is a different defect
+                if any(re.search(pat, t, re.I) for pat in _WRITES_RUNNABLE):
+                    hits.append(f"{b}:{p.name}:{v}")
+    print(f"  {total} templates screened, {len(hits)} two-stage")
+    for h in hits:
+        print(f"      {h}")
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("targets", nargs="*",
+                    help="backend:physics:variant (default: a known set)")
+    ap.add_argument("--screen", metavar="REPO", default=None,
+                    help="static pass over every template in REPO to find the "
+                         "two-stage ones cheaply, then stop")
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--json", default=None)
+    args = ap.parse_args()
+
+    if args.screen:
+        screen(Path(args.screen))
+        return 0
+
+    targets = args.targets or ["kratos:dem:2d"]
+    rows = []
+    for t in targets:
+        parts = t.split(":")
+        if len(parts) != 3:
+            print(f"  skipping malformed target {t!r}")
+            continue
+        row = check(*parts, timeout=args.timeout)
+        rows.append(row)
+        head = f"{t:<28} {row['status']:<16}"
+        if row["status"] == "TWO_STAGE":
+            verdict = ("SHALLOW GATE — template rc=0 but the file it wrote "
+                       "fails" if row.get("gate_is_shallow") else "both run")
+            print(f"  {head} template_rc={row['template_rc']} "
+                  f"{row['ran']}_rc={row.get('emitted_rc')}  {verdict}")
+            if row.get("gate_is_shallow"):
+                print(f"        emitted: {', '.join(row['emitted'])}")
+                for ln in (row.get("emitted_tail") or "").strip().splitlines()[-3:]:
+                    print(f"        | {ln[:110]}")
+        else:
+            print(f"  {head} {row.get('reason', '') or row.get('emitted', '')}")
+    if args.json:
+        Path(args.json).write_text(json.dumps(rows, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_execution_ledger.py
+++ b/scripts/build_execution_ledger.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Record which fixtures actually ran, passed, and were killed by their mutation.
+
+THE NUMBER THIS EXISTS TO PRODUCE
+---------------------------------
+OASiS can say "1245 of 1377 knowledge warnings have a proof fixture" — 90%. Two
+independent audits established what that sentence means: **a fixture exists**.
+Not that it ran. Not that it passed.
+
+The evidence of execution is `scripts/scan_results/tier2_results.json`, and it is
+stale nearly everywhere:
+
+    ofa-know-4c        116 recorded / 472 fixtures  (3 of them FAILED)
+    ofa-verify-fenics  108 / 287
+    ofa-verify-ngs     108 / 330
+    ofa-know-febio     183 / 184     <- the only one doing this right
+
+Three of four still hold the pre-campaign 108-fixture baseline. The cause is in
+`docs/CONSOLIDATION.md`: the runner's `--write-results` flag was parsed and never
+read during the campaigns, so every campaign's greenness lives in a session
+transcript nobody can re-run.
+
+So the two numbers a reviewer asks for first do not exist:
+
+    N of <total> fixtures pass on commit X
+    M of <controls> mutations go red
+
+This produces both, per backend, with the commit sha and a timestamp.
+
+WHY THE MUTATION HALF MATTERS AS MUCH AS THE PASS HALF
+-----------------------------------------------------
+A fixture greps stdout for strings it expects. Nothing in that mechanism can
+tell a fixture that prints the right strings for the right reason from one that
+prints them for the wrong reason — a script hardcoding its own expected output
+passes identically. The mutation control is the whole difference: remove the
+pathology, and the fixture must go red.
+
+So a fixture that passes BOTH mutated and unmutated proves nothing, and finding
+those is the most valuable output here. They are reported, never repaired — a
+red row with a diagnosis is worth more than a green one somebody engineered.
+
+WHAT THIS DELIBERATELY DOES NOT DO
+----------------------------------
+It does not judge whether a fixture asserts the RIGHT thing. It cannot. Recent
+passes found a DUNE fixture printing `zero_pressure_entry_claim_not_reproduced`
+when the claim IS reproduced (its mask sliced the wrong leg of an interpolation),
+and a skfem fixture printing `free_boundary_leaves_zero_immediately=True` while
+its own next line printed `max_over_run=0.0` — because `np.argmax` returns 0 on
+an all-False array. Both pass. Both would be killed by their mutation, because
+the mutation flips the assertion either way. Only a person re-reading the probe
+catches that class, and pretending otherwise would be the same error one level
+up from the one this project exists to fix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+
+# The interpreter each backend's fixtures need. Getting this wrong does not
+# produce an error — it produces a SKIP that reads as green, which is exactly
+# the failure this ledger exists to stop. DUNE is the sharp case: with
+# DUNE_PYTHON unset, every DUNE fixture skips silently.
+INTERPRETERS = {
+    "skfem": os.environ.get("SKFEM_PYTHON",
+                            "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python"),
+    "ngsolve": os.environ.get("NGSOLVE_PYTHON",
+                              "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python"),
+    "kratos": os.environ.get("KRATOS_PYTHON", "/usr/bin/python3"),
+    "dune": os.environ.get("DUNE_PYTHON", ""),
+    "fenics": os.environ.get("FENICS_PYTHON", ""),
+    "sparta": os.environ.get("SPARTA_PYTHON",
+                             "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python"),
+    "febio": os.environ.get("FEBIO_PYTHON",
+                            "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python"),
+    "coupling": os.environ.get("COUPLING_PYTHON",
+                               "/home/alexander/Schreibtisch/open-fem-agent/.venv/bin/python"),
+}
+
+
+def claim_key(spec: dict) -> str:
+    """The claim a fixture defends. Keyed by claim, never by fixture name.
+
+    Fixture names drift and collide: `elasticity_mms_convergence` exists under
+    four backends, and the current results file keys by name, so eleven distinct
+    runs collapsed into three rows and whichever backend ran last is the one the
+    record describes.
+    """
+    covers = spec.get("covers")
+    if isinstance(covers, list) and covers:
+        return ",".join(sorted(str(c) for c in covers))
+    physics, idx = spec.get("physics"), spec.get("pitfall_index")
+    if physics is not None and idx is not None:
+        return f"{physics}:{idx}"
+    return "(unkeyed)"
+
+
+def claim_text_hash(backend: str, spec: dict) -> str:
+    """Hash of the warning text, so a row is invalidated when it is reworded.
+
+    Without this the ledger silently certifies a claim whose wording — and
+    therefore whose meaning — has changed since the run. Returns "" when the
+    warning cannot be resolved, which is itself worth recording.
+    """
+    physics, idx = spec.get("physics"), spec.get("pitfall_index")
+    if physics is None or idx is None:
+        return ""
+    try:
+        sys.path.insert(0, str(REPO / "src"))
+        from core.registry import get_backend, load_all_backends
+        load_all_backends()
+        be = get_backend(backend)
+        k = be.get_knowledge(str(physics)) if be else None
+        pit = (k or {}).get("pitfalls") or []
+        if 0 <= int(idx) < len(pit):
+            return hashlib.sha256(pit[int(idx)].encode()).hexdigest()[:16]
+    except Exception:
+        pass
+    return ""
+
+
+def _load_shared_matcher():
+    """Import the runner's matcher so there is exactly ONE definition of 'present'.
+
+    There used to be two, and they disagreed. The runner lowercases both sides;
+    this file compared raw strings. So a fixture whose probe printed
+    `space_has_Nedelec=False` against an expectation of `space_has_nedelec=False`
+    passed the runner and failed the ledger — same fixture, same output, two
+    verdicts. Whichever number got quoted was the one that happened to be run.
+
+    The runner is the authority: it is what the merge gate calls, and its rule
+    (case-insensitive, with a value boundary on `key=value` expectations) is the
+    stricter of the two on the axis that actually spoofs — value prefixes —
+    while being the more forgiving one on capitalisation, which spoofs nothing.
+
+    Degrades loudly rather than crashing when the runner is older than this
+    file: agents copy this ledger between worktrees, and a worktree whose branch
+    predates the matcher fix has no `_needle_present`. An ImportError there would
+    kill a multi-hour sweep at minute zero, so the fallback is the old plain
+    substring rule with a banner saying which rule produced the numbers.
+    """
+    import importlib.util
+    p = REPO / "scripts" / "run_tier2_fixtures.py"
+    try:
+        spec = importlib.util.spec_from_file_location("run_tier2_fixtures", p)
+        mod = importlib.util.module_from_spec(spec)
+        # Registered under its REAL name for two reasons: dataclasses resolve
+        # annotations through sys.modules, and mutate_tier2_fixtures.py does
+        # `from run_tier2_fixtures import _eval_fixture` — seeding the name here
+        # means it gets THIS hardened runner instead of loading a second copy.
+        sys.modules["run_tier2_fixtures"] = mod
+        spec.loader.exec_module(mod)
+        return mod._needle_present, mod
+    except (AttributeError, OSError, ImportError) as exc:
+        print(f"!! {p} has no hardened matcher ({type(exc).__name__}); falling "
+              f"back to PLAIN SUBSTRING matching. Value-prefix spoofs "
+              f"(key=1 matching key=10) are NOT caught in this run.",
+              file=sys.stderr)
+        return (lambda needle, low: needle.lower() in low), None
+
+
+_needle_present, _RUNNER = _load_shared_matcher()
+
+
+def _load_mutation_checker():
+    """The recipe-driven mutation checker, or None.
+
+    Two different things are both called "the mutation control", and conflating
+    them is why 354 of 395 4C fixtures looked like they proved nothing:
+
+      * an **env branch** — the fixture's own source reads `T2_MUTATE` and
+        removes the pathology itself. Running it again with the variable set is
+        the whole control.
+      * a **declared recipe** — a `_mutation` block naming a file and a from/to
+        substitution. `T2_MUTATE=1` does nothing for these: the recipe has to be
+        APPLIED, in a staged copy, by mutate_tier2_fixtures.py.
+
+    This ledger previously ran only the first kind and treated the second as if
+    it were the first, so 354 fixtures ran byte-identically twice and were
+    recorded PASS/PASS. They were never vacuous — they were never mutated.
+    """
+    import importlib.util
+    for cand in (REPO / "scripts" / "mutate_tier2_fixtures.py",
+                 FIXTURES.parent / "mutate_tier2_fixtures.py"):
+        if not cand.is_file():
+            continue
+        try:
+            spec = importlib.util.spec_from_file_location("_t2mut", cand)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["_t2mut"] = mod
+            spec.loader.exec_module(mod)
+            return mod.check_one
+        except Exception as exc:
+            print(f"!! could not load {cand}: {exc}", file=sys.stderr)
+    return None
+
+
+def evaluate(out: str, spec: dict) -> tuple[bool, list[str]]:
+    """The runner's own rule: every expect present, no forbid present."""
+    low = out.lower()
+    missing = [e for e in (spec.get("expect_in_output") or [])
+               if not _needle_present(str(e), low)]
+    # Forbidden strings stay plain substring, matching the runner: a tripwire
+    # should fire on the widest reading.
+    hit = [f for f in (spec.get("forbid_in_output") or [])
+           if str(f).lower() in low]
+    return (not missing and not hit), missing + [f"FORBIDDEN:{f}" for f in hit]
+
+
+def run_one(d: Path, backend: str, mutate: bool, timeout: int) -> dict:
+    spec = json.loads((d / "fixture.json").read_text())
+    interp = INTERPRETERS.get(backend, "")
+    src = d / "source.py"
+    cmd_sh = d / "cmd.sh"
+
+    if cmd_sh.is_file():
+        cmd = ["bash", str(cmd_sh)]
+    elif src.is_file():
+        if not interp:
+            return {"status": "SKIPPED",
+                    "reason": f"no interpreter configured for {backend} — set "
+                              f"{backend.upper()}_PYTHON. A missing interpreter "
+                              f"is NOT a pass."}
+        cmd = [interp, str(src)]
+    else:
+        return {"status": "SKIPPED", "reason": "no runnable artefact"}
+
+    env = dict(os.environ)
+    if mutate:
+        env["T2_MUTATE"] = "1"
+    t0 = time.time()
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, cwd=str(d),
+                           timeout=timeout, env=env, stdin=subprocess.DEVNULL)
+        out = (p.stdout or "") + (p.stderr or "")
+        ok, why = evaluate(out, spec)
+        return {"status": "PASS" if ok else "FAIL", "rc": p.returncode,
+                "seconds": round(time.time() - t0, 1),
+                "missing": why[:4]}
+    except subprocess.TimeoutExpired:
+        return {"status": "TIMEOUT", "seconds": timeout}
+    except OSError as exc:
+        return {"status": "ERROR", "reason": str(exc)[:120]}
+
+
+def control_kind(d: Path, spec: dict) -> str | None:
+    """Which KIND of mutation control this fixture carries: "env", "recipe", None.
+
+    The env branch is checked first. A fixture may carry both, and when it does
+    the in-source branch is the one its author wired to run.
+    """
+    for f in d.iterdir():
+        if f.is_file() and f.suffix in (".py", ".sh", ".cpp", ".cc"):
+            try:
+                if "T2_MUTATE" in f.read_text(errors="ignore"):
+                    return "env"
+            except OSError:
+                pass
+    if spec.get("_mutation") or spec.get("mutations"):
+        return "recipe"
+    return None
+
+
+def run_recipe_mutation(d: Path, check_one) -> dict:
+    """Apply the declared from/to recipe and report whether it killed the fixture.
+
+    Translated into the same vocabulary as the env-branch arm so both kinds land
+    in one column. The distinctions that must NOT collapse into "pass":
+
+      * FROM_NOT_FOUND — the recipe's anchor text is no longer in the file. The
+        substitution silently does nothing, so the fixture "survives" a mutation
+        that never happened. This is rot, and it reads exactly like a fixture
+        that fails to discriminate unless it is named separately.
+      * VACUOUS_BASELINE — the fixture does not even pass unmutated in the
+        staged copy, so no verdict about the mutation means anything.
+    """
+    if check_one is None:
+        return {"status": "NO_MUTATION_TOOL",
+                "reason": "mutate_tier2_fixtures.py not found; declared "
+                          "recipes could not be applied — NOT a pass"}
+    try:
+        row = check_one(d)
+    except Exception as exc:
+        return {"status": "ERROR", "reason": f"{type(exc).__name__}: {exc}"[:160]}
+
+    verdict = row.get("verdict")
+    if verdict == "KILLED":
+        # Killed by its own antidote == the mutated run failed, which is what
+        # "discriminates" means for the env arm too.
+        return {"status": "FAIL", "detail": "recipe killed the fixture"}
+    if verdict == "VACUOUS_BASELINE":
+        return {"status": "VACUOUS_BASELINE",
+                "reason": row.get("baseline_status", ""),
+                "notes": row.get("baseline_notes", [])}
+    if verdict == "NOT_MUTABLE_DECLARED":
+        # A `_mutation` block with a reason and no from/to: the author declared
+        # that no faithful mutation exists. It must NOT be credited as
+        # discriminating, and it must not be reported as having "survived its
+        # own antidote" either — it never had one, and the two are different
+        # facts about the fixture.
+        return {"status": "NOT_MUTABLE_DECLARED",
+                "reason": row.get("note", "")[:300]}
+    stale = [r for r in row.get("results", [])
+             if r.get("status") in ("FROM_NOT_FOUND", "TARGET_MISSING")]
+    if stale:
+        return {"status": "MUTATION_STALE",
+                "reason": f"{len(stale)} recipe step(s) no longer match the "
+                          f"fixture: {stale[0].get('status')}",
+                "detail": stale[0]}
+    return {"status": "PASS", "detail": "survived its own antidote"}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("backends", nargs="*", help="default: all present")
+    ap.add_argument("--fixtures", default=None, metavar="DIR",
+                    help="fixture root to run instead of this worktree's. The "
+                         "campaign fixtures live on the branch that built them, "
+                         "so the ledger has to reach across worktrees; copying "
+                         "the scripts in instead leaves untracked files behind "
+                         "for the consolidation merge to trip over.")
+    ap.add_argument("--timeout", type=int, default=300)
+    ap.add_argument("--no-mutation", action="store_true",
+                    help="skip the mutation half (faster, halves the evidence)")
+    ap.add_argument("--out", default=str(REPO / "data" / "execution_ledger.json"))
+    args = ap.parse_args()
+
+    global FIXTURES
+    if args.fixtures:
+        FIXTURES = Path(args.fixtures).resolve()
+        if not FIXTURES.is_dir():
+            print(f"no such fixture root: {FIXTURES}")
+            return 2
+
+    # Stamp the commit of the tree the FIXTURES came from, not the tree this
+    # script lives in. With --fixtures those differ, and recording the script's
+    # sha would attribute every result to the wrong branch.
+    prov = FIXTURES.parent.parent
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(prov),
+                         capture_output=True, text=True).stdout.strip()[:12]
+    dirty = bool(subprocess.run(["git", "status", "--porcelain"], cwd=str(prov),
+                                capture_output=True, text=True).stdout.strip())
+
+    CHECK_ONE = _load_mutation_checker()
+    if CHECK_ONE is None:
+        print("!! mutate_tier2_fixtures.py not found — fixtures whose control "
+              "is a DECLARED RECIPE cannot be exercised. They are recorded "
+              "NO_MUTATION_TOOL, never PASS.", file=sys.stderr)
+
+    names = args.backends or sorted(p.name for p in FIXTURES.iterdir()
+                                    if p.is_dir())
+    rows = []
+    for backend in names:
+        be = FIXTURES / backend
+        if not be.is_dir():
+            continue
+        for d in sorted(be.iterdir()):
+            if not (d / "fixture.json").is_file():
+                continue
+            spec = json.loads((d / "fixture.json").read_text())
+            row = {"backend": backend, "fixture": d.name,
+                   "claim": claim_key(spec),
+                   "claim_text_sha": claim_text_hash(backend, spec),
+                   "commit": sha, "tree_dirty": dirty,
+                   "recorded": datetime.now(timezone.utc).isoformat(timespec="seconds")}
+            row["unmutated"] = run_one(d, backend, False, args.timeout)
+            kind = control_kind(d, spec)
+            row["control"] = kind or "none"
+            if args.no_mutation or kind is None:
+                row["mutated"] = {"status": "NO_CONTROL"}
+                row["discriminates"] = None
+            elif kind == "env":
+                row["mutated"] = run_one(d, backend, True, args.timeout)
+                mst = row["mutated"]["status"]
+                # The verdict that matters: green unmutated AND red mutated.
+                #
+                # "Red" means FAIL — the fixture ran and its assertions did not
+                # hold. It does NOT mean TIMEOUT or ERROR. Crediting those was
+                # an overcount: a sweep found five rows whose entire claim to
+                # discriminating rested on the mutated run being killed by the
+                # clock, which says nothing about whether the mutation was
+                # detected. A fixture slow enough to time out under mutation
+                # would earn the same credit if its assertion were absent.
+                row["discriminates"] = (
+                    True if (row["unmutated"]["status"] == "PASS"
+                             and mst == "FAIL")
+                    else False if mst == "PASS"
+                    else None)
+            else:
+                row["mutated"] = run_recipe_mutation(d, CHECK_ONE)
+                st = row["mutated"]["status"]
+                # Only FAIL earns credit. A stale recipe, a vacuous baseline or
+                # a missing tool are all "we do not know", recorded as None so
+                # they can never be counted as either evidence or a defect.
+                row["discriminates"] = (
+                    True if (row["unmutated"]["status"] == "PASS"
+                             and st == "FAIL")
+                    else False if st == "PASS"
+                    else None)
+            rows.append(row)
+            print(f"  {backend}/{d.name[:44]:<46} "
+                  f"{row['unmutated']['status']:<8} "
+                  f"mut={row['mutated']['status']}", flush=True)
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"commit": sha, "tree_dirty": dirty,
+                               "rows": rows}, indent=2))
+
+    passed = sum(1 for r in rows if r["unmutated"]["status"] == "PASS")
+    disc = sum(1 for r in rows if r["discriminates"] is True)
+    both = [r for r in rows if r["discriminates"] is False]
+    import collections as _c
+    unknown = _c.Counter(r["mutated"]["status"] for r in rows
+                         if r["discriminates"] is None)
+    print(f"\n=== LEDGER  commit {sha}{' (DIRTY TREE)' if dirty else ''} ===")
+    print(f"  {passed} of {len(rows)} fixtures pass")
+    print(f"  {disc} of {len(rows)} discriminate (green unmutated, red mutated)")
+    if both:
+        print(f"\n  {len(both)} PASS BOTH WAYS — these prove nothing:")
+        for r in both[:12]:
+            print(f"     {r['backend']}/{r['fixture']}")
+    if unknown:
+        print(f"\n  {sum(unknown.values())} give NO VERDICT (not evidence, "
+              f"not a defect — they did not run a real mutation):")
+        for st, n in unknown.most_common():
+            print(f"     {n:>5}  {st}")
+    print(f"\n  written to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mutate_tier2_fixtures.py
+++ b/scripts/mutate_tier2_fixtures.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Prove each fixture goes RED when the pathology it tests is removed.
+
+A tier-2 fixture that passes whether or not the pitfall is present is
+decoration. The only way to know is to remove the pathology and watch the
+fixture fail — and the only way for a reader to know is for that removal to be
+recorded next to the fixture and re-runnable.
+
+So a fixture declares its own antidote::
+
+    "_mutation": {
+      "note": "write the CORRECT element category, so the diagnostic vanishes",
+      "file": "cmd.sh",
+      "from": "SOLID QUAD4 1 2 3 4 MAT 1",
+      "to":   "ALE2 QUAD4 1 2 3 4 MAT 1"
+    }
+
+This script applies that substitution in a scratch copy of the fixture, runs it
+through the ordinary evaluator, and asserts the result is NOT ``passed``. The
+fixture itself is never modified.
+
+A list of mutations is allowed; each is applied in turn and each must kill the
+fixture on its own.
+
+Usage:
+    python scripts/mutate_tier2_fixtures.py [backend] [--fixture NAME] [--json OUT]
+
+Exit status is 0 only when every fixture that declares a mutation is killed by
+it, and no fixture is missing its declaration.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+sys.path.insert(0, str(REPO / "scripts"))
+
+from run_tier2_fixtures import _eval_fixture  # noqa: E402
+
+
+def _mutations(meta: dict) -> list[dict]:
+    m = meta.get("_mutation")
+    if m is None:
+        return []
+    return m if isinstance(m, list) else [m]
+
+
+def _stage(fixture_dir: Path, td: str) -> Path:
+    """Copy the fixture into a scratch tree that still resolves its siblings.
+
+    The first version copied ONLY the fixture directory. 174 of the 4C fixtures
+    begin with
+
+        . "$(dirname "$0")/../_lib/preamble.sh"
+
+    and that path is one level ABOVE the fixture, so in the scratch tree it did
+    not exist: the preamble never loaded, `run4c` and `upstream` were undefined
+    and the copy could not run at all. Both the unmutated and the mutated copy
+    then failed, and this script recorded KILLED — the same verdict a real
+    detection produces. It would have reported KILLED for a no-op mutation just
+    as readily, which makes the whole verdict worthless exactly where it is
+    supposed to carry the weight.
+
+    Worse than a bug: the preamble exists to STOP vacuous passes (it aborts with
+    FIXTURE_ABORT=no_binary so a missing solver turns a fixture red). A scoping
+    slip disabled the anti-vacuity machinery inside the tool whose only job is to
+    prove fixtures are not vacuous.
+
+    So the parent directory layout is preserved and every shared sibling — any
+    directory whose name starts with `_` — is copied alongside.
+    """
+    parent = Path(td) / fixture_dir.parent.name
+    parent.mkdir(parents=True, exist_ok=True)
+    work = parent / fixture_dir.name
+    shutil.copytree(fixture_dir, work)
+    for sib in fixture_dir.parent.iterdir():
+        if sib.is_dir() and sib.name.startswith("_"):
+            shutil.copytree(sib, parent / sib.name, dirs_exist_ok=True)
+    return work
+
+
+def check_one(fixture_dir: Path) -> dict:
+    meta = json.loads((fixture_dir / "fixture.json").read_text())
+    muts = _mutations(meta)
+    row = {"fixture": f"{fixture_dir.parent.name}/{fixture_dir.name}",
+           "declared": len(muts), "killed": 0, "results": []}
+    if not muts:
+        row["verdict"] = "NO_MUTATION_DECLARED"
+        return row
+
+    # A `_mutation` block with a `note` and NO `from` is a DECLARATION that the
+    # fixture cannot be mutated faithfully — DUNE's helmholtz_indefinite_no_
+    # diagnostic is the reference case: its claim is that the solver's report is
+    # uninformative, which is true at every wavenumber, so the pathology cannot
+    # be removed from outside.
+    #
+    # Without this branch such a block was scored SURVIVED, because an empty
+    # `from` is "in" every text, `str.replace("", "")` is a no-op, and the
+    # unchanged copy passes. SURVIVED is the verdict for a mutation that failed
+    # to kill — the opposite of what the author declared — so an honest
+    # admission read as a defect and, worse, an author who wanted a green run
+    # had an incentive to invent a fake control instead.
+    if all("from" not in m for m in muts):
+        row["verdict"] = "NOT_MUTABLE_DECLARED"
+        row["note"] = str(muts[0].get("note", ""))[:400]
+        return row
+
+    # ── vacuity precheck ────────────────────────────────────────────────
+    # Run the UNMUTATED copy in the scratch tree first. If it does not pass
+    # there, every mutant will "fail" for reasons that have nothing to do with
+    # the mutation, and a KILLED verdict would mean only that nothing ran. A
+    # harness that cannot tell detection from silence is not evidence.
+    with tempfile.TemporaryDirectory() as td:
+        base = _stage(fixture_dir, td)
+        r0 = _eval_fixture(base, meta)
+        if r0.status != "passed":
+            row["verdict"] = "VACUOUS_BASELINE"
+            row["baseline_status"] = r0.status
+            row["baseline_notes"] = [n[:200] for n in r0.notes[:2]]
+            return row
+
+    for i, mut in enumerate(muts):
+        target = mut.get("file") or ("cmd.sh" if (fixture_dir / "cmd.sh").is_file()
+                                     else "source.py")
+        frm, to = mut.get("from", ""), mut.get("to", "")
+        with tempfile.TemporaryDirectory() as td:
+            work = _stage(fixture_dir, td)
+            p = work / target
+            if not p.is_file():
+                row["results"].append({"i": i, "status": "TARGET_MISSING",
+                                       "target": target})
+                continue
+            text = p.read_text()
+            if frm not in text:
+                row["results"].append({"i": i, "status": "FROM_NOT_FOUND",
+                                       "from": frm[:80]})
+                continue
+            n = text.count(frm)
+            p.write_text(text.replace(frm, to))
+            r = _eval_fixture(work, meta)
+            killed = r.status != "passed"
+            row["killed"] += int(killed)
+            row["results"].append({
+                "i": i, "occurrences_replaced": n,
+                "mutant_status": r.status,
+                "killed": killed,
+                "note": mut.get("note", ""),
+                "missing": [nt for nt in r.notes if "missing in output" in nt][:1],
+            })
+    row["verdict"] = ("KILLED" if row["killed"] == len(muts) and muts
+                      else "SURVIVED")
+    return row
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("backend", nargs="?", default=None)
+    ap.add_argument("--fixture", default=None)
+    ap.add_argument("--json", default=None)
+    args = ap.parse_args()
+
+    dirs = sorted(p.parent for p in FIXTURES.glob("*/*/fixture.json"))
+    if args.backend:
+        dirs = [d for d in dirs if d.parent.name == args.backend]
+    if args.fixture:
+        dirs = [d for d in dirs if d.name == args.fixture]
+
+    rows = []
+    bad = 0
+    for d in dirs:
+        row = check_one(d)
+        rows.append(row)
+        glyph = {"KILLED": "✓", "SURVIVED": "✗",
+                 "VACUOUS_BASELINE": "∅",
+                 "NOT_MUTABLE_DECLARED": "≡",
+                 "NO_MUTATION_DECLARED": "—"}[row["verdict"]]
+        print(f"  {glyph} {row['fixture']}: {row['verdict']}", flush=True)
+        if row["verdict"] == "NOT_MUTABLE_DECLARED":
+            print(f"      {row.get('note', '')}")
+        if row["verdict"] == "VACUOUS_BASELINE":
+            print(f"      unmutated copy did not pass in the scratch tree "
+                  f"({row.get('baseline_status')}); the mutation verdict would "
+                  f"mean nothing")
+            for n_ in row.get("baseline_notes", []):
+                print(f"      {n_}")
+        for r in row["results"]:
+            if not r.get("killed", False):
+                print(f"      arm {r['i']}: {r.get('status', r.get('mutant_status'))}"
+                      f" {r.get('from', '')}")
+        # A declared non-mutable fixture is not a failure — it is the honest
+        # outcome the gate asks for. It is counted separately and printed so the
+        # number stays visible; a corpus where that number grows is a corpus
+        # quietly opting out.
+        if row["verdict"] not in ("KILLED", "NOT_MUTABLE_DECLARED"):
+            bad += 1
+
+    n = len(rows)
+    killed = sum(1 for r in rows if r["verdict"] == "KILLED")
+    surv = sum(1 for r in rows if r["verdict"] == "SURVIVED")
+    vac = sum(1 for r in rows if r["verdict"] == "VACUOUS_BASELINE")
+    nod = sum(1 for r in rows if r["verdict"] == "NO_MUTATION_DECLARED")
+    nom = sum(1 for r in rows if r["verdict"] == "NOT_MUTABLE_DECLARED")
+    print(f"\nmutation-killed {killed}/{n};  survived {surv};  "
+          f"vacuous baseline {vac};  declared not mutable {nom};  "
+          f"no mutation declared {nod}")
+    if args.json:
+        Path(args.json).write_text(json.dumps(rows, indent=1))
+    return 0 if bad == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_tier2_fixtures.py
+++ b/scripts/run_tier2_fixtures.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -51,16 +52,168 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURES_DIR = REPO_ROOT / "scripts" / "tier2_fixtures"
 OUTPUT = REPO_ROOT / "scripts" / "scan_results" / "tier2_results.json"
 
-# Prefer the Debug-built deal.II at ~/Schreibtisch/dealii-debug
-# (Assert macros enabled — unlocks the Assert-gated Signal families
-# like ExcDimensionMismatch). Falls back to the conda Release install
-# (~/miniconda3/envs/ofa-dealii) which leaves Assert as a no-op.
-_DEBUG_PREFIX = Path.home() / "Schreibtisch" / "dealii-debug"
-_RELEASE_PREFIX = Path.home() / "miniconda3" / "envs" / "ofa-dealii"
-DEFAULT_DEALII_PREFIX = (
-    _DEBUG_PREFIX if (_DEBUG_PREFIX / "lib" / "libdeal_II.g.so").is_file()
-    else _RELEASE_PREFIX
-)
+
+# A `key=value` expectation must match the WHOLE value, not a prefix of it.
+#
+# The matcher is plain case-insensitive substring, so `same_name_files=1` stayed
+# matched when the fixture's own mutation turned the value into `10`. A DUNE pass
+# found that live and named two more of the same shape
+# (`umfpack_linear_iterations=1`, `k10_linear_iterations=1`); both survive only
+# because a boolean guard happens to sit beside the number. Measured across the
+# corpus, 2931 expectations have the `key=<int>` form and are prefixes of any
+# longer value.
+#
+# Fixing 2931 strings would be the wrong repair — the defect is in the matcher.
+# So for a needle that looks like an assertion (`key=value`, no spaces), the
+# character following the match must not continue the value: end of output, a
+# newline, a space, or punctuation is fine; another digit or letter is not.
+# Everything else — prose fragments, quoted diagnostics, multi-word phrases —
+# keeps plain substring matching, which is what those need.
+_ASSERTION = re.compile(r"^[A-Za-z_][\w.\[\]]*=\S+$")
+
+
+def _needle_present(needle: str, low_out: str) -> bool:
+    """True if `needle` appears in `low_out` without being truncated."""
+    low = needle.lower()
+    if not _ASSERTION.match(needle.strip()):
+        return low in low_out
+    start = 0
+    while True:
+        i = low_out.find(low, start)
+        if i == -1:
+            return False
+        j = i + len(low)
+        # The KEY must start where the needle starts. Guarding only the right
+        # edge left the mirror-image hole open: a needle that is a SUFFIX of a
+        # longer key matched that longer key's line, so an expectation could be
+        # satisfied by a sibling expectation it never mentions.
+        #
+        #     masked_max=1.000000            matched  unmasked_max=1.000000
+        #     displacement_criterion_satisfied=true   matched
+        #         tight_gamma_displacement_criterion_satisfied=true
+        #
+        # 11 expectations in the corpus were guaranteed true this way, including
+        # both control expectations of dune/unmasked_ds_flux_covers_whole_boundary
+        # — whose own docstring says the mutation drives unmasked_max to
+        # 1.000000, which then satisfies the masked_max control. Same defect as
+        # the value-prefix one this function was written to fix, one character to
+        # the left.
+        if i > 0 and (low_out[i - 1].isalnum() or low_out[i - 1] == "_"):
+            start = i + 1
+            continue
+        # A value continues only through word characters, a dot, or a sign;
+        # anything else (newline, space, comma, quote, EOF) ends it.
+        if j >= len(low_out) or not (low_out[j].isalnum()
+                                     or low_out[j] in "._-+"):
+            return True
+        start = i + 1
+
+def fixture_inventory_fingerprint() -> str:
+    """Identity of the fixture set: which fixtures exist and what they contain.
+
+    Deliberately NOT a claim about whether they pass — it records what was
+    summarised, so a summary can be told apart from a stale one. Every file in
+    every fixture directory is hashed, so editing a fixture's expectation or its
+    source counts as a change, not just adding or deleting one.
+    """
+    import hashlib
+
+    h = hashlib.sha256()
+    for d in sorted(p.parent for p in FIXTURES_DIR.glob("*/*/fixture.json")):
+        h.update(f"{d.parent.name}/{d.name}\n".encode())
+        for f in sorted(d.iterdir()):
+            if f.is_file():
+                h.update(f.name.encode())
+                h.update(hashlib.sha256(f.read_bytes()).digest())
+    return h.hexdigest()
+
+# Which deal.II do the deal.II fixtures compile against?
+#
+# Prefer a DEBUG build wherever one exists, because Assert is compiled out in
+# Release and the Assert-gated Signal families (ExcDimensionMismatch,
+# ExcInvalidFEIndex, ExcDivideByZero, …) simply cannot be produced by a Release
+# library. A fixture asserting such a Signal against a Release deal.II is not
+# testing anything.
+#
+# This used to be two hard-coded paths from one developer's machine
+# (~/Schreibtisch/dealii-debug and ~/miniconda3/envs/ofa-dealii). Neither
+# exists on this host, and the consequence was not an error but a SKIP: every
+# deal.II fixture reported "install root not present", which reads identically
+# to "no deal.II here" on a machine that has two working builds.
+#
+# TWO BRANCHES FIXED THIS INDEPENDENTLY AND BOTH FIXES ARE KEPT:
+#   knowledge/dealii-verify        replaced each single path with a CANDIDATE
+#                                  LIST probed by the library file itself, and
+#                                  found the real build locations on this host.
+#   knowledge/setup-and-portability delegated to the deal.II BACKEND's own
+#                                  discovery — the same code path the MCP
+#                                  server uses, so the fixtures and the server
+#                                  cannot disagree about which install is in
+#                                  play.
+# Order: explicit env override, then a Debug build from the candidate list,
+# then the backend's own discovery, then the Release candidates, then the
+# historical guesses.
+def _first_existing(cands, marker) -> Optional[Path]:
+    for c in cands:
+        try:
+            if (Path(c) / marker).is_file():
+                return Path(c)
+        except OSError:
+            continue
+    return None
+
+
+_DEBUG_CANDIDATES = [
+    os.environ.get("DEAL_II_DEBUG_DIR", ""),
+    Path.home() / "Schreibtisch" / "dealii-debug",
+    Path("/media/alexander/PortableSSD/dealii-verify-r2/dbgbuild"),
+    Path.home() / "dealii" / "dbgbuild",
+]
+_RELEASE_CANDIDATES = [
+    os.environ.get("DEAL_II_DIR", ""),
+    Path.home() / "dealii" / "build",
+    Path.home() / "dealii" / "install",
+    Path.home() / "miniconda3" / "envs" / "ofa-dealii",
+]
+# A build tree keeps its package config under cmake/config/, an install tree
+# under lib/cmake/deal.II/ — accept either, and key the Debug probe on the
+# debug library itself since that is what Assert needs.
+_DEBUG_PREFIX = (_first_existing(_DEBUG_CANDIDATES, "lib/libdeal_II.g.so")
+                 or Path.home() / "Schreibtisch" / "dealii-debug")
+_RELEASE_PREFIX = (
+    _first_existing(_RELEASE_CANDIDATES, "lib/libdeal_II.so")
+    or _first_existing(_RELEASE_CANDIDATES, "cmake/config/deal.IIConfig.cmake")
+    or Path.home() / "miniconda3" / "envs" / "ofa-dealii")
+
+
+def _has_debug_library(p: Path) -> bool:
+    return any((p / "lib").glob("libdeal_II.g.so*")) or \
+        any((p / "lib").glob("libdeal.ii.g.so*"))
+
+
+def _discover_dealii_prefix() -> Path:
+    env = os.environ.get("DEALII_PREFIX") or os.environ.get("DEAL_II_DIR")
+    if env and Path(env).is_dir():
+        return Path(env)
+    if _has_debug_library(_DEBUG_PREFIX):
+        return _DEBUG_PREFIX
+    try:
+        sys.path.insert(0, str(REPO_ROOT / "src"))
+        from backends.dealii.backend import _find_dealii  # type: ignore
+        found = _find_dealii()
+        if found is not None:
+            # A source tree keeps its libraries under build/.
+            for candidate in (Path(found) / "build", Path(found)):
+                if candidate.is_dir() and any(
+                        (candidate / "lib").glob("libdeal_II*.so*")):
+                    return candidate
+            return Path(found)
+    except Exception:
+        pass
+    return _RELEASE_PREFIX
+
+
+DEFAULT_DEALII_PREFIX = _discover_dealii_prefix()
 
 
 @dataclass
@@ -107,7 +260,13 @@ def _eval_fixture(fixture_dir: Path,
     key = f"{backend}::{physics}::{idx}"
     result = FixtureResult(
         key=key, backend=backend, physics=physics,
-        pitfall_index=idx, fixture_id=fixture_dir.name,
+        # BACKEND-QUALIFIED. The bare directory name is not unique across the
+        # tree — elasticity_mms_convergence, poisson_mms_convergence and
+        # stokes_mms_convergence each exist under several backends — and the
+        # results record is read row-wise by fixture_id, so a bare name made
+        # each backend's row overwrite the previous one's and ten runs
+        # collapsed to three. Qualifying it keeps every run its own row.
+        pitfall_index=idx, fixture_id=f"{backend}/{fixture_dir.name}",
         mode=mode,
     )
     expect = [str(s) for s in meta.get("expect_in_output", [])]
@@ -132,11 +291,17 @@ def _eval_fixture(fixture_dir: Path,
     if requires_debug and not has_debug_lib and backend == "dealii":
         result.status = "skipped"
         result.notes.append(
-            "fixture requires Debug-built deal.II at "
-            "~/Schreibtisch/dealii-debug (Assert macros enabled); "
-            "current install is Release-only — skip until rebuilt "
-            "(task #30)")
+            f"fixture requires a Debug-built deal.II (Assert macros live); "
+            f"none of {[str(c) for c in _DEBUG_CANDIDATES if c]} has "
+            f"lib/libdeal_II.g.so — set DEAL_II_DEBUG_DIR to one")
         return result
+    # Point the build at the Debug tree when the fixture asked for it, so
+    # `requires_debug` actually changes which library gets linked instead of
+    # merely gating the run. Without this the flag was a no-op whenever a
+    # Release install happened to be found first.
+    if requires_debug and has_debug_lib and backend == "dealii":
+        env.setdefault("DEAL_II_DIR", str(_DEBUG_PREFIX))
+        env["DEAL_II_DIR"] = str(_DEBUG_PREFIX)
 
     if mode == "compile_only" and backend == "dealii":
         prefix = Path(env.get("DEAL_II_DIR",
@@ -367,53 +532,176 @@ def _eval_fixture(fixture_dir: Path,
         python = sys.executable
         REPO_VENV = REPO_ROOT / ".venv" / "bin" / "python"
 
-        def _route_to_repo_venv(env_var: str, label: str) -> str | None:
-            cand = env.get(env_var) or (
-                str(REPO_VENV) if REPO_VENV.is_file() else None)
-            if cand and Path(cand).is_file():
+        def _route_to_repo_venv(env_var: str, label: str,
+                               probe_module: str = "") -> str | None:
+            """Find an interpreter that can run this backend's fixture.
+
+            The first version looked only at `$ENV_VAR` and `REPO_ROOT/.venv`.
+            That fails in every git worktree and in any clone whose environment
+            lives elsewhere: measured here, 96 of 108 fixtures skipped and the
+            run then OVERWROTE `tier2_results.json` with `passed: 1`. A sibling
+            audit hit the same thing from the other side, rewriting 112 to 6.
+
+            So the search now widens, cheapest first, and — the part that
+            actually matters — it CHECKS the candidate can import the package
+            instead of assuming a path implies a working environment.
+            """
+            def _readable_file(p) -> bool:
+                # `is_file()` RAISES PermissionError on a path whose parent is
+                # unreadable — it does not return False. Scanning sibling
+                # directories walked into one such venv and killed the whole
+                # run before a single fixture reported.
+                try:
+                    return Path(p).is_file()
+                except OSError:
+                    return False
+
+            candidates = [env.get(env_var),
+                          str(REPO_VENV) if _readable_file(REPO_VENV) else None]
+            # A sibling checkout's venv: worktrees share one environment, and
+            # REPO_ROOT is the worktree, not the checkout that owns the venv.
+            try:
+                siblings = sorted(REPO_ROOT.parent.iterdir())
+            except OSError:
+                siblings = []
+            for sibling in siblings:
+                try:
+                    if sibling.is_dir():
+                        candidates.append(
+                            str(sibling / ".venv" / "bin" / "python"))
+                except OSError:
+                    continue
+            # The interpreter running this script, last: if it can import the
+            # package it is as good as any path we could guess.
+            candidates.append(sys.executable)
+
+            for cand in candidates:
+                if not cand or not _readable_file(cand):
+                    continue
+                if probe_module:
+                    try:
+                        probe = subprocess.run(
+                            [cand, "-c", f"import {probe_module}"],
+                            capture_output=True, timeout=120,
+                            stdin=subprocess.DEVNULL)
+                    except (OSError, subprocess.SubprocessError):
+                        continue
+                    if probe.returncode != 0:
+                        continue
                 return cand
+
             result.status = "skipped"
             result.notes.append(
-                f"{label} env python not found; set "
-                f"{env_var} or install repo .venv (task #18)")
+                f"{label}: no interpreter found that can import "
+                f"{probe_module or 'the package'}; set {env_var} to one")
             return None
 
-        if backend == "fenics":
-            cand = (env.get("FENICS_PYTHON")
-                    or str(Path.home() / "miniconda3" / "envs"
-                           / "ofa-fenicsx" / "bin" / "python"))
-            if Path(cand).is_file():
-                python = cand
-            else:
-                result.status = "skipped"
-                result.notes.append(
-                    "FEniCSx env python not found; set "
-                    "FENICS_PYTHON or install ofa-fenicsx conda env")
+        def _conda_python(env_var: str, env_names: list[str], label: str,
+                          probe_module: str) -> str | None:
+            """Find an interpreter for a conda-hosted backend.
+
+            The hard-coded env name (`ofa-fenicsx`, `ofa-dune`) is a GUESS,
+            and on this host it is wrong: the dolfinx env is called `fenics`
+            (plus `fenicsc` for the complex build). A wrong guess made every
+            fenics fixture report `skipped` — which a reader cannot tell apart
+            from "dolfinx is not installed". So: try the override, then each
+            known env name, then the running interpreter, and in every case
+            CHECK the candidate can import the package rather than inferring
+            that from the path.
+            """
+            cands = [env.get(env_var)]
+            for name in env_names:
+                cands.append(str(Path.home() / "miniconda3" / "envs" / name
+                                 / "bin" / "python"))
+                cands.append(str(Path.home() / "anaconda3" / "envs" / name
+                                 / "bin" / "python"))
+                cands.append(str(Path.home() / "mambaforge" / "envs" / name
+                                 / "bin" / "python"))
+            cands.append(sys.executable)
+            tried = []
+            for c in cands:
+                if not c:
+                    continue
+                try:
+                    if not Path(c).is_file():
+                        continue
+                except OSError:
+                    continue
+                tried.append(c)
+                try:
+                    probe = subprocess.run(
+                        [c, "-c", f"import {probe_module}"],
+                        capture_output=True, timeout=180,
+                        stdin=subprocess.DEVNULL)
+                except (OSError, subprocess.SubprocessError):
+                    continue
+                if probe.returncode == 0:
+                    return c
+            result.status = "skipped"
+            result.notes.append(
+                f"{label}: no interpreter found that can import "
+                f"{probe_module}; tried {tried or cands}; set {env_var}")
+            return None
+
+        # A cross_backend fixture is not a single-backend fixture, and its
+        # `backend` field does not say what it needs. All four are filed as
+        # `backend: kratos` "for runner-routing purposes" (their own _comment
+        # says so) because the kratos slot used to land in the repo .venv, which
+        # is where the MCP stack lives. That stopped being true: the kratos
+        # branch now PROBES `import KratosMultiphysics`, the repo venv's Kratos
+        # wheel fails on this host with `GLIBC_2.32 not found`, and the only
+        # interpreter that does import Kratos (/mnt/kratos-tier2/kv) has no
+        # `mcp`. So all four reported `skipped` — indistinguishable, to a
+        # reader, from "no Kratos installed here", while their recorded status
+        # stayed `passed` from an older run.
+        #
+        # They are routed like `coupling` instead, for the same reason: what
+        # they actually import is the MCP stack and the live registry. Probing
+        # `mcp` is the honest requirement; probing any one backend is a claim
+        # about what the fixture runs that is not true.
+        if fixture_dir.parent.name == "cross_backend":
+            cand = _route_to_repo_venv("OASIS_PYTHON", "OASiS server", "mcp")
+            if cand is None:
                 return result
+            python = cand
+        elif backend == "fenics":
+            cand = _conda_python("FENICS_PYTHON",
+                                 ["fenics", "ofa-fenicsx", "fenicsx",
+                                  "dolfinx"], "FEniCSx", "dolfinx")
+            if cand is None:
+                return result
+            python = cand
         elif backend == "dune":
-            cand = (env.get("DUNE_PYTHON")
-                    or str(Path.home() / "miniconda3" / "envs"
-                           / "ofa-dune" / "bin" / "python"))
-            if Path(cand).is_file():
-                python = cand
-            else:
-                result.status = "skipped"
-                result.notes.append(
-                    "DUNE-fem env python not found; set "
-                    "DUNE_PYTHON or install ofa-dune conda env")
+            cand = _conda_python("DUNE_PYTHON",
+                                 ["ofa-dune", "dune-fem-env", "dune311"],
+                                 "DUNE-fem", "dune.fem")
+            if cand is None:
                 return result
+            python = cand
         elif backend == "kratos":
-            cand = _route_to_repo_venv("KRATOS_PYTHON", "Kratos")
+            cand = _route_to_repo_venv("KRATOS_PYTHON", "Kratos", "KratosMultiphysics")
             if cand is None:
                 return result
             python = cand
         elif backend == "ngsolve":
-            cand = _route_to_repo_venv("NGSOLVE_PYTHON", "NGSolve")
+            cand = _route_to_repo_venv("NGSOLVE_PYTHON", "NGSolve", "ngsolve")
             if cand is None:
                 return result
             python = cand
         elif backend == "skfem":
-            cand = _route_to_repo_venv("SKFEM_PYTHON", "scikit-fem")
+            cand = _route_to_repo_venv("SKFEM_PYTHON", "scikit-fem", "skfem")
+            if cand is None:
+                return result
+            python = cand
+        elif backend == "coupling":
+            # A coupling fixture is not a single-backend fixture. It DRIVES
+            # several backends through the registered `couple` tool, so the
+            # interpreter it needs is one that can import the MCP stack — each
+            # participant is then launched in its own backend's interpreter, by
+            # the driver, exactly as a real coupling does it. Probing `mcp` is
+            # the honest requirement; probing any one backend would be a lie
+            # about what the fixture runs.
+            cand = _route_to_repo_venv("OASIS_PYTHON", "OASiS server", "mcp")
             if cand is None:
                 return result
             python = cand
@@ -450,9 +738,12 @@ def _eval_fixture(fixture_dir: Path,
     # Match expectations on captured output.
     low_out = out.lower()
     for needle in expect:
-        if needle.lower() in low_out:
+        if _needle_present(needle, low_out):
             result.expect_matched.append(needle)
     for needle in forbid:
+        # Forbidden strings keep PLAIN substring matching, deliberately. A
+        # forbid is a tripwire, and a tripwire should fire on the widest
+        # reading — if "Traceback" appears in any form we want the failure.
         if needle.lower() in low_out:
             result.forbid_violated.append(needle)
 
@@ -472,15 +763,29 @@ def _eval_fixture(fixture_dir: Path,
     return result
 
 
-def run() -> dict:
+def run(backend: str | None = None, fixture: str | None = None) -> dict:
+    """Evaluate the fixtures, optionally narrowed to one backend and/or one
+    fixture id.
+
+    The filters exist because a whole-tree run is now hours: the coupling
+    fixtures alone drive two solvers through tens to hundreds of iterations
+    each. Without them, checking one fixture means either running everything or
+    invoking its `source.py` by hand, and running it by hand bypasses the
+    routing and the expectation matching — which is to say it does not check
+    the fixture, only the script inside it.
+    """
     out_map: dict[str, dict] = {}
     if not FIXTURES_DIR.is_dir():
         return out_map
     for backend_dir in sorted(FIXTURES_DIR.iterdir()):
         if not backend_dir.is_dir():
             continue
+        if backend and backend_dir.name != backend:
+            continue
         for fixture_dir in sorted(backend_dir.iterdir()):
             if not fixture_dir.is_dir():
+                continue
+            if fixture and fixture_dir.name != fixture:
                 continue
             meta_path = fixture_dir / "fixture.json"
             if not meta_path.is_file():
@@ -529,9 +834,32 @@ def main():
     ap.add_argument(
         "--write-results", action="store_true",
         help="persist results to scan_results/tier2_results.json")
+    ap.add_argument(
+        "--backend", default=None,
+        help="only fixtures under scripts/tier2_fixtures/<backend>/")
+    ap.add_argument(
+        "--fixture", default=None,
+        help="only the fixture directory with this name")
     args = ap.parse_args()
 
-    results = run()
+    # A PARTIAL run must never become the whole-tree record. That is the same
+    # defect d17ac19 fixed from the other side: there, `--write-results` was
+    # parsed and never read, so any exploratory run silently replaced the
+    # snapshot. Adding filters re-opens it — `--backend coupling
+    # --write-results` would write 18 rows over 108 and the summary would read
+    # as a catastrophic regression. So the two are refused together.
+    if (args.backend or args.fixture) and args.write_results:
+        print("refusing to write results from a filtered run: the snapshot is "
+              "a whole-tree record, and 18 rows written over 108 reads as a "
+              "regression rather than as a partial run. Re-run without "
+              "--backend/--fixture to persist.")
+        return
+
+    results = run(backend=args.backend, fixture=args.fixture)
+    if not results:
+        where = " ".join(x for x in (args.backend, args.fixture) if x)
+        print(f"no fixtures matched {where!r}")
+        return
 
     summary = {
         "n_fixtures": len(results),
@@ -547,9 +875,29 @@ def main():
     print()
     print(f"Tier-2 summary: {summary}")
 
+    # `--write-results` was PARSED AND NEVER READ, so the write was
+    # unconditional and the flag was decoration. Every exploratory run destroyed
+    # the recorded snapshot: a DUNE audit reported it rewriting 112 passes to 6,
+    # and it overwrote 108 with 1 under me before I noticed. A summary that any
+    # incidental run can clobber is not a record.
+    if not args.write_results:
+        print("\nresults NOT written (pass --write-results to persist). "
+              f"Recorded snapshot at {OUTPUT.relative_to(REPO_ROOT)} is "
+              f"untouched.")
+        return
+
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(json.dumps({
         "summary": summary,
+        # Identity of the fixture set these results describe. Without it a
+        # committed snapshot cannot be told from a current one: an audit found
+        # `tier2_results.json` 18 commits stale, recording `passed: 113` on a
+        # host where 7 passed and 10 failed — and the floor test that reads it
+        # was green, including with the backend's binary hidden. The number
+        # travels with the repo, so every user gets our result reported as
+        # theirs. Comparing this fingerprint catches the fixture set having moved
+        # underneath a stale summary.
+        "fixture_fingerprint": fixture_inventory_fingerprint(),
         "results": results,
     }, indent=2))
     print(f"results written to "

--- a/tests/test_assembled_payload_is_clean.py
+++ b/tests/test_assembled_payload_is_clean.py
@@ -1,0 +1,155 @@
+"""Scan what the agent RECEIVES, not the files the text came from.
+
+`test_knowledge_not_contaminated.py` greps source files. An adversarial 4C audit
+showed why that is not enough: it measured **240 host absolute paths across
+48 of 48 served payloads** — `/home/alexander/4C/build/4C` 144 times, the venv
+interpreter 48, a host test-file path 48 — while the same sweep over
+`get_knowledge()` returned zero.
+
+Nothing was hidden. The paths live in an "Installed-version API reference" block
+that `prepare_simulation` appends AFTER the JSON, so a check that reads the
+knowledge dict cannot see them and a check that reads source files sees them
+without knowing they reach an agent. The audit's phrase for it was "wrong surface
+verified", and it applies to a guard I wrote.
+
+So this one drives the real tool and reads the assembled reply. It is the only
+check in the repo positioned where the agent stands.
+
+WHY HOST PATHS IN A SERVED PAYLOAD ARE A DEFECT, not untidiness: OASiS is going
+to be cloned and run by people whose machines are not this one. A payload that
+tells an agent the solver is at `/home/alexander/4C/build/4C` is confidently
+wrong everywhere else, and an agent that will not second-guess a served fact
+follows it. The fix is to describe how to LOCATE an install, not to record where
+one happened to be.
+"""
+from __future__ import annotations
+
+import functools
+import re
+
+import pytest
+
+# `/home/<user>/`, `/Users/<user>/`, `/media/<user>/` — a path rooted in one
+# person's account. `/usr`, `/opt` and `/tmp` are deliberately not matched: they
+# are system locations that are legitimately the same on another machine.
+_HOST_PATH = re.compile(r"(?:/home|/Users|/media)/[a-z][a-z0-9_.-]*/")
+
+# Naming a variable is how an agent is TOLD to find its own path, so a payload
+# that mentions one alongside a path is teaching rather than hard-coding.
+_TEACHES = re.compile(
+    r"FOURC_BINARY|FOURC_ROOT|FEBIO_BINARY|FENICS_PYTHON|KRATOS_ROOT"
+    r"|LD_LIBRARY_PATH|CONDA_DEFAULT_ENV|DEAL_II_DIR|VIRTUAL_ENV"
+    r"|environment variable|set (?:it|this) to|on this machine|your install")
+
+# A section that declares its paths to be local observations rather than facts.
+# Whole blocks need this, not a nearby window: the installed-API reference
+# carries its disclaimer once at the top and then lists paths for thousands of
+# characters, which is exactly the shape a proximity check gets wrong.
+_LOCAL_OBSERVATION = re.compile(
+    r"LOCAL OBSERVATIONS?|local observations?|not universal facts?"
+    r"|machine hosting this OASiS", re.I)
+
+
+@functools.lru_cache(maxsize=1)
+def _served():
+    """Every assembled `prepare_simulation` reply, generated once."""
+    from core.registry import get_backend, list_backends, load_all_backends
+    from tools import consolidated as C
+
+    load_all_backends()
+    captured = {}
+
+    class _Recorder:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    C.register_consolidated_tools(_Recorder())
+    prepare = captured["prepare_simulation"]
+
+    out = []
+    for entry in list_backends():
+        be = get_backend(entry["name"])
+        if not be:
+            continue
+        for p in be.supported_physics():
+            try:
+                out.append((entry["name"], p.name, prepare(entry["name"], p.name)))
+            except Exception as exc:
+                out.append((entry["name"], p.name, f"__ERROR__ {exc}"))
+    return tuple(out)
+
+
+def test_no_served_payload_hard_codes_a_host_path():
+    """The 4C finding, generalised to every backend.
+
+    A hit is allowed only where the payload is plainly teaching an agent how to
+    locate its own install — naming the environment variable, or saying "on this
+    machine". Anything else states one person's filesystem as fact.
+    """
+    offenders: list[str] = []
+    for backend, physics, text in _served():
+        # A block may declare up front that its paths are local observations.
+        # Everything until the next `## ` heading inherits that declaration —
+        # a nearby-window check cannot work, because the disclaimer sits at the
+        # top of a block whose paths run for thousands of characters.
+        labelled: list[tuple[int, int]] = []
+        for hm in re.finditer(r"^## .*$", text, re.M):
+            end = text.find("\n## ", hm.end())
+            end = len(text) if end == -1 else end
+            if _LOCAL_OBSERVATION.search(text[hm.start():min(end, hm.end() + 900)]):
+                labelled.append((hm.start(), end))
+
+        for m in _HOST_PATH.finditer(text):
+            if any(lo <= m.start() < hi for lo, hi in labelled):
+                continue
+            window = text[max(0, m.start() - 400):m.end() + 200]
+            if _TEACHES.search(window) or _LOCAL_OBSERVATION.search(window):
+                continue
+            offenders.append(
+                f"{backend}/{physics}: {text[m.start():m.start() + 70]!r}")
+    # Report per backend so the failure is actionable rather than a wall.
+    if offenders:
+        by_backend: dict[str, int] = {}
+        for o in offenders:
+            by_backend[o.split("/")[0]] = by_backend.get(o.split("/")[0], 0) + 1
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(by_backend.items()))
+    assert not offenders, (
+        f"served payloads state a host absolute path as fact ({summary}). This "
+        f"is what an agent receives, so it is wrong on every machine that is "
+        f"not this one. Describe how to locate the install — name the "
+        f"environment variable — instead of recording where it happens to "
+        f"be.\n  " + "\n  ".join(offenders[:12])
+        + (f"\n  ... and {len(offenders) - 12} more" if len(offenders) > 12 else ""))
+
+
+def test_the_guard_looks_at_more_than_the_knowledge_dict():
+    """Calibration, and the whole point of this file.
+
+    The 4C audit found 240 host paths in the assembled payloads and 0 in
+    `get_knowledge()`. If this test only ever saw the JSON it would agree with
+    the check it exists to supersede, so assert the assembled reply really is
+    larger than the knowledge block alone.
+    """
+    import json
+
+    from core.registry import get_backend
+
+    for backend, physics, text in _served():
+        if text.startswith("__ERROR__"):
+            continue
+        be = get_backend(backend)
+        try:
+            k = be.get_knowledge(physics) or {}
+        except Exception:
+            continue
+        if not isinstance(k, dict) or not k:
+            continue
+        assert len(text) > len(json.dumps(k, default=str)) / 2, (
+            f"{backend}/{physics}: the assembled reply is not materially "
+            f"larger than its knowledge dict, so this guard may be reading the "
+            f"same surface as the source-file check")
+        return
+    pytest.skip("no backend served a knowledge dict to compare against")

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,0 +1,158 @@
+"""Regression tests for result attestation.
+
+Every test here corresponds to a fabrication route that was demonstrated to
+work against an earlier version of this module. They exist so those routes
+cannot silently reopen.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+meshio = pytest.importorskip("meshio")
+
+from core.attestation import (Attestation, AttestationError, attest_quantity,
+                              find_data_artefacts, require_attested,
+                              verify_attestation)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+def _grid(n: int = 8):
+    pts = np.array([[i / n, j / n, 0.0] for i in range(n + 1)
+                    for j in range(n + 1)], float)
+    tris = []
+    for i in range(n):
+        for j in range(n):
+            a = i * (n + 1) + j
+            tris.append([a, a + 1, a + n + 1])
+            tris.append([a + 1, a + n + 2, a + n + 1])
+    return pts, [("triangle", np.array(tris))]
+
+
+def _write_field(directory: Path, value, name: str = "u", fname: str = "sol.vtu"):
+    directory.mkdir(parents=True, exist_ok=True)
+    pts, cells = _grid()
+    vals = (np.full(len(pts), value) if np.isscalar(value)
+            else np.asarray(value, float))
+    meshio.write_points_cells(str(directory / fname), pts, cells,
+                              point_data={name: vals})
+    return directory / fname
+
+
+# ── the core property ─────────────────────────────────────────────────────
+def test_honest_claim_is_accepted(tmp_path):
+    _write_field(tmp_path, 2.0)
+    att = attest_quantity(tmp_path, "j1", "l2_norm")
+    ok, why = require_attested(att.value, att)
+    assert ok, why
+
+
+def test_fabricated_claim_is_refused(tmp_path):
+    _write_field(tmp_path, 2.0)
+    att = attest_quantity(tmp_path, "j1", "l2_norm")
+    ok, why = require_attested(att.value * 10, att)
+    assert not ok and "not the value OASiS computed" in why
+
+
+def test_claim_without_attestation_is_refused():
+    ok, why = require_attested(1.234, None)
+    assert not ok and "no attestation" in why
+
+
+# ── routes that previously worked ─────────────────────────────────────────
+def test_value_printed_by_the_solver_script_is_not_evidence(tmp_path):
+    """The agent authors the script, so printed values are narration.
+
+    A real run whose script printed a hard-coded 'L2_error = 1e-12' once
+    attested that fabricated number. Narration must never be admissible.
+    """
+    (tmp_path / "stdout.log").write_text("run complete\nL2_error = 1.0000e-12\n")
+    (tmp_path / "results_summary.json").write_text('{"L2_error": 1e-12}')
+    assert find_data_artefacts(tmp_path) == []
+    with pytest.raises(AttestationError, match="no solver data output"):
+        attest_quantity(tmp_path, "j1", "l2_norm")
+
+
+def test_small_values_are_compared_relatively(tmp_path):
+    """A tolerance floor of 1.0 once made every pair of tiny numbers match:
+    a claim eight times the attested value passed."""
+    _write_field(tmp_path, 1.25e-13)
+    att = attest_quantity(tmp_path, "j1", "l2_norm")
+    assert att.value < 1e-10
+    ok, _ = require_attested(att.value * 8, att)
+    assert not ok
+    ok_honest, _ = require_attested(att.value, att)
+    assert ok_honest
+
+
+def test_probe_outside_the_mesh_is_refused(tmp_path):
+    """probe_field extrapolates rather than failing, so the domain must be
+    checked explicitly."""
+    _write_field(tmp_path, 1.0)
+    with pytest.raises(AttestationError, match="outside the mesh"):
+        attest_quantity(tmp_path, "j1", "probe_values",
+                        probe_points=[[9.0, 9.0, 0.0]])
+
+
+def test_probe_inside_the_mesh_works(tmp_path):
+    _write_field(tmp_path, 3.0)
+    att = attest_quantity(tmp_path, "j1", "probe_values",
+                          probe_points=[[0.5, 0.5, 0.0]])
+    assert att.values and abs(att.values[0] - 3.0) < 1e-9
+
+
+def test_artefact_outside_the_run_window_is_refused(tmp_path):
+    _write_field(tmp_path, 1.0)
+    long_ago = time.time() - 600
+    with pytest.raises(AttestationError, match="during the run"):
+        attest_quantity(tmp_path, "j1", "l2_norm",
+                        run_started=long_ago, run_finished=long_ago + 60)
+
+
+def test_artefact_inside_the_run_window_is_accepted(tmp_path):
+    _write_field(tmp_path, 1.0)
+    now = time.time()
+    att = attest_quantity(tmp_path, "j1", "l2_norm",
+                          run_started=now - 60, run_finished=now + 60)
+    assert att.value > 0
+
+
+def test_artefact_edited_after_attestation_is_refused(tmp_path):
+    _write_field(tmp_path, 1.0)
+    att = attest_quantity(tmp_path, "j1", "l2_norm")
+    _write_field(tmp_path, 5.0)                      # tamper
+    ok, why = verify_attestation(att)
+    assert not ok and "changed after attestation" in why
+    gated, why2 = require_attested(att.value, att)
+    assert not gated
+
+
+def test_non_finite_field_is_refused(tmp_path):
+    _write_field(tmp_path, np.nan)
+    with pytest.raises(AttestationError):
+        attest_quantity(tmp_path, "j1", "l2_norm")
+
+
+def test_unknown_quantity_is_refused(tmp_path):
+    _write_field(tmp_path, 1.0)
+    with pytest.raises(AttestationError, match="not attestable"):
+        attest_quantity(tmp_path, "j1", "whatever_i_like")
+
+
+def test_no_data_output_at_all_is_refused(tmp_path):
+    (tmp_path / "notes.txt").write_text("I solved it, the answer is 42")
+    with pytest.raises(AttestationError):
+        attest_quantity(tmp_path, "j1", "l2_norm")
+
+
+def test_attestation_records_provenance(tmp_path):
+    p = _write_field(tmp_path, 2.0)
+    att = attest_quantity(tmp_path, "job42", "l2_norm")
+    assert att.job_id == "job42"
+    assert Path(att.source_file).name == p.name
+    assert len(att.source_sha256) == 64
+    assert att.n_points > 0
+    assert "l2" in att.computed_by.lower() or att.computed_by

--- a/tests/test_availability_checks_identity.py
+++ b/tests/test_availability_checks_identity.py
@@ -1,0 +1,264 @@
+"""An "available" backend must be the backend, not merely a file that exists.
+
+A setup audit found `FOURC_BINARY=/bin/true` reporting
+`available — 4C at /bin/true`. The check confirmed a path existed and was
+executable, and nothing more.
+
+That is the worst place in the system to be wrong. An agent calls `discover`,
+is told the backend is available, and proceeds; every run then fails for a cause
+the availability report has already ruled out. A stale path, a half-built tree,
+or a same-named program earlier on PATH were all indistinguishable from a
+working install — and the community will hit exactly those, because they are what
+a machine that is not ours looks like.
+
+The check now runs the program and looks for 4C's own vocabulary. It fails OPEN
+when it cannot look (timeout, permission, OSError), because a check that cannot
+run must not condemn a working install; it fails CLOSED only when the program
+ran and said something that is not 4C.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core.backend import BackendStatus
+from core.registry import get_backend, load_all_backends
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _backends():
+    load_all_backends()
+
+
+@pytest.fixture
+def fourc(monkeypatch):
+    import backends.fourc.backend as M
+    monkeypatch.setattr(M, "_FOURC_IDENT_CACHE", {})   # per-test isolation
+    return get_backend("fourc")
+
+
+# Every one of these was measured passing an earlier version of the check.
+# `4c` as a token is two characters, so `pwd`/`ls` pass when the working
+# directory contains it and `env` passes when any variable does — which is the
+# normal state for a 4C user, since LD_LIBRARY_PATH=/opt/4C-dependencies/lib
+# contains it. `input file` passes gcc, whose no-argument output is "no input
+# files". And gzip's non-UTF-8 output raised UnicodeDecodeError, a ValueError,
+# which the fail-open branch caught and ACCEPTED.
+@pytest.mark.parametrize("path", ["/bin/true", "/bin/echo", "/bin/pwd",
+                                  "/bin/ls", "/usr/bin/env", "/usr/bin/gcc",
+                                  "/usr/bin/gzip", "/bin/cat"])
+def test_an_executable_that_is_not_4c_is_not_available(fourc, monkeypatch, path):
+    """The regression. `/bin/true` exits 0, says nothing, and is not a solver."""
+    if not os.path.exists(path):
+        pytest.skip(f"{path} not present")
+    monkeypatch.setenv("FOURC_BINARY", path)
+    status, message = fourc.check_availability()
+    assert status is not BackendStatus.AVAILABLE, message
+    assert "does not identify itself as 4C" in message
+
+
+def test_the_real_binary_is_still_available(fourc, monkeypatch):
+    """The other half: the fix must not condemn a working install."""
+    monkeypatch.delenv("FOURC_BINARY", raising=False)
+    status, message = fourc.check_availability()
+    if status is BackendStatus.NOT_INSTALLED:
+        pytest.skip("no 4C build on this machine")
+    assert status is BackendStatus.AVAILABLE, message
+
+
+def test_identity_check_fails_open_when_it_cannot_look(monkeypatch):
+    """A check that cannot run must not accuse.
+
+    On a machine where the binary is present but unrunnable — a sandbox, a
+    permission-restricted CI box — refusing to report the backend would be a
+    false negative that no user could diagnose.
+    """
+    import subprocess
+
+    import backends.fourc.backend as M
+
+    monkeypatch.setattr(M, "_FOURC_IDENT_CACHE", {})
+
+    def _boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="4C", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    ok, why = M._identifies_as_fourc("/anything")
+    assert ok is True
+    assert "not checked" in why
+
+
+def test_the_verdict_is_cached_so_discover_stays_cheap(monkeypatch):
+    """`check_availability` is called by every knowledge surface; spawning a
+    process each time would make the whole tool layer slow enough that someone
+    removes the check."""
+    import subprocess
+
+    import backends.fourc.backend as M
+
+    monkeypatch.setattr(M, "_FOURC_IDENT_CACHE", {})
+    calls = []
+    real = subprocess.run
+
+    def _count(*a, **k):
+        calls.append(1)
+        return real(*a, **k)
+
+    monkeypatch.setattr(subprocess, "run", _count)
+    M._identifies_as_fourc("/bin/true")
+    M._identifies_as_fourc("/bin/true")
+    M._identifies_as_fourc("/bin/true")
+    assert len(calls) == 1, f"ran the binary {len(calls)} times, expected 1"
+
+
+def test_the_probe_does_not_read_the_parents_stdin(monkeypatch):
+    """The most dangerous defect found in this check.
+
+    `subprocess.run([binary])` inherits the parent's stdin. An audit pointed the
+    probe at `/bin/cat`, which consumed the parent's ENTIRE stdin and made the
+    verdict a function of that text; pointed at a real solver it hung the full
+    timeout and then failed open. Under an MCP stdio server the parent's stdin is
+    the JSON-RPC stream, so an availability probe could eat the protocol.
+    """
+    import subprocess
+
+    import backends.fourc.backend as M
+
+    monkeypatch.setattr(M, "_FOURC_IDENT_CACHE", {})
+    seen = {}
+    real = subprocess.run
+
+    def _capture(*a, **k):
+        seen.update(k)
+        return real(*a, **k)
+
+    monkeypatch.setattr(subprocess, "run", _capture)
+    M._identifies_as_fourc("/bin/true")
+    assert seen.get("stdin") is subprocess.DEVNULL, (
+        "the identity probe must close stdin; inheriting it lets the probed "
+        "program consume the MCP JSON-RPC stream")
+
+
+def test_a_non_utf8_binary_is_not_accepted_by_the_fail_open_path(monkeypatch):
+    """UnicodeDecodeError is a ValueError. Catching ValueError in the
+    cannot-look branch meant every binary with non-text output was accepted."""
+    import backends.fourc.backend as M
+
+    monkeypatch.setattr(M, "_FOURC_IDENT_CACHE", {})
+    import os
+    if not os.path.exists("/usr/bin/gzip"):
+        pytest.skip("no gzip to probe")
+    ok, why = M._identifies_as_fourc("/usr/bin/gzip")
+    assert ok is False, why
+
+
+# ── the other three backends with the same defect ─────────────────────────
+# A setup audit measured all three reporting `available` for a path that is not
+# the software. SPARTA read worst: it already RAN `<binary> -h` and then threw
+# the result away, so the code looked like it validated.
+@pytest.mark.parametrize("var, value, backend", [
+    ("FEBIO_BINARY", "/bin/true", "febio"),
+    ("FEBIO_BINARY", "/bin/echo", "febio"),
+    ("SPARTA_BINARY", "/bin/true", "sparta"),
+    ("SPARTA_BINARY", "/bin/echo", "sparta"),
+    ("DEAL_II_DIR", "/tmp", "dealii"),
+    ("DEALII_ROOT", "/tmp", "dealii"),
+])
+def test_a_path_that_is_not_the_backend_is_not_available(monkeypatch, var, value,
+                                                         backend):
+    if not os.path.exists(value):
+        pytest.skip(f"{value} not present")
+    import backends.febio.backend as FB
+    monkeypatch.setattr(FB, "_FEBIO_IDENT_CACHE", {})
+    monkeypatch.setenv(var, value)
+    be = get_backend(backend)
+    if be is None:
+        pytest.skip(f"{backend} not registered")
+    status, message = be.check_availability()
+    assert status is not BackendStatus.AVAILABLE, message
+
+
+@pytest.mark.parametrize("backend", ["febio", "sparta", "dealii"])
+def test_the_real_installs_are_still_available(monkeypatch, backend):
+    """The half that is easy to forget, and the one that matters more.
+
+    A check that refuses a working install is worse than no check: it is a false
+    negative the user cannot diagnose. deal.II caught me here — `_find_dealii()`
+    returns the SOURCE root while `config.h` is generated into the BUILD tree, so
+    requiring the marker directly under the returned directory refused the real
+    install.
+    """
+    import backends.febio.backend as FB
+    monkeypatch.setattr(FB, "_FEBIO_IDENT_CACHE", {})
+    for v in ("FEBIO_BINARY", "SPARTA_BINARY", "DEAL_II_DIR", "DEALII_ROOT"):
+        monkeypatch.delenv(v, raising=False)
+    be = get_backend(backend)
+    if be is None:
+        pytest.skip(f"{backend} not registered")
+    status, message = be.check_availability()
+    if status is BackendStatus.NOT_INSTALLED:
+        pytest.skip(f"no {backend} on this machine")
+    assert status is BackendStatus.AVAILABLE, message
+
+
+def test_every_backend_identity_probe_closes_stdin():
+    """Generalised from the 4C finding: an inherited stdin under an MCP stdio
+    server is the JSON-RPC stream, and a probed program that reads it consumes
+    the protocol. Any `subprocess.run` in a `check_availability` path must say
+    so explicitly."""
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "src" / "backends"
+    offenders = []
+    for path in sorted(root.glob("*/backend.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            if getattr(fn, "attr", None) != "run":
+                continue
+            if getattr(getattr(fn, "value", None), "id", None) != "subprocess":
+                continue
+            kws = {k.arg for k in node.keywords}
+            if "stdin" not in kws:
+                offenders.append(f"{path.parent.name}/backend.py:{node.lineno}")
+    assert not offenders, (
+        "these subprocess.run calls inherit the parent's stdin; under an MCP "
+        "stdio server that is the JSON-RPC stream:\n  " + "\n  ".join(offenders))
+
+
+def test_an_invalid_binary_override_is_not_silently_ignored(monkeypatch):
+    """A stale override must not resolve to a different binary.
+
+    Both FEBio and 4C used to accept `FEBIO_BINARY=/nonexistent` and fall
+    through to the search path, so the binary OASiS tested was not the one the
+    user named. An audit hit this while trying to verify that fixtures go red
+    with no binary: setting the override to a nonexistent path found the REAL
+    binary and everything passed, so the verification measured nothing. A silent
+    fallback does not just mislead the user — it invalidates tests written
+    against it.
+    """
+    import backends.febio.backend as FB
+
+    monkeypatch.setattr(FB, "_FEBIO_IDENT_CACHE", {})
+    monkeypatch.setenv("FEBIO_BINARY", "/nonexistent/febio4")
+    be = get_backend("febio")
+    if be is None:
+        pytest.skip("febio not registered")
+    status, message = be.check_availability()
+    assert status is BackendStatus.MISCONFIGURED, message
+    assert "not a file" in message
+    # and it must name the variable, so the user knows what to fix
+    assert "FEBIO_BINARY" in message
+
+
+def test_an_invalid_fourc_override_does_not_fall_through(monkeypatch):
+    import backends.fourc.backend as M
+
+    monkeypatch.setattr(M, "_FOURC_IDENT_CACHE", {})
+    monkeypatch.setenv("FOURC_BINARY", "/nonexistent/4C")
+    assert M._find_fourc_binary() is None, (
+        "an invalid FOURC_BINARY resolved to some other binary")

--- a/tests/test_backend_setup.py
+++ b/tests/test_backend_setup.py
@@ -42,11 +42,26 @@ from core.backend_setup import (  # noqa: E402
 class TestRouteCatalogInvariants(unittest.TestCase):
 
     def test_every_backend_has_at_least_one_route(self) -> None:
-        self.assertEqual(
-            sorted(SETUP_ROUTES),
-            sorted(["skfem", "ngsolve", "kratos", "dune", "fenics",
-                    "dealii", "fourc", "febio"]),
-            "Route catalog must cover all 8 backends.")
+        """Every REGISTERED backend needs an install route.
+
+        This used to compare against a hardcoded list of eight names, which
+        is how SPARTA — the ninth backend, and the only one with no route at
+        all — went unnoticed: adding a backend did not fail any test, so a
+        user asking how to install it got nothing back. Deriving the
+        expectation from the registry means the next backend added cannot
+        repeat that."""
+        from core.registry import all_backends, load_all_backends
+
+        load_all_backends()
+        registered = {b.name() for b in all_backends()}
+        self.assertTrue(registered, "no backends registered at all")
+        missing = sorted(registered - set(SETUP_ROUTES))
+        self.assertFalse(
+            missing,
+            f"registered backend(s) with no install route: {missing}. "
+            f"Add one to SETUP_ROUTES in src/core/backend_setup.py — a "
+            f"backend a user cannot be told how to install is a backend "
+            f"they cannot use.")
         for be, routes in SETUP_ROUTES.items():
             self.assertGreater(len(routes), 0, be)
 
@@ -140,16 +155,52 @@ class TestDetectAndStatus(unittest.TestCase):
         but this machine's real config lives at the pre-rebrand
         ~/.config/open-fem-agent/. The fallback must surface fourc's
         source tree. (Regression found + fixed 2026-06-12.)"""
-        legacy = (Path.home() / ".config" / "open-fem-agent"
-                  / "sources.json")
-        new = Path.home() / ".config" / "oasis" / "sources.json"
-        if not legacy.exists() and not new.exists():
-            self.skipTest("no sources.json on this machine")
-        d = detect_backend("fourc")
-        self.assertIsNotNone(
-            d["source_tree"],
-            "fourc source tree not resolved — the legacy-config "
-            "fallback in source_config.load() regressed.")
+        # HERMETIC. This test used to call `detect_backend("fourc")` and assert
+        # its source tree resolved, gated only on whether SOME sources.json
+        # existed. That made the outcome a function of a mutable file OUTSIDE the
+        # repository: a fourc entry present -> PASS, the file present without one
+        # -> FAIL, the file absent -> SKIP. Three separate audits were misled by
+        # it into reporting three different suite baselines, and one wasted a run
+        # proving its own changes innocent. A test whose colour depends on
+        # machine state is worse than no test — it manufactures disagreement
+        # about whether the suite is green.
+        #
+        # What the 2026-06-12 regression was actually about is the FALLBACK: the
+        # rebrand moved the config from ~/.config/open-fem-agent/ to
+        # ~/.config/oasis/, and installs with only the old path stopped
+        # resolving. That mechanism is testable without touching the real config.
+        import importlib
+
+        from core import source_config
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            legacy_dir = root / ".config" / "open-fem-agent"
+            legacy_dir.mkdir(parents=True)
+            # Real schema, read off the machine's own config rather than
+            # guessed: {"backends": {"<name>": {"source": "<path>"}}}. My first
+            # attempt invented {"sources": {...: {"source_tree": ...}}} and the
+            # test failed for that reason alone — which is the same mistake as
+            # writing a Signal clause from memory.
+            (legacy_dir / "sources.json").write_text(json.dumps(
+                {"backends": {"fourc": {"source": "/tmp/pretend-4c"}}}))
+
+            with mock.patch.object(Path, "home", staticmethod(lambda: root)):
+                mod = importlib.reload(source_config)
+                cfg = mod.load()
+
+            # `backends[name]` is a BackendPaths dataclass whose `source` is a
+            # PosixPath — not a dict. Two wrong guesses at this structure cost
+            # two runs; reading what `load()` actually returns cost one command.
+            entry = (cfg.backends or {}).get("fourc")
+            tree = str(getattr(entry, "source", "")) if entry else ""
+            self.assertEqual(
+                tree, "/tmp/pretend-4c",
+                "the legacy ~/.config/open-fem-agent/sources.json fallback did "
+                "not resolve — the rebrand regression is back.")
+
+        # Restore the module to the real environment for any later test.
+        importlib.reload(source_config)
 
     def test_status_table_renders(self) -> None:
         md = render_status_markdown()
@@ -173,22 +224,47 @@ class TestSetupSessionRegressions(unittest.TestCase):
 
     def test_prefer_unavailable_route_is_explicit_error(self) -> None:
         """Finding 2: plan(dune, route='source') used to silently
-        return the conda route. dune has only a conda route — asking
-        for anything else must error, not substitute."""
+        return a different route. Asking for a route a backend does not
+        have must error and name what it does have, not substitute."""
         p = plan_setup("dune", prefer="source")
         self.assertIn("error", p)
         self.assertIn("source", p["error"])
-        self.assertIn("conda", str(p["error"]))
+        # The error must name the kinds that DO exist, so the caller can
+        # pick one without a second round-trip.
+        available = {r["kind"] for r in SETUP_ROUTES["dune"]}
+        self.assertTrue(
+            any(k in str(p["error"]) for k in available),
+            f"error must name an available route kind {sorted(available)}: "
+            f"{p['error']}")
 
-    def test_dune_conda_route_not_marked_verified_on_linux(self) -> None:
-        """Finding 1: dune-fem is not on conda-forge (confirmed
-        2026-06-12 via api.anaconda.org) — the route must not claim
-        verified_on_this_os until that changes."""
-        dune_conda = [r for r in SETUP_ROUTES["dune"]
-                      if r["kind"] == "conda"][0]
-        self.assertFalse(dune_conda["os_support"]["linux"]["verified"])
-        notes = " ".join(dune_conda["os_support"]["linux"]["notes"])
-        self.assertIn("conda-forge", notes)
+    def test_dune_route_is_pip_and_documents_the_absent_conda_package(self):
+        """dune-fem has no conda-forge package, so there is no conda route
+        to mark verified or unverified — there is only the pip route.
+
+        This test replaced one that asserted the conda route existed but
+        was flagged unverified. That was the wrong shape: a route the user
+        cannot execute is not a route, and leaving it in the catalog meant
+        `setup_backend(action='plan', solver='dune')` could still offer it.
+        Confirmed by execution: `conda search -c conda-forge
+        --override-channels dune-fem` answers "No match found for:
+        dune-fem". What the catalog must keep is the KNOWLEDGE that the
+        conda path is a dead end, so nobody re-adds it."""
+        kinds = {r["kind"] for r in SETUP_ROUTES["dune"]}
+        self.assertIn("pip", kinds,
+                      "dune's working route is pip (PyPI), not conda")
+        self.assertNotIn(
+            "conda", kinds,
+            "a conda route for dune cannot work — conda-forge has no "
+            "dune-fem package")
+        notes = " ".join(
+            n for r in SETUP_ROUTES["dune"]
+            for n in r["os_support"]["linux"]["notes"])
+        self.assertIn("conda-forge", notes,
+                      "the absent conda-forge package must stay documented "
+                      "so the dead route is not re-added")
+        self.assertIn("mpi4py", notes,
+                      "mpi4py is an undeclared dependency of the dune "
+                      "wheels; without it the first import stops")
 
     def test_smoke_dune_honours_ok_false(self) -> None:
         """Finding 3: the dune smoke script exits 0 even on

--- a/tests/test_catalog_consistency.py
+++ b/tests/test_catalog_consistency.py
@@ -803,17 +803,57 @@ class TestDuneFemAPIPaths(unittest.TestCase):
         cls.checked = (
             _collect_dune_path_mentions() | set(dune_gt.CATALOG_API_PATHS)
         )
+        # The catalog deliberately NAMES a handful of paths that do not
+        # exist — they are the phantom APIs a model would otherwise
+        # reach for (dune.fem.space.product_space, the lowercase
+        # raviartthomas, an importable dune.fem.solver). The exemption
+        # list lives with the documentation, in
+        # src/backends/dune/generators/verified_api.py, and
+        # test_known_absent_paths_really_are_absent below turns it into
+        # an extra positive check rather than a hole.
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from backends.dune.generators.verified_api import (  # noqa: E402
+            JIT_GENERATED_PATH_PREFIXES, KNOWN_ABSENT_DUNE_PATHS)
+        cls.known_absent = set(KNOWN_ABSENT_DUNE_PATHS)
+        cls.jit_prefixes = tuple(JIT_GENERATED_PATH_PREFIXES)
 
     def test_no_unresolved_dune_path(self):
         unresolved = [
             path for path in sorted(self.checked)
             if dune_gt.has_attr(path) is False
+            and path not in self.known_absent
+            and not path.startswith(self.jit_prefixes)
         ]
         self.assertFalse(
             unresolved,
             f"\nDUNE-fem catalog references dune paths that do not "
             f"resolve on the installed package: {unresolved}\n"
-            f"Likely an upstream rename or a build missing the module.",
+            f"Likely an upstream rename or a build missing the module.\n"
+            f"If the catalog names one of these BECAUSE it does not "
+            f"exist, add it to KNOWN_ABSENT_DUNE_PATHS in "
+            f"src/backends/dune/generators/verified_api.py — that list "
+            f"is itself asserted to stay unresolvable.",
+        )
+
+    def test_known_absent_paths_really_are_absent(self):
+        """The exemption list must never shelter a path that exists.
+
+        If upstream adds e.g. a real ``dune.fem.space.product_space``,
+        this fires and the corresponding "phantom API" claim in the
+        catalog has to be retired.
+        """
+        resurrected = [
+            path for path in sorted(self.known_absent)
+            if dune_gt.has_attr(path) is not False
+        ]
+        self.assertFalse(
+            resurrected,
+            f"\nPaths listed as KNOWN_ABSENT now RESOLVE on the "
+            f"installed dune: {resurrected}\n"
+            f"The catalog documents them as phantom APIs — that claim "
+            f"is no longer true for this version. Remove them from "
+            f"KNOWN_ABSENT_DUNE_PATHS and update "
+            f"verified_api.EXECUTED_API['phantom_apis_checked'].",
         )
 
 

--- a/tests/test_coupling.py
+++ b/tests/test_coupling.py
@@ -686,5 +686,16 @@ class TestKnowledgeTools:
         assert "get_precice_knowledge" in captured
         result = captured["get_precice_knowledge"]()
         assert "preCICE" in result
-        assert "MCP" in result
         assert "adapter" in result.lower()
+        # This assertion used to be `"MCP" in result`, which passed only because
+        # the function still returned the PRE-REWRITE inline string. The rewrite
+        # replaced that payload with `precice_knowledge()`, and this test going
+        # green on the old text was one of the signals that the new corpus was
+        # never actually being served. Assert on the contract instead of on a
+        # word that happened to be in the legacy prose.
+        assert "couple_precice" in result
+        for token in ("precice-config.xml", "requires_writing_checkpoint",
+                      "set_mesh_vertices"):
+            assert token in result, f"preCICE payload does not document {token}"
+        # and the solver argument must be honoured, not dropped
+        assert captured["get_precice_knowledge"]("fenics") != result

--- a/tests/test_coupling_data_staging.py
+++ b/tests/test_coupling_data_staging.py
@@ -1,12 +1,10 @@
-"""Data-file staging for the COUPLED path (T15 campaign fix, 2026-08).
+"""Data-file staging for the COUPLED path.
 
-The T15 evaluation campaign (rarefied conjugate heat transfer, SPARTA DSMC
-<-> FEM solid) showed that the coupled path did no data staging at all:
-SpartaBackend.run() staged species/surf files for single runs (#42), but
-couple()/run_coupling executed raw participant commands in fresh work_dirs,
-so SPARTA died with 'Cannot open species file ar.species'
-(../particle.cpp:711) unless the agent hand-copied every file. Several
-agents gave up and substituted kinetic-theory formulas for the DSMC run.
+The coupled path used to do no data staging at all: SpartaBackend.run()
+staged species/surf files for single runs (#42), but couple()/run_coupling
+executed raw participant commands in fresh work_dirs, so SPARTA died with
+'Cannot open species file ar.species' (../particle.cpp:711) unless every
+file had been hand-copied first.
 
 Fixes under test:
   1. Participant.data_files — the driver stages listed files into work_dir
@@ -116,7 +114,7 @@ def test_stage_deck_refs_from_extra_dirs(tmp_path):
 
 def test_task_data_dir_beats_distribution(tmp_path, monkeypatch):
     """A task-specific circle.surf must win over a distribution file of
-    the same name — they are different geometries (T15)."""
+    the same name — they are different geometries."""
     dist = tmp_path / "dist"
     (dist / "data").mkdir(parents=True)
     (dist / "data" / "circle.surf").write_text("distribution circle\n")

--- a/tests/test_coupling_driver.py
+++ b/tests/test_coupling_driver.py
@@ -91,3 +91,122 @@ def test_validators():
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+# ── the stochastic branch: a residual floor that is MEASURED, not assumed ────
+#
+# A Monte-Carlo participant answers the same question slightly differently every
+# time, so the residual — which is the CHANGE in the export — cannot fall below
+# that scatter however well the coupling has converged. A `tol` under the floor
+# is unreachable by construction and every run of a correct coupling was
+# reported as a failure. These use a noisy participant with a seed drawn per
+# invocation, so they exercise the real mechanism with no solver involved.
+
+_NOISY = (
+    'import json, os, random\nfrom pathlib import Path\n'
+    'random.seed(int.from_bytes(os.urandom(8), "little"))\n'
+    'imp=json.loads(Path("imports.json").read_text() or "{}")\n'
+    'y=imp["B"]["values"][0] if "B" in imp else 0.0\n'
+    'v=0.5*y+1.0\n'
+    'v*= 1.0 + AMP*(random.random()-0.5)\n'
+    'json.dump({"field_name":"x","n_points":1,"coordinates":[[0.0]],'
+    '"values":[v]},open("exports.json","w"))\n')
+
+_QUIET_B = (
+    'import json\nfrom pathlib import Path\n'
+    'imp=json.loads(Path("imports.json").read_text() or "{}")\n'
+    'x=imp["A"]["values"][0] if "A" in imp else 0.0\n'
+    'json.dump({"field_name":"y","n_points":1,"coordinates":[[0.0]],'
+    '"values":[0.5*x+2.0]},open("exports.json","w"))\n')
+
+
+def _noisy_pair(tmp_path, amp=0.05):
+    a = _write_participant(tmp_path, "A", _NOISY.replace("AMP", repr(amp)))
+    b = _write_participant(tmp_path, "B", _QUIET_B)
+    return (Participant("A", [sys.executable, "run.py"], a, imports_from=["B"]),
+            Participant("B", [sys.executable, "run.py"], b, imports_from=["A"]))
+
+
+def test_stochastic_participant_fails_without_the_noise_branch(tmp_path):
+    """The symptom the branch exists to remove: a correct coupling, a tol under
+    the sampling noise, and an unconditional FAILURE."""
+    pa, pb = _noisy_pair(tmp_path)
+    r = run_coupling([pa, pb], max_iter=25, tol=1e-9, accelerator="constant")
+    assert not r.converged
+    assert r.noise_floor is None, "no floor was asked for, so none may be claimed"
+    assert "did not converge" in (r.error or "")
+    # And the failure message must point at the measurement rather than leaving
+    # the reader to halve theta forever.
+    assert "noise_replicates" in (r.error or ""), (
+        "a residual that STOPPED FALLING should name the noise-floor route")
+
+
+def test_measured_floor_lets_a_stochastic_coupling_converge(tmp_path):
+    """Same run, floor measured: converged, judged against max(tol, floor), and
+    the floor reported so nobody grades tighter than the sampler allows."""
+    pa, pb = _noisy_pair(tmp_path)
+    # FIVE, not three. The floor is itself an estimate and three replicates
+    # give only three non-independent pairs: the same coupling measured
+    # 1.2e-03 from three and 9.6e-03 from five, a factor of eight of pure
+    # estimator scatter on the number the verdict is compared against.
+    # A generous iteration budget, on purpose. Stopping needs a BLOCK of
+    # consecutive residuals to average below the floor, and once the run is IN
+    # the noise each block is roughly a coin toss — which is the point of block
+    # averaging. Twenty-odd chances make a spurious failure vanishingly
+    # unlikely without weakening anything the test asserts.
+    r = run_coupling([pa, pb], max_iter=60, tol=1e-9, accelerator="constant",
+                     noise_replicates=6)
+    assert r.converged
+    assert r.stopped_at_noise_floor
+    assert r.noise_floor and r.noise_floor > 1e-9
+    assert r.tol_effective == max(1e-9, r.noise_floor)
+    # SAID, and said in `criterion_notes` rather than in `warnings`. The
+    # sentence and its job are unchanged — a verdict reached at the floor that
+    # does not SAY so is a softened failure, which is worse than the honest one
+    # it replaced — but the field moved when this branch met
+    # feature/coupling-robustness. There, `couple` takes ANY entry in the
+    # findings list as making a coupling untrustworthy, on purpose, so that no
+    # check can be lost by rewording; and it builds that list from `warnings`.
+    # A correct stochastic coupling therefore came back NOT VERIFIED, which is
+    # the verdict this whole branch exists to stop being unavoidable. The notice
+    # is now reported in the coverage channel, which is always printed in the
+    # verdict and never flips it.
+    assert any("NOISE FLOOR" in w.upper() for w in r.criterion_notes), (
+        "a verdict reached at the floor that does not SAY so is a softened "
+        "failure, which is worse than the honest one it replaced")
+    assert not any("NOISE FLOOR" in w.upper() for w in r.warnings), (
+        "the criterion notice must NOT be a warning: `couple` copies warnings "
+        "into `validation` and treats a non-empty `validation` as untrustworthy")
+    # The physics is still right: the fixed point of x=0.5y+1, y=0.5x+2.
+    assert abs(r.exports["A"]["values"][0] - 8 / 3) < 0.3
+    assert abs(r.exports["B"]["values"][0] - 10 / 3) < 0.3
+
+
+def test_noise_branch_is_inert_for_deterministic_participants(tmp_path):
+    """max(tol, 0) is tol. A branch that changed a deterministic verdict would
+    be a way of passing failures."""
+    pa, pb = _noisy_pair(tmp_path, amp=0.0)
+    r = run_coupling([pa, pb], max_iter=80, tol=1e-9, accelerator="constant",
+                     noise_replicates=6)
+    assert r.converged
+    assert r.noise_floor == 0.0
+    assert not r.stopped_at_noise_floor
+    assert r.tol_effective == 1e-9
+    assert abs(r.exports["A"]["values"][0] - 8 / 3) < 1e-5
+    # The measurement's provenance is a NOTE, not a warning: `warnings` becomes
+    # the tool's `validation` block, and an agent is told an empty validation
+    # block is what a correct coupling looks like.
+    assert not r.warnings, r.warnings
+    assert any("SEED IS FIXED" in n for n in r.notes), (
+        "a floor of exactly zero must be reported \u2014 on a Monte-Carlo "
+        "participant it means the seed is fixed, and a residual that falls "
+        "under a fixed seed proves only that one draw was repeated")
+
+
+def test_declared_floor_is_honoured_without_replicates(tmp_path):
+    """A caller who measured the floor elsewhere can declare it."""
+    pa, pb = _noisy_pair(tmp_path)
+    r = run_coupling([pa, pb], max_iter=25, tol=1e-9, accelerator="constant",
+                     noise_floor=0.2)
+    assert r.converged and r.stopped_at_noise_floor
+    assert r.tol_effective == 0.2

--- a/tests/test_coupling_knowledge.py
+++ b/tests/test_coupling_knowledge.py
@@ -1,0 +1,494 @@
+"""Guards for the coupling knowledge an agent is actually served.
+
+The failure this file exists to prevent, measured on the live tools before the
+rewrite: the whole coupling corpus for all nine backends was smaller than a
+tenth of one backend's pitfall payload, named two backends out of nine, varied
+not at all with `solver=`, and documented the DEPRECATED tool's enum while the
+general tool's contract lived only inside that tool's own docstring.
+
+Every assertion here is structural — a key that must be documented, a payload
+that must differ per backend, a script that must compile. Nothing pins a number
+produced by a run, because a knowledge test that pins a measurement makes the
+measurement part of the shipped corpus.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+from tools.coupling_knowledge import (            # noqa: E402
+    _BACKEND_ORDER, _PARTICIPANT_DIR, coupling_core, coupling_knowledge,
+    coupling_sides_table, precice_knowledge,
+)
+
+
+def _core() -> str:
+    return coupling_core()
+
+
+# ── the contract must be IN the knowledge, not only in a docstring ───────
+
+@pytest.mark.parametrize("token", [
+    "imports.json", "exports.json", "InterfaceData", "coordinates",
+    "normal_fluxes", "imports_from", "work_dir", "field_name", "n_points",
+])
+def test_couple_contract_terms_are_documented(token):
+    """The `couple` contract used to exist ONLY in the tool's docstring: the
+    knowledge contained zero occurrences of any of these."""
+    assert token in _core(), f"'{token}' missing from knowledge(topic='coupling')"
+
+
+def test_knowledge_names_the_general_tool_not_the_deprecated_enum():
+    core = _core()
+    assert "couple(" in core
+    # the legacy enum values must not be presented as the way to couple
+    for legacy in ("heat_dd", "poisson_dd", "tsi_dd", "poisson_dd_study"):
+        assert legacy not in core, (
+            f"knowledge still advertises the deprecated coupled_solve enum "
+            f"value '{legacy}'")
+
+
+def test_knowledge_does_not_point_at_private_generators():
+    """It used to instruct the agent to write 'a new subdomain script generator
+    (analogous to `_fenics_heat_subdomain_script`)' — a private function that no
+    agent can call."""
+    core = _core()
+    assert "_fenics_heat_subdomain_script" not in core
+    assert "_generate_domain_b_input" not in core
+
+
+def test_theta_guidance_matches_a_real_parameter():
+    """Two knowledge sections used to give theta-selection tables while the tool
+    had no theta parameter at all."""
+    from tools import consolidated
+    src = inspect.getsource(consolidated)
+    sig = re.search(r"async def couple\((.*?)\) -> str:", src, re.S).group(1)
+    assert "theta" in sig, "couple() has no theta parameter"
+    assert "theta" in _core(), "knowledge does not mention theta"
+
+
+def test_sign_convention_states_both_quantities():
+    core = _core()
+    assert "apply the same number, export opposite numbers" in core.lower()
+
+
+# ── per-backend payloads must actually differ ────────────────────────────
+
+def test_every_backend_has_a_named_payload_entry():
+    core = _core()
+    for name in _BACKEND_ORDER:
+        assert f"solver='{name}'" in core, (
+            f"knowledge(topic='coupling') never tells the agent to ask for "
+            f"solver='{name}'")
+
+
+def test_coupling_payload_varies_by_backend():
+    """The measured bug: byte-identical output for every solver."""
+    seen = {}
+    for name in _BACKEND_ORDER:
+        text = coupling_knowledge(name)
+        assert text != coupling_core(), f"solver='{name}' returned the core payload"
+        assert text not in seen.values(), (
+            f"solver='{name}' is byte-identical to solver='{seen and [k for k,v in seen.items() if v==text][0]}'")
+        seen[name] = text
+
+
+def test_precice_payload_varies_by_backend():
+    seen = {}
+    for name in _BACKEND_ORDER:
+        text = precice_knowledge(name)
+        assert text not in seen.values(), (
+            f"precice solver='{name}' is byte-identical to another backend")
+        seen[name] = text
+
+
+def test_unknown_solver_is_not_a_dead_end():
+    out = coupling_knowledge("no-such-backend")
+    assert "no-such-backend" in out
+    # still hands over the general contract rather than nothing
+    assert "imports.json" in out
+
+
+# ── the shipped participant scripts must be real, runnable files ─────────
+
+def _script_backends():
+    return [n for n in _BACKEND_ORDER
+            if (_PARTICIPANT_DIR / f"participant_{n}.py").is_file()]
+
+
+def test_at_least_the_flagship_participants_ship():
+    for name in ("fenics", "fourc"):
+        assert (_PARTICIPANT_DIR / f"participant_{name}.py").is_file(), (
+            f"participant script for {name} is missing")
+
+
+@pytest.mark.parametrize("name", _script_backends())
+def test_participant_script_parses_and_is_complete(name):
+    p = _PARTICIPANT_DIR / f"participant_{name}.py"
+    text = p.read_text()
+    ast.parse(text)                                   # syntactically runnable
+    assert "imports.json" in text and "exports.json" in text
+    assert "EDIT THIS BLOCK" in text, (
+        "the script must mark the block a user edits, or a weak model has to "
+        "work out which constants are problem data")
+    assert "PLACEHOLDER" in text, (
+        "the edit block must say its numbers are placeholders — shipping a "
+        "ready-made benchmark configuration is the anchoring the project bans")
+    assert re.search(r"^PARTNER\b", text, re.M), f"{name}: no PARTNER constant"
+    # a participant that can take both roles must expose which one it is
+    if "SIDE ==" in text:
+        assert re.search(r"^SIDE\b", text, re.M), f"{name}: no SIDE constant"
+
+
+@pytest.mark.parametrize("name", _script_backends())
+def test_served_payload_contains_the_whole_script(name):
+    served = coupling_knowledge(name)
+    text = (_PARTICIPANT_DIR / f"participant_{name}.py").read_text()
+    assert text in served, (
+        f"knowledge(topic='coupling', solver='{name}') does not serve the "
+        f"participant script verbatim — it can drift from the file that is tested")
+    assert "```python" in served
+
+
+# ── nothing machine-specific may be served ───────────────────────────────
+
+_HOST_PATH = re.compile(r"(?<![\w/])(?:/home/|/Users/|/opt/|/usr/(?:local/)?(?:bin|lib))")
+
+
+@pytest.mark.parametrize("name", [""] + _BACKEND_ORDER)
+def test_no_absolute_host_paths_in_served_coupling_knowledge(name):
+    for text in (coupling_knowledge(name), precice_knowledge(name)):
+        hits = _HOST_PATH.findall(text)
+        assert not hits, (
+            f"solver='{name}': served knowledge carries a path from the build "
+            f"host ({hits[:3]}); it is wrong on every other machine. Tell the "
+            f"agent to read the path from discover(query='list') instead.")
+
+
+def test_discover_has_a_coupling_branch():
+    """There was no path to the coupling knowledge unless you already knew the
+    topic string existed."""
+    from tools import consolidated
+    src = inspect.getsource(consolidated)
+    assert 'query == "coupling"' in src
+    doc = re.search(r"def discover\(.*?\"\"\"(.*?)\"\"\"", src, re.S).group(1)
+    assert "coupling" in doc, (
+        "discover's docstring does not advertise query='coupling'")
+    assert "knowledge(topic='coupling'" in src, (
+        "discover(query='coupling') must name the follow-up knowledge call")
+
+
+# ── the launch section must be SPECIALISED where the participant is a wrapper ──
+
+# backend -> the constant its shipped script keeps the solver binary in
+_WRAPPER_BACKENDS = {"fourc": "FOURC_BIN", "febio": "FEBIO",
+                     "sparta": "SPARTA", "dealii": "DEALII_EXE"}
+
+
+@pytest.mark.parametrize("name,const", sorted(_WRAPPER_BACKENDS.items()))
+def test_wrapper_backends_say_the_command_runs_the_wrapper(name, const):
+    """For these four the participant is a Python WRAPPER around a binary, so
+    `command` must run PYTHON and the binary goes into a constant in the script.
+
+    The measured bug this pins: the specialised step 4 was applied with
+    `_LAUNCH_PY.replace(<literal>, ...)` and ALL FOUR literals were stale, so
+    every one of these backends served the generic "get the interpreter or
+    binary from discover(query='list')" — and what discover prints for them IS
+    the binary. `str.replace` cannot fail, so the corpus said nothing while
+    telling a weak model to put a solver binary where an interpreter goes.
+    """
+    served = coupling_knowledge(name)
+    assert "runs the WRAPPER" in served, (
+        f"solver='{name}': the launch section does not say that `command` runs "
+        f"the wrapper rather than the {name} binary")
+    assert const in served, (
+        f"solver='{name}': the launch section never names `{const}`, the "
+        f"constant the binary path actually goes into")
+
+
+@pytest.mark.parametrize("name", _BACKEND_ORDER)
+def test_launch_section_has_no_unsubstituted_field(name):
+    """A named field left in the served text is a hard stop for a weak model."""
+    for text in (coupling_knowledge(name), coupling_core()):
+        assert "{INTERP}" not in text, f"solver='{name}': unsubstituted {{INTERP}}"
+        assert "{RIGHT}" not in text, f"solver='{name}': unsubstituted {{RIGHT}}"
+
+
+@pytest.mark.parametrize("name", _BACKEND_ORDER)
+def test_served_edit_block_only_names_constants_the_script_defines(name):
+    """Step 2 hands over a "complementary side" edit block. Every constant in it
+    must EXIST in the script served in the same payload.
+
+    The measured bug: the CONDUCTION right-side block was embedded in all nine
+    payloads. FEBio's script is elasticity (no K, F_SRC, T_OUTER, T_INIT),
+    Kratos's has no SIDE/IFACE_X/Y0,Y1/NX,NY/F_SRC/Q_INIT, and SPARTA's has none
+    of nine of them — so three of nine backends were told to set constants that
+    do not exist in the file they had just been given. For SPARTA the block also
+    said `SIDE="neumann"` while the same payload says the Neumann role is
+    IMPOSSIBLE. Applying the served block to the served FEBio script was
+    confirmed to fail on its first key.
+    """
+    def assigned(text):
+        """Names bound by a module-level assignment, incl. `X0, X1 = a, b`."""
+        out = set()
+        for m in re.finditer(r"^([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*=[^=]", text, re.M):
+            out |= {c.strip() for c in m.group(1).split(",")}
+        return out
+
+    served = coupling_knowledge(name)
+    script = (_PARTICIPANT_DIR / f"participant_{name}.py").read_text()
+    defined = assigned(script)
+    blocks = re.findall(r"```python\n(.*?)```", served, re.S)
+    # the edit blocks are the short fenced blocks; the participant is the long one
+    for blk in [b for b in blocks if b != script and len(b) < 2000]:
+        missing = sorted(assigned(blk) - defined)
+        assert not missing, (
+            f"solver='{name}': the served edit block sets {missing}, which the "
+            f"served participant script never defines")
+
+
+def test_sparta_flux_claim_is_not_overstated():
+    """The payload said SPARTA "CANNOT take the Neumann role" because
+    "`fix surf/temp` derives one from SPARTA's OWN computed flux, not from an
+    imported one". The second half is factually wrong, checked in the SPARTA
+    source on this install:
+
+      * fix_surf_temp.cpp accepts `f_<fixID>` and the ONLY requirement is
+        `per_surf_flag != 0` — it never checks where the flux came from. SPARTA's
+        own doc/fix_surf_temp.txt says "Note that SPARTA does not check that the
+        specified compute/fix calculates an energy flux."
+      * fix_ave_surf.cpp accepts `s_<name>` (CUSTOM, arg[i][0] == 's') and sets
+        `per_surf_flag = 1`, and its CUSTOM branch reads `surf->edvec[...]`.
+      * `custom surf ... file` resets custom per-surf values from a FILE.
+
+    So an imported flux does reach `fix surf/temp`, which converts it via
+    `T = (q/(sigma*emisurf))^(1/4)` (fix_surf_temp.cpp: `pow(prefactor*qw,0.25)`
+    with `prefactor = 1/(emi*SB_SI)`). That is not a Neumann BC and carries real
+    caveats, but "cannot" removed a capability that exists. A wrong "cannot" is
+    as costly as a wrong "can".
+    """
+    served = coupling_knowledge("sparta")
+    assert "CANNOT take the Neumann role" not in served, (
+        "the flat 'cannot' is wrong: an imported flux can reach fix surf/temp")
+    assert "not from an imported one" not in served, (
+        "fix surf/temp does not care where the flux came from")
+    # the honest version must still be unmistakable about the absence of a real
+    # flux BC, and must name the indirect route rather than hiding it
+    assert "NO native flux boundary condition" in served
+    assert "fix surf/temp" in served and "Stefan-Boltzmann" in served
+    assert "custom surf" in served and "fix ave/surf" in served
+    assert "NOT been run here" in served, (
+        "a source-derived route must be marked unproven, not implied to be tested")
+
+
+def test_sparta_is_not_handed_a_neumann_edit_block():
+    """SPARTA's own payload says the Neumann role is impossible; the launch
+    section must not simultaneously tell the agent to make a neumann copy."""
+    served = coupling_knowledge("sparta")
+    assert 'SIDE      = "neumann"' not in served, (
+        "the SPARTA payload serves a neumann edit block while stating that the "
+        "Neumann role cannot be done at all")
+    assert "DIRICHLET-side" in served or "Dirichlet-side" in served
+
+
+def test_pure_python_backends_do_not_claim_a_wrapper():
+    """The complement: a backend whose participant IS the script must not tell
+    the agent to look for a binary constant that does not exist in it."""
+    for name in ("fenics", "ngsolve", "skfem", "dune"):
+        assert "runs the WRAPPER" not in coupling_knowledge(name), (
+            f"solver='{name}': participant is a plain script, not a wrapper")
+
+
+# ── through the TOOL, which is the only path an agent has ────────────────
+#
+# Everything above calls the payload functions directly. That is how a whole
+# surface stayed broken while the suite was green: `knowledge(topic='precice',
+# solver=...)` reached `get_precice_knowledge()`, which took NO solver argument
+# while its caller passed one, so EVERY preCICE call — core included — returned
+#   "⚠ `get_precice_knowledge()` raised: `TypeError: ... takes 0 positional
+#    arguments but 1 was given`"
+# a 151-character error string in place of an 11 kB payload, for all nine
+# backends. Measured through the tool, the per-backend corpus was 117,632
+# characters rather than the 217,492 the functions produce. Direct-call tests
+# cannot see this; only driving the tool can.
+
+def _knowledge_tool():
+    """The registered `knowledge` tool function, as an agent would reach it."""
+    from tools.consolidated import register_consolidated_tools
+
+    captured = {}
+
+    class _Recorder:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    register_consolidated_tools(_Recorder())
+    return captured["knowledge"]
+
+
+_ERROR_MARK = "⚠ `"
+
+
+@pytest.mark.parametrize("topic", ["coupling", "precice"])
+@pytest.mark.parametrize("solver", [""] + _BACKEND_ORDER)
+def test_knowledge_tool_serves_a_real_payload(topic, solver):
+    out = _knowledge_tool()(topic=topic, solver=solver)
+    assert _ERROR_MARK not in out, (
+        f"knowledge(topic={topic!r}, solver={solver!r}) served an ERROR STRING "
+        f"instead of a payload: {out[:200]}")
+    assert len(out) > 3000, (
+        f"knowledge(topic={topic!r}, solver={solver!r}) served only {len(out)} "
+        f"characters — that is not the payload, it is a stub or an error")
+
+
+@pytest.mark.parametrize("topic", ["coupling", "precice"])
+def test_knowledge_tool_output_matches_the_payload_function(topic):
+    """The tool must serve what the tested function returns, not a second copy
+    and not a legacy inline string that drifted away from it."""
+    fn = coupling_knowledge if topic == "coupling" else precice_knowledge
+    tool = _knowledge_tool()
+    for solver in [""] + _BACKEND_ORDER:
+        assert tool(topic=topic, solver=solver) == fn(solver), (
+            f"knowledge(topic={topic!r}, solver={solver!r}) does not match "
+            f"{fn.__name__}({solver!r}) — the served path and the tested path "
+            f"have diverged")
+
+
+def test_the_default_accelerator_is_not_disparaged():
+    """The knowledge told the agent that "aitken" — the tool's DEFAULT — "is not
+    the safe choice here" and to use "constant" FIRST.
+
+    Swept on this driver over rho in {1/4, 1/2, 1, 2, 4, 9} x theta in
+    {0.1,...,1.0} (40 cells), that is backwards: Aitken matched or beat the
+    constant theta in 39 of 40 cells and converged to the correct interface value
+    in 10 cells where the SAME constant theta diverged (at rho=4, theta=0.7:
+    constant reached 3e63, Aitken converged in 86 iterations). Exactly one cell
+    went the other way, marginally. Steering a weak model from the adaptive
+    default to the setting that diverges by tens of orders of magnitude is the
+    most expensive kind of wrong advice this section could give.
+    """
+    core = _core()
+    assert 'accelerator="constant"' not in core.split("| Symptom")[1].split(
+        "residual falls steadily")[0], (
+        "the first-try row of the symptom table must not send the agent to "
+        "accelerator='constant'")
+    assert "USE THIS FIRST" not in core, (
+        "'constant' must not be advertised as the first choice")
+    low = core.lower()
+    assert "the default, \"aitken\", is also the safer one" in low or \
+           "default and you should normally keep" in low, (
+        "the knowledge must say plainly that the default accelerator is the "
+        "safer one")
+
+
+def test_iteration_sizing_is_a_worked_formula_not_a_lookup_table():
+    """The knowledge tells the agent to size max_iter from log(tol)/log(1-theta).
+
+    It used to follow that with six pre-evaluated values — "about 27 iterations
+    at theta=0.5, 52 at theta=0.3, 83 at theta=0.2; at tol=1e-6, about
+    20 / 39 / 62" — in the same breath as telling the reader to "evaluate the
+    expression for your own theta and tol instead of reusing a number". The
+    numbers were arithmetic, not measurements, so no contamination gate saw
+    them; the objection is different. A table of six reusable figures is a
+    lookup table, and the one thing an agent graded on a relaxation study will
+    do with a lookup table is quote it as a result. One worked example teaches
+    the method; six teach the answers.
+
+    So: exactly one worked evaluation, it must be arithmetically right, and it
+    must say in words that it is a value of the formula rather than something
+    observed.
+    """
+    import math
+    core = _core()
+    assert "SIZING GUIDE" in core or "not a lower bound" in core, (
+        "the figure was stated as a bound the iteration needs 'AT LEAST', and "
+        "runs beat it, because the residual is normalised by the field "
+        "magnitude — a good relative starting point needs FEWER iterations")
+    assert "not something anybody observed" in core, (
+        "the worked figure must be marked as a value of the formula; without "
+        "that it reads as a measured iteration count and will be quoted as one")
+    worked = re.findall(
+        r"theta=([\d.]+), tol=(1e-\d+), d0=1\s*->\s*log\(1e-\d+\)/log\("
+        r"[\d.]+\)\s*~\s*(\d+) iterations", core)
+    assert len(worked) == 1, (
+        f"expected exactly ONE worked evaluation of the sizing formula, found "
+        f"{len(worked)}; a list of them is a lookup table")
+    th, tol, got = worked[0]
+    want = math.log(float(tol)) / math.log(1 - float(th))
+    assert abs(int(got) - want) <= 1.5, (
+        f"the worked figure for theta={th} at tol={tol} is quoted as {got}, "
+        f"but log({tol})/log(1-{th}) = {want:.1f}")
+    # And no second table sneaking back in.
+    assert not re.search(r"about \d+ / \d+ / \d+", core), (
+        "a slash-separated run of iteration counts is the lookup-table shape "
+        "this test exists to keep out")
+
+
+def test_sides_table_does_not_overstate_what_converged_here():
+    """The blanket sentence under the table claimed every "yes" was a coupling
+    that ran on THIS install and CONVERGED. Two of the nine rows contradicted it
+    in their own text: Kratos says "in a separate Kratos install, not OASiS's own
+    interpreter here", and SPARTA says the residual "cannot beat the Monte-Carlo
+    noise" — i.e. `couple` reported FAILURE. The rows were honest; the summary
+    over them was not, and it is the headline `discover('coupling')` serves.
+    """
+    table = coupling_sides_table()
+    assert "Every \"yes\" above means" in table or "Every UNSTARRED" in table, (
+        "the table needs a summary sentence stating what a yes is evidence of")
+    # The rule, whichever way a cell is marked: an UNSTARRED yes may not sit in
+    # a row whose own text takes it back. Both stars were removed once real
+    # couplings backed them (pair_kratos_skfem for Kratos on Dirichlet,
+    # tests/test_coupling_pair_fourc_kratos.py for Kratos on Neumann,
+    # stochastic_noise_floor_makes_dsmc_gradable for SPARTA), and this is what
+    # stops the next star being removed without the run behind it.
+    RETRACTIONS = ("NOT reproducible", "not reproducible", "reported FAILURE",
+                   "cannot beat", "could not be run", "was not run here")
+    for line in table.splitlines():
+        if not line.startswith("|") or "yes" not in line:
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 3 or cells[0] in ("Backend",):
+            continue
+        unstarred = [c for c in cells[1:3] if c.startswith("yes")
+                     and not c.startswith("yes*")]
+        if not unstarred:
+            continue
+        for phrase in RETRACTIONS:
+            assert phrase not in line, (
+                f"the {cells[0]} row carries an UNSTARRED yes while its own "
+                f"text says {phrase!r}. Either star the cell or delete the "
+                f"retraction — the summary sentence is the headline "
+                f"discover('coupling') serves and it must not be contradicted "
+                f"by the row underneath it.")
+
+
+def test_sides_table_agrees_with_the_per_backend_payloads():
+    """Both are served surfaces; they must not disagree about what was coupled.
+    The table said DUNE and deal.II were "coupled to FEniCSx" while their own
+    payloads said FEniCSx AND each other, in all four role/position combinations.
+    """
+    table = coupling_sides_table()
+    for label, name, partner in (("DUNE-fem", "dune", "deal.II"),
+                                 ("deal.II", "dealii", "DUNE-fem")):
+        row = next(r for r in table.splitlines() if r.startswith(f"| {label}"))
+        assert partner in row, (
+            f"the table omits that {label} was coupled to {partner}, which "
+            f"knowledge(topic='coupling', solver='{name}') states")
+
+
+def test_sides_table_covers_every_backend():
+    table = coupling_sides_table()
+    for label in ("FEniCSx", "NGSolve", "scikit-fem", "DUNE", "deal.II",
+                  "4C", "FEBio", "Kratos", "SPARTA"):
+        assert label in table, f"{label} is absent from the side table"

--- a/tests/test_coupling_pair_dealii_ngsolve.py
+++ b/tests/test_coupling_pair_dealii_ngsolve.py
@@ -18,6 +18,9 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).resolve().parents[1]
+
+# See the note in tests/test_coupling_pair_fourc_kratos.py.
+SIDES_COVERED = [("dealii", "dirichlet"), ("ngsolve", "neumann")]
 sys.path.insert(0, str(REPO / "src"))
 
 PAIR_DIR = REPO / "benchmarks" / "coupling_pairs" / "dealii_ngsolve_cht"

--- a/tests/test_coupling_pair_fourc_kratos.py
+++ b/tests/test_coupling_pair_fourc_kratos.py
@@ -27,6 +27,13 @@ sys.path.insert(0, str(REPO))
 PAIR_DIR = REPO / "benchmarks" / "coupling_pairs" / "fourc_kratos_cht"
 PARAMS = json.loads((PAIR_DIR / "params.json").read_text())
 
+# Which (backend, role) cells of the served sides table this file establishes.
+# Read by scripts/tier2_fixtures/coupling/sides_table_backed_by_runs, so a table
+# cell can be backed by a live pytest coupling as well as by a tier-2 fixture.
+# It sits next to the run it describes: a wrong entry here is a lie in the same
+# file as the evidence it claims.
+SIDES_COVERED = [("fourc", "dirichlet"), ("kratos", "neumann")]
+
 
 def _kratos_usable() -> bool:
     py = PARAMS["kratos_python"]

--- a/tests/test_coupling_participants_run.py
+++ b/tests/test_coupling_participants_run.py
@@ -1,0 +1,215 @@
+"""EXECUTE the shipped participant scripts — do not merely parse them.
+
+`knowledge(topic='coupling', solver=...)` serves these files verbatim and tells
+the agent to copy them and run them. A syntax check does not establish that,
+and an audit found the claim "the artefact that gets executed in the test suite"
+resting on nothing but `ast.parse`. So this module actually runs them.
+
+Nothing here pins a measured number. The assertions are structural (a file was
+written, the required keys are present, the values are finite, the interface is
+non-empty) plus one cross-side CONSISTENCY check: the two participants must
+agree with EACH OTHER at the shared interface once the coupling has converged.
+That is a property of a correct coupling, not a result read off a run.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+PART_DIR = REPO / "data" / "coupling_participants"
+
+# The complementary side, exactly as the served payload prescribes it.
+RIGHT_EDITS = {
+    "SIDE": '"neumann"', "PARTNER": '"left"', "X0, X1": "0.6, 1.1",
+    "Y0, Y1": "0.0, 0.4", "IFACE_X": "0.6", "K": "1.5", "T_OUTER": "300.0",
+    "NX, NY": "18, 12", "T_INIT": "310.0", "Q_INIT": "0.0",
+}
+
+
+def _edit(text: str, edits: dict) -> str:
+    import re
+    for k, v in edits.items():
+        pat = re.compile(rf"^({re.escape(k)}\s*=\s*)(.*?)(\s*(?:#.*)?)$", re.M)
+        assert pat.search(text), f"edit key {k!r} not found in the shipped script"
+        text = pat.sub(lambda m: m.group(1) + v + m.group(3), text, count=1)
+    return text
+
+
+def _interpreter(backend: str):
+    """Whatever this install actually uses for that backend, or None."""
+    if backend == "fenics":
+        from backends.fenics.backend import _find_fenics_python
+        p = _find_fenics_python()
+        return str(p) if p else None
+    if backend in ("skfem", "ngsolve", "fourc", "dealii", "febio", "kratos"):
+        return sys.executable                    # the wrapper runs here
+    if backend == "dune":
+        from backends.dune.backend import _find_dune_python
+        return _find_dune_python()
+    return None
+
+
+def _fourc_edits() -> dict:
+    from backends.fourc.backend import _find_fourc_binary
+    b = _find_fourc_binary()
+    if not b:
+        return {}
+    e = {"FOURC_BIN": json.dumps(str(b))}
+    ld = os.environ.get("LD_LIBRARY_PATH", "")
+    if ld:
+        e["FOURC_LD"] = json.dumps(ld.split(os.pathsep)[0])
+    return e
+
+
+def _available(name: str) -> bool:
+    from core.registry import get_backend, load_all_backends
+    load_all_backends()
+    b = get_backend(name)
+    return bool(b) and b.check_availability()[0].value == "available"
+
+
+def _shipped(name: str) -> Path:
+    return PART_DIR / f"participant_{name}.py"
+
+
+def _prepare(tmp: Path, backend: str, side: str) -> Path:
+    """Write one participant, edited for `side`, into its own work dir."""
+    wd = tmp / f"{backend}_{side}"
+    wd.mkdir(parents=True, exist_ok=True)
+    text = _shipped(backend).read_text()
+    edits = dict(_fourc_edits()) if backend == "fourc" else {}
+    if backend == "dealii":
+        exe = _dealii_exe()
+        if exe is None:
+            pytest.skip("no deal.II build environment on this host")
+        edits["DEALII_EXE"] = json.dumps(str(exe))
+    if side == "right":
+        edits.update(RIGHT_EDITS)
+    if edits:
+        text = _edit(text, edits)
+    dst = wd / f"participant_{side}.py"
+    dst.write_text(text)
+    return dst
+
+
+def _check_export(wd: Path):
+    ep = wd / "exports.json"
+    assert ep.is_file(), f"no exports.json in {wd}"
+    d = json.loads(ep.read_text())
+    for key in ("field_name", "coordinates", "values"):
+        assert key in d, f"exports.json is missing the required key {key!r}"
+    assert len(d["coordinates"]) > 0, "empty interface: nothing is shared"
+    assert len(d["values"]) == len(d["coordinates"])
+    import math
+    assert all(math.isfinite(v) for v in d["values"])
+    if "normal_fluxes" in d:
+        assert len(d["normal_fluxes"]) == len(d["coordinates"])
+        assert all(math.isfinite(q) for q in d["normal_fluxes"])
+    return d
+
+
+BACKENDS_WITH_SCRIPTS = sorted(
+    p.name[len("participant_"):-3] for p in PART_DIR.glob("participant_*.py"))
+
+# The backends whose shipped script implements the SAME canonical conduction
+# problem, so the documented right-side edit block applies verbatim to them.
+# FEBio (elasticity — FEBio 4 has no heat module), SPARTA (DSMC on a surface
+# mesh) and Kratos (Dirichlet-only script) solve different problems and are
+# covered by the contract tests, not by this parametrisation.
+DN_HEAT_BACKENDS = [b for b in ("fenics", "fourc", "ngsolve", "skfem", "dune",
+                                "dealii") if b in BACKENDS_WITH_SCRIPTS]
+
+
+def _dealii_exe():
+    """Build the shipped deal.II solver once; None if this host cannot."""
+    import shutil as _sh
+    if not _sh.which("cmake"):
+        return None
+    cand = [os.environ.get("DEAL_II_DIR", "")] + [
+        str(Path.home() / "dealii" / "build"), str(Path.home() / "dealii"),
+        "/usr/local", "/usr"]
+    root = next((c for c in cand if c and
+                 (Path(c) / "lib/cmake/deal.II/deal.IIConfig.cmake").is_file()), None)
+    if not root:
+        return None
+    build = Path(os.environ.get("TMPDIR", "/tmp")) / "oasis_dealii_participant_build"
+    exe = build / "heat_iface_dealii"
+    if exe.is_file():
+        return exe
+    build.mkdir(parents=True, exist_ok=True)
+    for cmd in (["cmake", "-S", str(PART_DIR), "-B", str(build),
+                 f"-DDEAL_II_DIR={root}", "-DCMAKE_BUILD_TYPE=Release"],
+                ["make", "-C", str(build), "-j4"]):
+        if subprocess.run(cmd, capture_output=True, text=True,
+                          timeout=1800).returncode != 0:
+            return None
+    return exe if exe.is_file() else None
+
+
+@pytest.mark.parametrize("backend", DN_HEAT_BACKENDS)
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_shipped_participant_runs_standalone(tmp_path, backend, side):
+    """Iteration-1 path: no imports.json, must still write a usable export."""
+    if not _available(backend):
+        pytest.skip(f"{backend} not available on this install")
+    py = _interpreter(backend)
+    if not py:
+        pytest.skip(f"no interpreter resolved for {backend}")
+    script = _prepare(tmp_path, backend, side)
+    r = subprocess.run([py, script.name], cwd=str(script.parent),
+                       capture_output=True, text=True, timeout=900)
+    assert (script.parent / "exports.json").is_file(), (
+        f"{backend} ({side}) wrote no exports.json, rc={r.returncode}\n"
+        f"stdout: {r.stdout[-1500:]}\nstderr: {r.stderr[-1500:]}")
+    _check_export(script.parent)
+
+
+@pytest.mark.parametrize("pair", [("fenics", "fourc"), ("fourc", "fenics")])
+def test_shipped_participants_couple_across_two_codes(tmp_path, pair):
+    """A REAL cross-code coupling through OASiS's own driver, both ways round.
+
+    Asserts convergence and that the two independent codes agree with each
+    other at the shared interface — a consistency property, not a stored value.
+    """
+    left, right = pair
+    for b in pair:
+        if not _available(b):
+            pytest.skip(f"{b} not available on this install")
+        if not _interpreter(b):
+            pytest.skip(f"no interpreter resolved for {b}")
+    if not _shipped(left).is_file() or not _shipped(right).is_file():
+        pytest.skip("participant script missing")
+
+    from core.coupling_driver import Participant, run_coupling
+    from core.quality_checks import check_interface_balance
+
+    sl = _prepare(tmp_path, left, "left")
+    sr = _prepare(tmp_path, right, "right")
+    parts = [
+        Participant("left", [_interpreter(left), sl.name], sl.parent,
+                    imports_from=["right"], timeout=900),
+        Participant("right", [_interpreter(right), sr.name], sr.parent,
+                    imports_from=["left"], timeout=900),
+    ]
+    res = run_coupling(parts, max_iter=90, tol=1e-7,
+                       accelerator="constant", theta0=0.7)
+    assert res.converged, f"{left}->{right} coupling failed: {res.error}"
+
+    ex = res.exports
+    tl = sum(ex["left"]["values"]) / len(ex["left"]["values"])
+    tr = sum(ex["right"]["values"]) / len(ex["right"]["values"])
+    span = 320.0 - 300.0                       # the placeholder problem's range
+    assert abs(tl - tr) < 1e-3 * span, (
+        f"the two codes disagree at the interface: {tl} vs {tr}")
+    assert not check_interface_balance(ex["left"], ex["right"], "left", "right")
+    # non-matching interface discretisation is the normal case, not a special one
+    assert ex["left"]["n_points"] != ex["right"]["n_points"]

--- a/tests/test_coupling_robustness.py
+++ b/tests/test_coupling_robustness.py
@@ -1,0 +1,1188 @@
+"""What a partitioned coupling gets WRONG quietly, and that OASiS now says so.
+
+Every case here was first run against the previous machinery and reported as a
+clean success, or reported nothing at all. They are the adversarial suite for
+`couple`: sign convention, unit mismatch, non-matching interfaces, a participant
+that exits 0 having done nothing, a crash mid-iteration, NaN in the exchanged
+data, non-convergence, one-way/two-way confusion, stale data, and relaxation.
+
+TWO RULES THESE TESTS ENFORCE ABOUT THEMSELVES.
+
+  * A test that passes whether or not the check exists is decoration. The
+    `*_discriminates` tests therefore stub the check out and assert the verdict
+    flips back to trustworthy — the check is what makes the difference, in this
+    suite, mechanically.
+  * A check that cannot look at anything must never report a pass. Findings
+    (`validation`) and coverage (`checks_not_run`) are separate channels, and
+    the second is asserted to reach the verdict text.
+
+The participants are deliberately small, opaque maps rather than FEM solves: the
+driver is physics-agnostic and these tests are about the driver. Cross-code runs
+with dolfinx / NGSolve / scikit-fem / 4C are how the physics side is exercised.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.coupling_driver import Participant, run_coupling          # noqa: E402
+from core.quality_checks import (                                    # noqa: E402
+    check_coupling_directionality, check_interface_balance,
+    check_interface_meshes, check_monolithic_consistency,
+    check_participant_responsiveness, check_residual_blocks,
+    check_returncodes,
+)
+
+
+# ── participants ─────────────────────────────────────────────────────────────
+# A: x <- 0.5*y + 1 ;  B: y <- 0.5*x + 2  =>  fixed point x = 8/3, y = 10/3.
+# Each also exports a normal flux with respect to its own outward normal, so the
+# two cancel at the fixed point exactly as a conservative interface must.
+_A = """\
+import json
+from pathlib import Path
+imp = json.loads(Path("imports.json").read_text() or "{}")
+y = imp["B"]["values"][0] if "B" in imp else 0.0
+x = 0.5 * y + 1.0
+json.dump({"field_name": "x", "n_points": 1, "coordinates": [[0.0, 0.0]],
+           "values": [x], "normal_fluxes": [x]}, open("exports.json", "w"))
+"""
+_B = """\
+import json
+from pathlib import Path
+imp = json.loads(Path("imports.json").read_text() or "{}")
+x = imp["A"]["values"][0] if "A" in imp else 0.0
+json.dump({"field_name": "y", "n_points": 1, "coordinates": [[0.0, 0.0]],
+           "values": [OFFSET + SCALE * x + 2.0], "normal_fluxes": [-x]},
+          open("exports.json", "w"))
+"""
+# The un-split solve of the SAME system, in one place: substitute and solve.
+_MONO = """\
+import json
+x = (1.0 + 0.5 * 2.0) / (1.0 - 0.25)
+json.dump({"field_name": "x", "n_points": 1, "coordinates": [[0.0, 0.0]],
+           "values": [x]}, open("monolithic.json", "w"))
+"""
+
+
+def _b(offset: float = 0.0, scale: float = 0.5) -> str:
+    return _B.replace("OFFSET", repr(offset)).replace("SCALE", repr(scale))
+
+
+def _mk(tmp_path: Path, name: str, body: str) -> Path:
+    d = tmp_path / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "run.py").write_text(body)
+    return d
+
+
+def _parts(tmp_path, a_body=_A, b_body=None, a_from=("B",), b_from=("A",)):
+    b_body = _b() if b_body is None else b_body
+    return [
+        Participant("A", [sys.executable, "run.py"], _mk(tmp_path, "A", a_body),
+                    imports_from=list(a_from)),
+        Participant("B", [sys.executable, "run.py"], _mk(tmp_path, "B", b_body),
+                    imports_from=list(b_from)),
+    ]
+
+
+# ── the tool, invoked for real ───────────────────────────────────────────────
+def _tool(name: str):
+    from mcp.server.fastmcp import FastMCP
+    from tools.consolidated import register_consolidated_tools
+    mcp = FastMCP("t")
+    register_consolidated_tools(mcp)
+    return mcp._tool_manager._tools[name].fn
+
+
+@pytest.fixture(autouse=True)
+def _fresh_critic(monkeypatch):
+    import tools.consolidated as C
+    from core.critic_gate import CriticRegistry
+    monkeypatch.setattr(C, "_CRITIC_REGISTRY", CriticRegistry())
+
+
+def _spec(parts):
+    return json.dumps([{"name": p.name, "command": p.command,
+                        "work_dir": str(p.work_dir),
+                        "imports_from": p.imports_from} for p in parts])
+
+
+def _couple(parts, *, reviewed=True, **kw):
+    """Call the real `couple` tool, with a critic review on record by default.
+
+    Without the review every verdict is NOT VERIFIED for that reason alone, and
+    a check could be removed without any test noticing. The interesting question
+    is whether the NUMERICAL checks flip the verdict, so the critic is satisfied
+    and then held constant.
+    """
+    from tools.consolidated import _coupling_setup_text, _CRITIC_REGISTRY
+    from core.critic_gate import setup_digest
+    kw.setdefault("max_iter", 60)
+    kw.setdefault("tol", 1e-8)
+    args = dict(participants=_spec(parts), **kw)
+    if reviewed:
+        setup = _coupling_setup_text(
+            participants=args["participants"], max_iter=args["max_iter"],
+            tol=args["tol"], accelerator=args.get("accelerator", "aitken"),
+            theta=args.get("theta", 0.5), monolithic=args.get("monolithic", ""),
+            probe=args.get("probe", True))
+        _CRITIC_REGISTRY.submit_review(
+            solver="couple", digest=setup_digest("couple", setup),
+            findings="Reviewed the participant maps, the units on both sides "
+                 "of the interface, the boundary conditions and the "
+                 "interface discretisation; no issue found that would "
+                 "invalidate the coupled run.")
+    loop = asyncio.new_event_loop()
+    try:
+        return json.loads(loop.run_until_complete(_tool("couple")(
+            critic_approved=True, **args)))
+    finally:
+        loop.close()
+
+
+def _hits(d, needle):
+    return [w for w in (d.get("validation") or []) if needle in w]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The control: a CORRECT coupling must come back clean. Every check below is
+# worthless if it also fires on this.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_a_correct_coupling_is_verified_and_produces_no_findings(tmp_path):
+    d = _couple(_parts(tmp_path))
+    assert d["converged"] is True
+    assert abs(d["exports"]["A"]["values"][0] - 8 / 3) < 1e-6
+    assert d["validation"] == [], d["validation"]
+    assert d["trustworthy_result"] is True
+    assert d["responsiveness"] == {"A": "responsive", "B": "responsive"}
+    assert d["returncodes"] == {"A": 0, "B": 0}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4 + 9. A participant that exits 0 having done nothing / re-serves a cached
+# answer. The coupling "converges" at iteration 2 with residual exactly 0.
+# ═══════════════════════════════════════════════════════════════════════════
+_NOOP = """\
+import json
+json.dump({"field_name": "y", "n_points": 1, "coordinates": [[0.0, 0.0]],
+           "values": [0.0], "normal_fluxes": [0.0]}, open("exports.json", "w"))
+"""
+
+
+def test_do_nothing_participant_converges_but_is_not_a_result(tmp_path):
+    d = _couple(_parts(tmp_path, b_body=_NOOP))
+    # It really does converge, and the residual really is zero. That is the
+    # problem: nothing about the iteration itself is wrong.
+    assert d["converged"] is True and d["residual"] == 0.0
+    assert d["responsiveness"]["B"] == "unresponsive"
+    assert _hits(d, "byte-identical")
+    assert d["trustworthy_result"] is False
+
+
+# Values-only exchange: no fluxes, so the interface-balance check has nothing to
+# look at and the responsiveness check is the ONLY thing standing between a
+# do-nothing participant and a VERIFIED verdict. That is the case the
+# discrimination test has to use.
+_A_NOFLUX = _A.replace(', "normal_fluxes": [x]', "")
+_NOOP_NOFLUX = """\
+import json
+json.dump({"field_name": "y", "n_points": 1, "coordinates": [[0.0, 0.0]],
+           "values": [0.0]}, open("exports.json", "w"))
+"""
+
+
+def test_do_nothing_detection_discriminates(tmp_path, monkeypatch):
+    """Two independent checks catch this, and BOTH are load-bearing.
+
+    Disabling either one alone still catches it — that is the point of having
+    two. Disabling both produces a VERIFIED coupling in which one participant
+    did nothing, which is what they are for.
+    """
+    import core.quality_checks as Q
+    dead = lambda *_a, **_k: ([], [])                       # noqa: E731
+
+    both = _couple(_parts(tmp_path / "b", a_body=_A_NOFLUX, b_body=_NOOP_NOFLUX))
+    assert both["converged"] is True and both["trustworthy_result"] is False
+
+    # only the interface-sensitivity probe left
+    monkeypatch.setattr(Q, "check_participant_responsiveness", dead)
+    probe_only = _couple(_parts(tmp_path / "p", a_body=_A_NOFLUX,
+                                b_body=_NOOP_NOFLUX))
+    assert probe_only["trustworthy_result"] is False
+    assert any("NOT COUPLED" in w for w in probe_only["validation"])
+    monkeypatch.undo()
+
+    # only the byte-identity responsiveness check left
+    resp_only = _couple(_parts(tmp_path / "r", a_body=_A_NOFLUX,
+                               b_body=_NOOP_NOFLUX), probe=False)
+    assert resp_only["trustworthy_result"] is False
+    assert any("byte-identical" in w for w in resp_only["validation"])
+
+    # neither
+    monkeypatch.setattr(Q, "check_participant_responsiveness", dead)
+    neither = _couple(_parts(tmp_path / "n", a_body=_A_NOFLUX,
+                             b_body=_NOOP_NOFLUX), probe=False)
+    assert neither["converged"] is True
+    assert neither["trustworthy_result"] is True, (
+        "with both stubbed out, a participant that did nothing produces a "
+        "VERIFIED coupling — which is what they are for")
+
+
+# ── the checks the critic pass added, each with its discrimination ───────────
+_STATEFUL_B = """\
+import json
+from pathlib import Path
+n = int(Path("n.txt").read_text()) + 1 if Path("n.txt").exists() else 1
+Path("n.txt").write_text(str(n))
+y = 10.0 * (1.0 - 0.5 ** n)          # converges on its own, reads nothing
+json.dump({"field_name": "y", "n_points": 1, "coordinates": [[0.0, 0.0]],
+           "values": [y]}, open("exports.json", "w"))
+"""
+
+
+def test_a_participant_with_hidden_state_is_caught_by_the_probe(tmp_path):
+    """It never opens imports.json, but its export moves every iteration, so it
+    reads as responsive throughout and the coupling converges."""
+    d = _couple(_parts(tmp_path, a_body=_A_NOFLUX, b_body=_STATEFUL_B))
+    assert d["converged"] is True
+    assert d["responsiveness"]["B"] == "responsive"      # the cheap check is fooled
+    assert any("NOT A FUNCTION" in w for w in d["validation"])
+    assert d["trustworthy_result"] is False
+
+
+def test_hidden_state_detection_discriminates(tmp_path):
+    d = _couple(_parts(tmp_path, a_body=_A_NOFLUX, b_body=_STATEFUL_B),
+                probe=False)
+    assert d["converged"] is True
+    assert d["trustworthy_result"] is True, (
+        "without the probe, a participant carrying hidden state between calls "
+        "converges and is stamped VERIFIED")
+    assert any("NOT probed" in c for c in d["checks_not_run"])
+
+
+# B pins its physics to a constant but echoes the imported value back in its
+# flux, so the STACKED export responds fully and the frozen half is invisible.
+_FROZEN_BLOCK_B = """\
+import json
+from pathlib import Path
+imp = json.loads(Path("imports.json").read_text() or "{}")
+x = imp["A"]["values"][0] if "A" in imp else 0.0
+json.dump({"field_name": "y", "n_points": 1, "coordinates": [[0.0, 0.0]],
+           "values": [10.0], "normal_fluxes": [-x]}, open("exports.json", "w"))
+"""
+
+
+def test_a_frozen_block_inside_a_responsive_export_is_caught(tmp_path):
+    d = _couple(_parts(tmp_path, b_body=_FROZEN_BLOCK_B))
+    assert d["converged"] is True
+    assert d["responsiveness"]["B"] == "responsive"
+    sens = d["interface_sensitivity"]["B"]
+    assert sens["S"] > 1e-9, "the export as a whole DOES respond"
+    assert any("do NOT respond" in w for w in d["validation"])
+    assert d["trustworthy_result"] is False
+
+
+def test_frozen_block_detection_discriminates(tmp_path):
+    d = _couple(_parts(tmp_path, b_body=_FROZEN_BLOCK_B), probe=False)
+    assert d["converged"] is True and d["trustworthy_result"] is True
+
+
+def test_the_probe_costs_nothing_in_correctness_on_a_good_coupling(tmp_path):
+    """It must not fire on a real coupling — the control for all of the above."""
+    d = _couple(_parts(tmp_path))
+    assert d["validation"] == [], d["validation"]
+    assert d["trustworthy_result"] is True
+    for name, rec in d["interface_sensitivity"].items():
+        assert rec["S"] > 1e-6, (name, rec)
+        assert rec["noise"] == 0.0, "a deterministic solver must repeat exactly"
+
+
+def test_a_genuinely_converged_participant_is_not_called_unresponsive(tmp_path):
+    """The check must key on 'output frozen while input moved', not on 'output
+    stopped moving' — otherwise every converged run trips it."""
+    d = _couple(_parts(tmp_path), tol=1e-14, max_iter=90)
+    assert d["responsiveness"] == {"A": "responsive", "B": "responsive"}
+    assert not _hits(d, "byte-identical")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. One-way vs two-way confusion.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_partner_name_typo_is_refused_not_silently_dropped(tmp_path):
+    parts = _parts(tmp_path, b_from=("Bee",))
+    r = run_coupling(parts, max_iter=5, tol=1e-8)
+    assert r.converged is False
+    assert "no such participant" in (r.error or "")
+    assert r.iterations == 0, "nothing must run before the graph is checked"
+
+
+def test_partner_name_typo_would_otherwise_converge_cleanly(tmp_path):
+    """Discrimination: with the edge dropped instead of refused — which is what
+    the driver used to do — the run converges and looks excellent."""
+    parts = _parts(tmp_path, b_from=())          # the dropped-edge outcome
+    r = run_coupling(parts, max_iter=20, tol=1e-8)
+    assert r.converged is True and r.residual < 1e-8
+    assert abs(r.exports["A"]["values"][0] - 8 / 3) > 0.5, (
+        "and the answer it converges to is not the coupled one")
+
+
+def test_one_way_graph_is_flagged_when_iterated(tmp_path):
+    d = _couple(_parts(tmp_path, b_from=()))
+    assert d["converged"] is True                 # it converges beautifully
+    assert _hits(d, "ONE-WAY")
+    assert d["trustworthy_result"] is False
+
+
+def test_one_way_declared_as_a_single_pass_is_not_flagged():
+    graph = {"participants": ["A", "B"], "declared_edges": {"A": ["B"], "B": []}}
+    iterated, _ = check_coupling_directionality(graph, max_iter=20)
+    single, not_run = check_coupling_directionality(graph, max_iter=1)
+    assert iterated and not single
+    assert not_run, "a declared single pass must still say no fixed point was found"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. A participant that crashes mid-iteration but leaves exports.json behind.
+# ═══════════════════════════════════════════════════════════════════════════
+_CRASH_AFTER_WRITE = _b() + """
+import sys
+from pathlib import Path
+n = int(Path("n.txt").read_text()) + 1 if Path("n.txt").exists() else 1
+Path("n.txt").write_text(str(n))
+if n >= 3:
+    sys.stderr.write("solver diverged\\n")
+    sys.exit(1)
+"""
+
+
+def test_nonzero_exit_is_refused_even_with_a_well_formed_export(tmp_path):
+    parts = _parts(tmp_path, b_body=_CRASH_AFTER_WRITE)
+    r = run_coupling(parts, max_iter=20, tol=1e-14)
+    assert r.converged is False
+    assert "exited with code 1" in (r.error or "")
+    assert r.iterations == 3
+    assert check_returncodes(r.returncodes)[0], "and the validator names it"
+
+
+def test_returncode_check_discriminates():
+    assert check_returncodes({"A": 0, "B": 1})[0]
+    assert not check_returncodes({"A": 0, "B": 0})[0]
+    # "no exit codes recorded" is NOT a pass.
+    findings, not_run = check_returncodes({})
+    assert not findings and not_run
+
+
+def test_a_participant_that_hangs_is_killed_and_reported(tmp_path):
+    hang = "import time\ntime.sleep(600)\n"
+    parts = _parts(tmp_path, b_body=hang)
+    parts[1].timeout = 2
+    r = run_coupling(parts, max_iter=3, tol=1e-8)
+    assert r.converged is False and "timed out" in (r.error or "")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. NaN / Inf in the exchanged data.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_nonfinite_flux_is_not_silently_passed_by_the_balance_check():
+    """`nan > rtol` is False, so an unguarded comparison reports NOTHING on the
+    most broken data the check can be handed."""
+    a = {"normal_fluxes": [1.0, 1.0]}
+    bad = {"normal_fluxes": [float("nan"), -1.0]}
+    good = {"normal_fluxes": [-1.0, -1.0]}
+    assert check_interface_balance(a, bad)
+    assert "could NOT be evaluated" in check_interface_balance(a, bad)[0]
+    assert not check_interface_balance(a, good)
+
+
+def test_a_component_that_is_zero_on_both_sides_is_not_an_imbalance():
+    """A validator that condemns a CORRECT coupling is worse than one that misses.
+
+    The per-component branch judges each component on its own scale. A component
+    that is zero on both sides — the tangential traction of a frictionless
+    interface, which is the ordinary case and not a corner one — then has a
+    denominator made of roundoff, and two entries that should cancel report tens
+    of percent. Measured before the floor: a normal traction of 1e5 cancelling
+    exactly, with 1e-17 tangential components, came back "NOT balanced ... 91.6%".
+
+    Remove the `floor` argument from the recursive call in
+    check_interface_balance and this test fails.
+    """
+    n = 11
+    rng = np.random.default_rng(0)
+    fa = np.stack([np.full(n, 1.0e5), rng.normal(0, 3e-17, n)], axis=1)
+    fb = np.stack([np.full(n, -1.0e5), rng.normal(0, 3e-17, n)], axis=1)
+    co = [[float(x), 0.0] for x in np.linspace(0, 1, n)]
+    assert check_interface_balance(
+        {"coordinates": co, "normal_fluxes": fa.tolist()},
+        {"coordinates": co, "normal_fluxes": fb.tolist()}) == []
+    # and the floor must not blind the check to a REAL imbalance in the same
+    # small component: comp1 off by a factor of two is still caught.
+    fb2 = np.stack([np.full(n, -1.0e5), np.full(n, -0.25)], axis=1)
+    fa2 = np.stack([np.full(n, 1.0e5), np.full(n, 0.5)], axis=1)
+    got = check_interface_balance(
+        {"coordinates": co, "normal_fluxes": fa2.tolist()},
+        {"coordinates": co, "normal_fluxes": fb2.tolist()})
+    assert got and "[1]" in got[0], got
+
+
+def test_nonfinite_export_is_reported_by_the_tool(tmp_path):
+    nan_b = _b().replace('"normal_fluxes": [-x]', '"normal_fluxes": [float("nan")]')
+    d = _couple(_parts(tmp_path, b_body=nan_b), max_iter=5)
+    assert any("non-finite" in w for w in d["validation"])
+    assert d["trustworthy_result"] is False
+
+
+def test_nonfinite_warnings_do_not_bury_every_other_finding(tmp_path):
+    """One NaN used to produce a warning per participant per iteration — about
+    eighty near-identical lines, with every specific finding lost among them."""
+    nan_b = _b().replace('"normal_fluxes": [-x]', '"normal_fluxes": [float("nan")]')
+    parts = _parts(tmp_path, b_body=nan_b)
+    r = run_coupling(parts, max_iter=40, tol=1e-8)
+    assert len(r.warnings) <= 6, r.warnings
+    assert any("suppressed" in w for w in r.warnings)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. Non-convergence, and the residual that is not representative.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_nonconvergence_is_reported_as_failure_not_as_a_result(tmp_path):
+    d = _couple(_parts(tmp_path, b_body=_b(scale=3.0)),
+                max_iter=8, tol=1e-12, accelerator="constant", theta=1.0)
+    assert d["converged"] is False
+    assert _hits(d, "NOT CONVERGED")
+    assert d["trustworthy_result"] is False
+
+
+def test_a_large_settled_block_cannot_hide_a_small_moving_one():
+    """The FSI/TSI conditioning trap: one global relative norm is set by the
+    largest-magnitude block, so a small quantity can be 100% wrong underneath a
+    converged residual."""
+    blocks = {"A.values[0]": 1e-12, "A.values[1]": 0.4, "B.normal_fluxes": 1e-12}
+    findings, not_run = check_residual_blocks(blocks, tol=1e-8)
+    assert findings and "A.values[1]" in findings[0]
+    assert not not_run
+    clean, _ = check_residual_blocks({k: 1e-12 for k in blocks}, tol=1e-8)
+    assert not clean
+    # and an empty record is NOT a pass
+    assert check_residual_blocks({}, tol=1e-8)[1]
+
+
+def test_block_residuals_are_recorded_per_component(tmp_path):
+    """A TSI interface carries temperature and displacement inside ONE `values`
+    array on wildly different scales; per-array residuals would still lump them."""
+    two = _A.replace('"values": [x], "normal_fluxes": [x]',
+                     '"values": [[x, 1e-9 * x]], "normal_fluxes": [x]')
+    parts = _parts(tmp_path, a_body=two)
+    parts[1].work_dir  # noqa: B018 - keep B as-is; it reads values[0] via [0]
+    b2 = _b().replace('imp["A"]["values"][0]', 'imp["A"]["values"][0][0]')
+    parts = _parts(tmp_path, a_body=two, b_body=b2)
+    r = run_coupling(parts, max_iter=30, tol=1e-10)
+    assert "A.values[0]" in r.block_residuals
+    assert "A.values[1]" in r.block_residuals
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1 + 2. Sign convention and unit mismatch: same imbalance number, opposite
+# diagnoses, and the agent is sent looking in a different place by each.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_matching_magnitudes_with_agreeing_signs_reads_as_a_sign_convention_error():
+    w = check_interface_balance({"normal_fluxes": [3.0]}, {"normal_fluxes": [3.0]})
+    assert w and "SIGN-CONVENTION" in w[0]
+    assert "same number on both sides" in w[0]
+
+
+def test_a_clean_power_of_ten_reads_as_a_unit_mismatch():
+    w = check_interface_balance({"normal_fluxes": [-100.0]},
+                                {"normal_fluxes": [0.1]})
+    assert w and "UNIT MISMATCH" in w[0]
+    assert "SIGN-CONVENTION" not in w[0]
+
+
+def test_an_ordinary_imbalance_names_neither():
+    w = check_interface_balance({"normal_fluxes": [-100.0]},
+                                {"normal_fluxes": [83.0]})
+    assert w and "UNIT MISMATCH" not in w[0] and "SIGN-CONVENTION" not in w[0]
+
+
+def test_balance_check_says_nothing_when_it_cannot_look(tmp_path):
+    """Values-only exchange is common and legitimate. What must not happen is an
+    empty finding list reading as 'conservation was checked and is fine'."""
+    a = _A.replace(', "normal_fluxes": [x]', "")
+    b = _b().replace(', "normal_fluxes": [-x]', "")
+    d = _couple(_parts(tmp_path, a_body=a, b_body=b))
+    assert d["converged"] is True
+    assert not _hits(d, "balance")
+    assert any("flux balance" in c and "NOT checked" in c
+               for c in d["checks_not_run"])
+    assert "COVERAGE" in d["verification"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. Non-matching interface discretisations.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_non_matching_interfaces_are_reported_with_what_that_costs():
+    a = {"coordinates": [[0.5, y / 4] for y in range(5)],
+         "normal_fluxes": [1.0] * 5}
+    b = {"coordinates": [[0.5, y / 2] for y in range(3)],
+         "normal_fluxes": [-1.0] * 3}
+    findings, not_run = check_interface_meshes(a, b, "A", "B")
+    assert not findings, "a non-matching interface is legitimate, not an error"
+    assert not_run and "NON-MATCHING" in not_run[0]
+    assert "flux balance" in not_run[0]
+
+
+def test_non_matching_without_any_flux_says_conservation_was_not_checked():
+    a = {"coordinates": [[0.5, y / 4] for y in range(5)]}
+    b = {"coordinates": [[0.5, y / 2] for y in range(3)]}
+    _, not_run = check_interface_meshes(a, b, "A", "B")
+    assert not_run and "NOTHING here checked" in not_run[0]
+
+
+def test_matching_interfaces_produce_no_note():
+    co = [[0.5, y / 4] for y in range(5)]
+    findings, not_run = check_interface_meshes({"coordinates": co},
+                                               {"coordinates": co})
+    assert not findings and not not_run
+
+
+def test_missing_coordinates_is_not_checked_rather_than_matching():
+    findings, not_run = check_interface_meshes({}, {})
+    assert not findings and not_run
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# An export whose layout changes between iterations.
+# ═══════════════════════════════════════════════════════════════════════════
+_GROWING = """\
+import json
+from pathlib import Path
+n = int(Path("n.txt").read_text()) + 1 if Path("n.txt").exists() else 1
+Path("n.txt").write_text(str(n))
+k = 1 if n < 2 else 3
+json.dump({"field_name": "y", "n_points": k,
+           "coordinates": [[0.0, 0.0]] * k, "values": [2.0] * k},
+          open("exports.json", "w"))
+"""
+
+
+def test_an_export_that_changes_length_is_refused(tmp_path):
+    parts = _parts(tmp_path, b_body=_GROWING)
+    r = run_coupling(parts, max_iter=5, tol=1e-8)
+    assert r.converged is False
+    assert "changed its export length" in (r.error or "")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 10. Relaxation. theta had no way in through the tool at all, and the
+# accelerator was not Aitken.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_theta_reaches_the_driver_and_the_applied_value_is_reported(tmp_path):
+    d = _couple(_parts(tmp_path), accelerator="constant", theta=0.25)
+    assert d["relaxation"]["mode"] == "constant"
+    assert d["relaxation"]["theta0"] == 0.25
+    assert d["relaxation"]["applied"] == 0.25
+
+
+def test_constant_relaxation_actually_uses_the_given_theta(tmp_path):
+    """Discrimination for the parameter itself: a theta that is ignored gives
+    the same iteration count for every value."""
+    n = {}
+    for th in (0.25, 0.5, 1.0):
+        parts = _parts(tmp_path / f"t{th}")
+        r = run_coupling(parts, max_iter=200, tol=1e-10,
+                         accelerator="constant", theta0=th)
+        assert r.converged
+        n[th] = r.iterations
+    assert len(set(n.values())) == 3, n
+
+
+def test_aitken_recovers_from_a_theta0_that_does_not_converge(tmp_path):
+    """The point of the accelerator, and the regression that mattered: Aitken
+    was handed the previous raw export where the formula wants the previous
+    residual, and relaxed each participant by a different theta.
+
+    scale=-2.0, not -1.0. The composite Jacobi map over the stacked state
+    (A.values, A.fluxes, B.values, B.fluxes) is J = [[0,0,.5,0], [0,0,.5,0],
+    [s,0,0,0], [s,0,0,0]], whose non-zero eigenvalues satisfy lambda^2 = 0.5*s.
+    At s=-1 that is |lambda| = 0.707, so theta=1 CONVERGES — in 68 iterations,
+    and `assert not converged` at max_iter=60 was passing on the budget being 8
+    short rather than on the premise in the comment. At s=-2, |lambda| = 1
+    exactly, the relaxed spectral radius is |1-theta+i*theta| >= 1 at theta=1,
+    and theta=1 provably cannot converge however long it runs (measured: still
+    2.65e+00 after 400 iterations). Same map, real premise.
+    """
+    body = _b(scale=-2.0)          # |lambda(J)| = 1 exactly: theta=1 cannot converge
+    fixed = run_coupling(_parts(tmp_path / "c", b_body=body), max_iter=120,
+                         tol=1e-10, accelerator="constant", theta0=1.0)
+    assert not fixed.converged, "theta0=1 must be the bad choice here"
+    # and not merely short of budget: the residual is still O(1), not creeping down
+    assert fixed.residual > 1e-3, fixed.residual
+    ait = run_coupling(_parts(tmp_path / "a", b_body=body), max_iter=120,
+                       tol=1e-10, accelerator="aitken", theta0=1.0)
+    assert ait.converged, "Aitken must find a theta that works from a bad start"
+    assert 0.05 <= ait.theta["applied"] <= 1.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# THE STRONGEST CHECK: compare against the same problem solved un-split.
+# ═══════════════════════════════════════════════════════════════════════════
+def _mono_spec(tmp_path, body=_MONO, timeout=60):
+    d = tmp_path / "MONO"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "run.py").write_text(body)
+    return json.dumps({"command": [sys.executable, "run.py"],
+                       "work_dir": str(d), "timeout": timeout})
+
+
+def test_monolithic_check_catches_a_coupling_that_passes_everything_else(tmp_path):
+    """A consistent offset in what one side reads — the K vs degC mistake.
+
+    The iteration converges, the interface flux balances exactly, every export
+    is finite, both participants respond to their inputs, the graph is two-way
+    and the interfaces match. The answer is wrong by a factor of four, and the
+    un-split re-solve is the only thing here that can see it.
+    """
+    parts = _parts(tmp_path, b_body=_b(offset=-5.0))
+    clean = _couple(parts)
+    assert clean["converged"] is True
+    assert clean["validation"] == [], clean["validation"]
+    assert clean["trustworthy_result"] is True          # nothing else objects
+    assert abs(clean["exports"]["A"]["values"][0] - 8 / 3) > 1.0
+
+    checked = _couple(_parts(tmp_path / "m", b_body=_b(offset=-5.0)),
+                      monolithic=_mono_spec(tmp_path))
+    assert checked["monolithic_check"]["status"] == "checked"
+    assert _hits(checked, "likely WRONG")
+    assert checked["trustworthy_result"] is False
+
+
+def test_monolithic_check_agrees_with_a_correct_coupling(tmp_path):
+    d = _couple(_parts(tmp_path), monolithic=_mono_spec(tmp_path))
+    assert d["monolithic_check"]["status"] == "checked"
+    assert d["monolithic_check"]["A"]["relative_l2"] < 1e-6
+    assert d["validation"] == [], d["validation"]
+    assert d["trustworthy_result"] is True
+
+
+def test_monolithic_check_refuses_to_compare_a_different_quantity(tmp_path):
+    """B exports y, the reference solves for x. Comparing them would report a
+    large disagreement that means nothing at all."""
+    d = _couple(_parts(tmp_path), monolithic=_mono_spec(tmp_path))
+    assert "A" in d["monolithic_check"] and "B" not in d["monolithic_check"]
+    assert any("nothing to compare" in c for c in d["checks_not_run"])
+
+
+def test_absence_of_a_monolithic_reference_is_stated_in_the_verdict(tmp_path):
+    d = _couple(_parts(tmp_path))
+    assert d["monolithic_check"] == {"status": "not supplied"}
+    assert any("monolithic consistency: NOT CHECKED" in c
+               for c in d["checks_not_run"])
+    assert "COVERAGE" in d["verification"]
+    assert d["trustworthy_result"] is True, (
+        "not supplying the reference is not evidence of a wrong answer — it is "
+        "an unchecked one, and the verdict must say which")
+
+
+def test_a_failed_reference_solve_is_not_read_as_agreement(tmp_path):
+    """The coupling is not innocent because its reference could not be produced."""
+    d = _couple(_parts(tmp_path),
+                monolithic=_mono_spec(tmp_path, body="import sys; sys.exit(2)"))
+    assert d["monolithic_check"]["status"] == "reference solve failed"
+    assert not _hits(d, "likely WRONG")
+    assert any("NOT CHECKED" in c for c in d["checks_not_run"])
+    assert "COVERAGE" in d["verification"]
+
+
+def test_monolithic_consistency_unit():
+    assert check_monolithic_consistency(96.9, 50.0)
+    assert not check_monolithic_consistency(50.0, 50.5)
+    assert check_monolithic_consistency(float("nan"), 50.0)
+    assert "not corroborated" in check_monolithic_consistency(float("nan"), 50.0)[0]
+    assert not check_monolithic_consistency(None, 50.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Coverage is a separate channel from findings, in the verdict itself.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_checks_that_could_not_run_never_flip_the_verdict_but_always_appear(tmp_path):
+    a = _A.replace(', "normal_fluxes": [x]', "")
+    b = _b().replace(', "normal_fluxes": [-x]', "")
+    d = _couple(_parts(tmp_path, a_body=a, b_body=b))
+    assert d["trustworthy_result"] is True
+    assert d["verification"].startswith("VERIFIED")
+    assert "COVERAGE" in d["verification"]
+    for note in d["checks_not_run"]:
+        assert note in d["verification"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The three limits that were true of the machinery but were stated only in
+# docstrings, which no agent reads. A limit that is not SERVED is a limit the
+# reader does not have, and VERIFIED then implies more than was established.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_the_digest_says_which_files_it_actually_covers(tmp_path):
+    """The fingerprint reaches the paths the SPEC NAMES. A helper module the
+    script imports at runtime is outside it: rewriting `model.py` moved a
+    reviewed x=2.666667 to x=334.666665 with the verdict still VERIFIED. That
+    is a real limit, so it is stated where the verdict is read.
+    """
+    d = _couple(_parts(tmp_path))
+    assert d["trustworthy_result"] is True
+    hit = [c for c in d["checks_not_run"] if "review-to-run binding SCOPE" in c]
+    assert hit, d["checks_not_run"]
+    assert "data_files" in hit[0]        # says how to bring such a file inside
+    assert hit[0] in d["verification"]
+
+
+def test_the_sensitivity_frontier_is_stated_where_the_verdict_is_read(tmp_path):
+    """S above the floor proves the export MOVES, not that it moves correctly.
+    Measured: values = 6.0 + 1e-6*import is 50% wrong and produces no finding.
+    """
+    d = _couple(_parts(tmp_path), probe=True)
+    hit = [c for c in d["checks_not_run"] if "sensitivity FRONTIER" in c]
+    assert hit, d["checks_not_run"]
+    assert "monolithic" in hit[0]
+    assert hit[0] in d["verification"]
+
+
+def test_the_wrong_surface_limit_is_stated_where_the_verdict_is_read(tmp_path):
+    """Overlapping coordinates are the coordinates the participants REPORTED."""
+    d = _couple(_parts(tmp_path))
+    hit = [c for c in d["checks_not_run"] if "interface identity" in c]
+    assert hit, d["checks_not_run"]
+    assert hit[0] in d["verification"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The degenerate case every value-based check is blind to: nothing exchanged.
+# ═══════════════════════════════════════════════════════════════════════════
+_EMPTY = """\
+import json
+json.dump({"field_name": "y", "n_points": 0, "coordinates": [], "values": []},
+          open("exports.json", "w"))
+"""
+
+
+def test_an_empty_interface_is_not_a_converged_coupling(tmp_path):
+    """With nothing in the stacked vector the residual is 0 at iteration 2, and
+    every value-based check has nothing to look at and therefore says nothing."""
+    parts = _parts(tmp_path, b_body=_EMPTY)
+    r = run_coupling(parts, max_iter=10, tol=1e-8)
+    assert r.converged is False
+    assert "EMPTY interface" in (r.error or "")
+
+
+def test_empty_interface_would_otherwise_report_a_zero_residual(tmp_path):
+    """Discrimination: the same participants with ONE value converge honestly,
+    so it is the emptiness the guard reacts to, not the participant."""
+    one = _EMPTY.replace('"n_points": 0, "coordinates": [], "values": []',
+                         '"n_points": 1, "coordinates": [[0.0, 0.0]], "values": [2.0]')
+    r = run_coupling(_parts(tmp_path / "b", b_body=one), max_iter=10, tol=1e-8)
+    assert r.converged is True and r.residual == 0.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Conservation is not one number, and an interface is not just a node count.
+# ═══════════════════════════════════════════════════════════════════════════
+from core.quality_checks import (                                    # noqa: E402
+    check_interface_flux_profile, check_interfaces_are_the_same_surface,
+    check_interface_sensitivity,
+)
+
+_CO4 = [[0.5, y / 3] for y in range(4)]
+
+
+def test_a_wrong_flux_distribution_that_sums_to_zero_is_caught():
+    """The net balance is a single number, and a redistribution along the
+    interface cancels in the sum. A exports a uniform flux; B piles it all onto
+    one node and takes it off the others. The totals cancel EXACTLY."""
+    a = {"coordinates": _CO4, "normal_fluxes": [1.0, 1.0, 1.0, 1.0]}
+    b = {"coordinates": _CO4, "normal_fluxes": [-40.0, 12.0, 12.0, 12.0]}
+    assert abs(sum(a["normal_fluxes"]) + sum(b["normal_fluxes"])) < 1e-12
+    assert not check_interface_balance(a, b), "the total balance is satisfied"
+    findings, not_run = check_interface_flux_profile(a, b)
+    assert findings and "POINT BY POINT" in findings[0]
+    assert not not_run
+
+
+def test_flux_profile_check_passes_a_correct_distribution():
+    a = {"coordinates": _CO4, "normal_fluxes": [1.0, 2.0, 3.0, 4.0]}
+    b = {"coordinates": _CO4, "normal_fluxes": [-1.0, -2.0, -3.0, -4.0]}
+    findings, not_run = check_interface_flux_profile(a, b)
+    assert not findings and not not_run
+
+
+def test_flux_profile_says_it_could_not_look_rather_than_passing():
+    """Different node counts, or coordinates that do not line up: the profile
+    cannot be compared, and that must not read as conservation being fine."""
+    a = {"coordinates": _CO4, "normal_fluxes": [1.0] * 4}
+    b = {"coordinates": _CO4[:2], "normal_fluxes": [-2.0] * 2}
+    findings, not_run = check_interface_flux_profile(a, b)
+    assert not findings and not_run and "ONLY conservation evidence" in not_run[0]
+    findings, not_run = check_interface_flux_profile({"coordinates": _CO4}, b)
+    assert not findings and not_run
+
+
+def test_two_interfaces_that_do_not_overlap_are_not_one_interface():
+    a = {"coordinates": [[0.5, 0.0], [0.5, 1.0]]}
+    b = {"coordinates": [[0.5, 5.0], [0.5, 6.0]]}
+    findings, _ = check_interfaces_are_the_same_surface(a, b)
+    assert findings and "do NOT overlap" in findings[0]
+
+
+def test_overlapping_interfaces_of_different_resolution_are_fine():
+    a = {"coordinates": [[0.5, y / 10] for y in range(11)]}
+    b = {"coordinates": [[0.5, y / 2] for y in range(3)]}
+    findings, not_run = check_interfaces_are_the_same_surface(a, b)
+    # No FINDING: differing resolution on the same surface is legitimate.
+    assert not findings
+    # Coverage is a different channel, and overlapping-as-reported is exactly
+    # where the reader needs telling that "as reported" is all that was checked.
+    assert [n for n in not_run if "interface identity" in n], not_run
+
+
+def test_missing_coordinates_is_reported_not_passed():
+    findings, not_run = check_interfaces_are_the_same_surface({}, {})
+    assert not findings and not_run
+
+
+# ── intra-block scale masking: a huge and a small entry in ONE flat array ────
+_BIG_A = """\
+import json
+from pathlib import Path
+imp = json.loads(Path("imports.json").read_text() or "{}")
+s = imp["B"]["values"][1] if "B" in imp else 0.0
+json.dump({"field_name": "v", "n_points": 2, "coordinates": [[0.0, 0.0], [0.0, 1.0]],
+           "values": [1e12, -1.0 * s + 1.0]}, open("exports.json", "w"))
+"""
+_BIG_B = """\
+import json
+from pathlib import Path
+imp = json.loads(Path("imports.json").read_text() or "{}")
+s = imp["A"]["values"][1] if "A" in imp else 0.0
+json.dump({"field_name": "v", "n_points": 2, "coordinates": [[0.0, 0.0], [0.0, 1.0]],
+           "values": [1e12, -1.0 * s + 1.0]}, open("exports.json", "w"))
+"""
+
+
+def test_a_huge_entry_cannot_mask_a_small_one_in_the_same_array(tmp_path):
+    """`values` is often a flat list of mixed quantities. A block NORM is set by
+    the largest entry, so a small entry oscillating by 100% of itself leaves the
+    block residual at 1e-12 and the coupling reports convergence at iteration 2.
+    """
+    d = _couple(_parts(tmp_path, a_body=_BIG_A, b_body=_BIG_B),
+                max_iter=40, tol=1e-8)
+    assert d["converged"] is True and d["residual"] < 1e-8
+    assert d["block_residuals"]["A.values"] > 0.1, (
+        "the entry-wise measure must see the oscillation the norm hides")
+    assert any("NOT representative" in w for w in d["validation"])
+    assert d["trustworthy_result"] is False
+
+
+def test_intra_block_masking_discriminates(tmp_path, monkeypatch):
+    """Restore the block-NORM measure and the oscillation disappears.
+
+    The probe is disabled here on purpose: it measures its per-block
+    sensitivity with the same function, so it independently catches this case
+    too. Isolating one check at a time is the only way to show that each is
+    doing the work the test claims.
+    """
+    import core.coupling_driver as D
+    import numpy as _np
+
+    def _norm_ratio(new, prev):          # the block-NORM measure it replaced
+        if new.shape != prev.shape or new.size == 0:
+            return float("nan")
+        ref = float(_np.linalg.norm(prev)) + float(_np.linalg.norm(new))
+        return 0.0 if ref <= 0 else float(_np.linalg.norm(new - prev)) * 2.0 / ref
+
+    monkeypatch.setattr(D, "_rel_change", _norm_ratio)
+    d = _couple(_parts(tmp_path, a_body=_BIG_A, b_body=_BIG_B),
+                max_iter=40, tol=1e-8, probe=False)
+    assert d["converged"] is True
+    assert d["block_residuals"]["A.values"] < 1e-8, (
+        "with the norm measure the oscillation is invisible")
+    assert d["trustworthy_result"] is True, (
+        "and the coupling is stamped VERIFIED with one exchanged quantity "
+        "oscillating by 100% of itself")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The critic gate binds a review to a SETUP. Anything that changes what is
+# solved and is not in the digest is a review of one thing approving another.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_rewriting_a_participant_script_after_review_is_refused(tmp_path):
+    """The spec names `["python", "run.py"]`; the physics is inside run.py.
+
+    Without the file contents in the digest, reviewing a correct coupling
+    approved any other coupling that reused the same file names.
+    """
+    parts = _parts(tmp_path)
+    ok = _couple(parts)
+    assert ok["trustworthy_result"] is True
+    x_reviewed = ok["exports"]["A"]["values"][0]
+
+    # same file name, same command, same work_dir — different physics
+    (parts[1].work_dir / "run.py").write_text(_b(offset=900.0))
+    swapped = _couple(parts, reviewed=False)
+    assert swapped["converged"] is True
+    assert abs(swapped["exports"]["A"]["values"][0] - x_reviewed) > 100.0
+    assert swapped["trustworthy_result"] is False
+    assert "changed after it was reviewed" in swapped["critic_review"]
+
+
+def test_script_fingerprint_discriminates(tmp_path, monkeypatch):
+    """Strip the file contents back out of the digest and the swap goes through."""
+    import tools.consolidated as C
+    monkeypatch.setattr(C, "_participant_fingerprints", lambda *_a, **_k: {})
+    parts = _parts(tmp_path)
+    assert _couple(parts)["trustworthy_result"] is True
+    (parts[1].work_dir / "run.py").write_text(_b(offset=900.0))
+    swapped = _couple(parts, reviewed=False)
+    assert swapped["converged"] is True
+    assert swapped["trustworthy_result"] is True, (
+        "without the script fingerprint, a review of one coupling stamps a "
+        "completely different one as VERIFIED")
+
+
+def test_a_participant_script_that_does_not_exist_yet_cannot_be_reviewed(tmp_path):
+    """Fail closed: an absent file is recorded as absent, so writing it later
+    changes the digest."""
+    from tools.consolidated import _participant_fingerprints
+    spec = json.dumps([{"name": "A", "command": [sys.executable, "later.py"],
+                        "work_dir": str(tmp_path)}])
+    before = _participant_fingerprints(spec)
+    (tmp_path / "later.py").write_text("pass\n")
+    after = _participant_fingerprints(spec)
+    assert before != after
+    assert before["A"]["later.py"] == "absent"
+    assert after["A"]["later.py"].startswith("sha256:")
+
+
+def test_data_files_are_part_of_the_setup(tmp_path):
+    """A compiled solver's physics is in its deck, which arrives via data_files."""
+    from tools.consolidated import _participant_fingerprints
+    deck = tmp_path / "deck.yaml"
+    deck.write_text("k: 1.0\n")
+    spec = json.dumps([{"name": "A", "command": ["/bin/true"],
+                        "work_dir": str(tmp_path), "data_files": [str(deck)]}])
+    before = _participant_fingerprints(spec)
+    deck.write_text("k: 1000.0\n")
+    assert _participant_fingerprints(spec) != before
+
+
+def test_submit_critic_review_uses_the_same_definition_as_the_run(tmp_path):
+    """The review path used to build its own setup text, so the two could — and
+    did — cover different sets of arguments."""
+    import tools.consolidated as C
+    parts = _parts(tmp_path)
+    args = {"participants": _spec(parts), "max_iter": 60, "tol": 1e-8,
+            "accelerator": "aitken", "theta": 0.5, "monolithic": "",
+            "probe": True}
+    loop = asyncio.new_event_loop()
+    try:
+        out = json.loads(loop.run_until_complete(_tool("submit_critic_review")(
+            solver="couple",
+            findings="Checked the participant maps, the interface units, the "
+                     "boundary conditions and the discretisation; nothing found "
+                     "that would invalidate the coupled run.",
+            coupling_args=json.dumps(args))))
+        assert out["accepted"] is True
+        d = json.loads(loop.run_until_complete(_tool("couple")(
+            critic_approved=True, **args)))
+    finally:
+        loop.close()
+    assert d["trustworthy_result"] is True, d["critic_review"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Mutation testing found these SIX checks untested. A check whose call site can
+# be deleted without a test noticing is not wired, whatever its unit test says.
+# ═══════════════════════════════════════════════════════════════════════════
+def test_vector_flux_components_are_balanced_one_by_one():
+    """Summing a vector traction across components lets a +x imbalance cancel a
+    -y one and report perfect conservation across an interface that conserves
+    nothing."""
+    a = {"normal_fluxes": [[10.0, 3.0]]}
+    b = {"normal_fluxes": [[-3.0, -10.0]]}          # totals: 13 and -13
+    assert abs(sum(sum(v) for v in a["normal_fluxes"])
+               + sum(sum(v) for v in b["normal_fluxes"])) < 1e-12
+    w = check_interface_balance(a, b)
+    assert w, "component-wise, neither x nor y balances"
+    assert any("[0]" in m for m in w) and any("[1]" in m for m in w)
+    ok = check_interface_balance({"normal_fluxes": [[10.0, 3.0]]},
+                                 {"normal_fluxes": [[-10.0, -3.0]]})
+    assert not ok
+
+
+def test_mismatched_flux_component_counts_are_reported_not_skipped():
+    w = check_interface_balance({"normal_fluxes": [[1.0, 2.0]]},
+                                {"normal_fluxes": [[-1.0, -2.0, 0.0]]})
+    assert w and "could NOT be evaluated" in w[0]
+
+
+# The three tool-level wirings. Each of these was reachable only through a unit
+# test, so deleting the call in `couple` changed nothing that any test saw.
+_CO11 = [[0.5, y / 10] for y in range(11)]
+
+
+def _iface_participant(coords, fluxes, value="x") -> str:
+    return (
+        "import json\nfrom pathlib import Path\n"
+        'imp = json.loads(Path("imports.json").read_text() or "{}")\n'
+        f'v = imp["{"B" if value == "x" else "A"}"]["values"][0] if imp else 0.0\n'
+        f"co = {coords!r}\nfl = {fluxes!r}\n"
+        'json.dump({"field_name": "t", "n_points": len(co), "coordinates": co,\n'
+        '           "values": [0.5 * v + 1.0] * len(co), "normal_fluxes": fl},\n'
+        '          open("exports.json", "w"))\n')
+
+
+def test_flux_profile_check_is_wired_into_couple(tmp_path):
+    """Totals cancel exactly; the distribution is nonsense."""
+    a = _iface_participant(_CO11, [1.0] * 11, "x")
+    b = _iface_participant(_CO11, [-11.0] + [0.0] * 10, "y")
+    d = _couple(_parts(tmp_path, a_body=a, b_body=b), max_iter=30, tol=1e-8)
+    assert d["converged"] is True
+    assert not any("NOT balanced" in w for w in d["validation"]), \
+        "the NET balance is satisfied — only the profile is wrong"
+    assert any("POINT BY POINT" in w for w in d["validation"])
+    assert d["trustworthy_result"] is False
+
+
+def test_same_surface_check_is_wired_into_couple(tmp_path):
+    a = _iface_participant([[0.5, 0.0], [0.5, 1.0]], [1.0, 1.0], "x")
+    b = _iface_participant([[0.5, 90.0], [0.5, 91.0]], [-1.0, -1.0], "y")
+    d = _couple(_parts(tmp_path, a_body=a, b_body=b), max_iter=30, tol=1e-8)
+    assert d["converged"] is True
+    assert any("do NOT overlap" in w for w in d["validation"])
+    assert d["trustworthy_result"] is False
+
+
+def test_mesh_conformity_note_is_wired_into_couple(tmp_path):
+    a = _iface_participant(_CO11, [1.0] * 11, "x")
+    b = _iface_participant([[0.5, y / 2] for y in range(3)], [-11.0 / 3] * 3, "y")
+    d = _couple(_parts(tmp_path, a_body=a, b_body=b), max_iter=30, tol=1e-8)
+    assert any("NON-MATCHING" in c for c in d["checks_not_run"])
+    assert "NON-MATCHING" in d["verification"]
+
+
+def test_aitken_beats_the_theta_it_started_from(tmp_path):
+    """Discrimination for the Aitken fix itself.
+
+    Handing the formula the previous RAW EXPORT where it wants the previous
+    RESIDUAL leaves theta wandering inside its clamp, which costs convergence
+    RATE rather than correctness — so a test that only asks "did it converge"
+    passes with the bug in place. This asks for the rate: on a map whose
+    un-relaxed iteration does not converge at all, correct Aitken has to find
+    the theta that does, and get there in a comparable number of iterations to
+    the best constant choice.
+    """
+    body = _b(scale=-1.0)                       # oscillates at theta = 1
+    best = run_coupling(_parts(tmp_path / "k", b_body=body), max_iter=400,
+                        tol=1e-10, accelerator="constant", theta0=0.5)
+    assert best.converged
+    ait = run_coupling(_parts(tmp_path / "a", b_body=body), max_iter=400,
+                       tol=1e-10, accelerator="aitken", theta0=1.0)
+    assert ait.converged
+    assert ait.iterations <= best.iterations + 4, (
+        f"Aitken took {ait.iterations} where the best constant theta took "
+        f"{best.iterations} — it is not tracking the residual")
+    # and it must have MOVED off the starting guess it was given, which is the
+    # whole claim. The optimum for this map is not derived here, so its value is
+    # not asserted — the rate above is the substantive check.
+    assert ait.theta["applied"] < 0.95, ait.theta
+
+
+def test_tool_level_returncode_check_is_wired(monkeypatch, tmp_path):
+    """Defence in depth, made testable.
+
+    The driver refuses a non-zero exit before it can reach the tool, so deleting
+    the tool's own check changes nothing any other test sees. That makes the call
+    look like decoration. It is not — it is the guard for a result that arrives
+    carrying a failed exit code — so exercise it directly by handing `couple` a
+    driver result the driver itself would never produce.
+    """
+    import tools.consolidated as C
+    from core.coupling_driver import CouplingResult
+
+    ex = {"field_name": "x", "n_points": 1, "coordinates": [[0.0, 0.0]],
+          "values": [1.0], "normal_fluxes": [1.0]}
+    exb = dict(ex, field_name="y", normal_fluxes=[-1.0])
+    fake = CouplingResult(
+        converged=True, iterations=3, residual=1e-12,
+        exports={"A": ex, "B": exb}, history=[float("nan"), 1e-12],
+        returncodes={"A": 0, "B": 137},          # killed, but "converged"
+        block_residuals={"A.values": 0.0, "B.values": 0.0},
+        responsiveness={"A": "responsive", "B": "responsive"},
+        graph={"participants": ["A", "B"],
+               "declared_edges": {"A": ["B"], "B": ["A"]}},
+        theta={"mode": "aitken", "theta0": 0.5, "applied": 0.5},
+        sensitivity={"A": {"noise": 0.0, "signal": 1e-3, "S": 1.0, "blocks": {}},
+                     "B": {"noise": 0.0, "signal": 1e-3, "S": 1.0, "blocks": {}}})
+    monkeypatch.setattr(C, "run_coupling", lambda *a, **k: fake, raising=False)
+    import core.coupling_driver as D
+    monkeypatch.setattr(D, "run_coupling", lambda *a, **k: fake)
+    d = _couple(_parts(tmp_path))
+    assert d["converged"] is True
+    assert any("exited non-zero" in w for w in d["validation"]), d["validation"]
+    assert d["trustworthy_result"] is False
+
+
+def test_aitken_formula_matches_the_hand_computation():
+    """Pin the formula itself: theta = -theta_prev (r_prev . dr) / (dr . dr).
+
+    With prev_relaxed = 0, new_raw = 2 the residual is r = 2; against r_prev = -1
+    that gives dr = 3 and theta = -0.5 * (-1 * 3) / 9 = 1/6. The function must
+    also RETURN r, since the caller has to store it for the next step.
+    """
+    from core.coupling_driver import _aitken
+    th, r_k = _aitken(np.array([0.0]), np.array([2.0]), np.array([-1.0]), 0.5)
+    assert abs(th - 1.0 / 6.0) < 1e-12, th
+    assert r_k.tolist() == [2.0]
+    # no previous residual yet -> hold theta, and still return the residual
+    th0, r0 = _aitken(np.array([0.0]), np.array([2.0]), None, 0.4)
+    assert th0 == 0.4 and r0.tolist() == [2.0]
+    # a zero denominator must not divide by zero
+    th1, _ = _aitken(np.array([0.0]), np.array([2.0]), np.array([2.0]), 0.3)
+    assert th1 == 0.3
+
+
+def test_aitken_is_given_the_residual_and_not_the_raw_export(tmp_path):
+    """Direct discrimination for the Aitken bookkeeping.
+
+    The formula needs the previous RESIDUAL r = G(x) - x; it used to be handed
+    the previous raw export G(x). Both are vectors of the right shape, so nothing
+    complains and the only symptom is a theta that wanders inside its clamp — a
+    convergence-RATE loss that a "did it converge" test does not see. What DOES
+    separate them is size: at convergence the residual is by definition tiny,
+    while the raw export is the size of the solution.
+
+    LIMIT, stated: this pins WHAT the driver stores. Mutation testing shows that
+    corrupting only what is PASSED BACK IN — the input to the formula — is caught
+    indirectly, by three tests that are sensitive to iteration count, and not by
+    any assertion written for it. Deriving the analytic optimum theta for this
+    map would close that, and is not done here.
+    """
+    r = run_coupling(_parts(tmp_path), max_iter=90, tol=1e-9,
+                     accelerator="aitken", theta0=0.5)
+    assert r.converged
+    solution_scale = abs(r.exports["A"]["values"][0])
+    assert solution_scale > 1.0
+    assert r.theta["residual_norm"] is not None
+    assert r.theta["residual_norm"] < 1e-6, (
+        f"Aitken is holding a vector of norm {r.theta['residual_norm']:.3g} "
+        f"where the converged residual must be tiny (the solution is of order "
+        f"{solution_scale:.3g}) — it is being handed the raw export, not the "
+        "residual")

--- a/tests/test_coverage_floor.py
+++ b/tests/test_coverage_floor.py
@@ -40,7 +40,8 @@ _FLOORS: dict[str, int] = {
                       #              schrodinger, contact, hydraulic_resistance
     "kratos":   39,
     "dune":     15,
-    "fourc":    47,
+    "fourc":    49,   # +particle_dem (2026-08-07): 4C DEM had 29 upstream
+                      #   decks and zero knowledge before this.
     "febio":    16,
 }
 

--- a/tests/test_critic_enforced_end_to_end.py
+++ b/tests/test_critic_enforced_end_to_end.py
@@ -1,0 +1,432 @@
+"""The critic requirement, exercised through the real MCP tools.
+
+The unit tests in test_critic_gate.py prove the registry refuses forged, stale,
+reused and mismatched tokens. They say nothing about whether OASiS ASKS it. An
+audit found exactly that gap: `critic_gate` existed, was tested, and was wired
+into nothing, so `run_simulation(..., critic_approved=True)` still stamped a
+result VERIFIED with no critic anywhere in the process.
+
+These tests therefore drive the tools themselves, with a real solver run, and
+assert on the verdict the agent actually receives.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import consolidated
+
+
+# A genuine, tiny scikit-fem Poisson solve. Real run, real output files, so
+# `evidence_ok` is True and the ONLY thing standing between it and a VERIFIED
+# stamp is the critic. That isolation is the point: a test that fails the
+# numerical checks would pass for the wrong reason.
+DECK = """
+import numpy as np, skfem
+from skfem import Basis, ElementTriP1, BilinearForm, LinearForm, asm, condense, solve
+from skfem.helpers import dot, grad
+
+m = skfem.MeshTri().refined(3)
+basis = Basis(m, ElementTriP1())
+
+@BilinearForm
+def a(u, v, w):
+    return dot(grad(u), grad(v))
+
+@LinearForm
+def L(v, w):
+    return 1.0 * v
+
+A, b = asm(a, basis), asm(L, basis)
+x = solve(*condense(A, b, D=basis.get_dofs()))
+m.save('solution.vtu', {'u': x})
+print('max u =', float(x.max()))
+"""
+
+FINDINGS = (
+    "Checked the weak form against -laplace(u)=1 on the unit square, confirmed "
+    "homogeneous Dirichlet data is applied on the whole boundary via "
+    "basis.get_dofs(), verified P1 elements are adequate for this smooth "
+    "problem, and confirmed the units are consistent (dimensionless)."
+)
+
+
+@pytest.fixture
+def tools(monkeypatch):
+    """Fresh server + registry per test, so one test's review cannot verify
+    another's run."""
+    from core.registry import load_all_backends
+    load_all_backends()
+    monkeypatch.setattr(consolidated, "_CRITIC_REGISTRY",
+                        consolidated.CriticRegistry())
+    captured = {}
+
+    class _Recorder:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    consolidated.register_consolidated_tools(_Recorder())
+    return captured
+
+
+def _skfem_available() -> bool:
+    try:
+        import skfem  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+needs_skfem = pytest.mark.skipif(not _skfem_available(),
+                                 reason="scikit-fem not installed")
+
+
+# ── the hole that was open ────────────────────────────────────────────────
+@needs_skfem
+@pytest.mark.asyncio
+async def test_asserting_critic_approved_does_not_verify_a_run(tools):
+    """THE regression. `critic_approved=True` with no review on record used to
+    stamp a real run VERIFIED. It must not."""
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK, critic_approved=True))
+    assert out["trustworthy_result"] is False
+    # It must fail on the CRITIC, not on missing evidence — otherwise this test
+    # would still pass with the critic requirement torn out, which is exactly
+    # the kind of green that means nothing.
+    assert "MANDATORY independent critic" in out["verification"], out["verification"]
+    # and the verdict must NAME the false claim rather than quietly ignoring it
+    assert "critic_approved=True" in out["critic_review"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_submitted_review_verifies_that_setup(tools):
+    sub = json.loads(await tools["submit_critic_review"](
+        solver="skfem", setup=DECK, findings=FINDINGS))
+    assert sub["accepted"] is True and sub["critic_token"]
+
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK, critic_approved=True))
+    assert out["trustworthy_result"] is True, out["verification"]
+    assert "VERIFIED" in out["verification"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_editing_the_deck_after_review_invalidates_it(tools):
+    """Review a clean deck, run a different one — the obvious way to defeat a
+    critic requirement."""
+    await tools["submit_critic_review"](solver="skfem", setup=DECK,
+                                        findings=FINDINGS)
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK + "\n# one extra character of change",
+        critic_approved=True))
+    assert out["trustworthy_result"] is False
+    assert "changed after it was reviewed" in out["critic_review"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_review_for_another_solver_does_not_transfer(tools):
+    await tools["submit_critic_review"](solver="fenics", setup=DECK,
+                                        findings=FINDINGS)
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK, critic_approved=True))
+    assert out["trustworthy_result"] is False
+
+
+# ── the registry's own refusals, reached through the tool ─────────────────
+@pytest.mark.asyncio
+async def test_an_empty_approval_is_refused(tools):
+    """"Looks fine" is indistinguishable from no review at all."""
+    sub = json.loads(await tools["submit_critic_review"](
+        solver="skfem", setup=DECK, findings="LGTM"))
+    assert sub["accepted"] is False and "characters" in sub["error"]
+
+
+@pytest.mark.asyncio
+async def test_a_review_must_name_exactly_one_setup(tools):
+    both = json.loads(await tools["submit_critic_review"](
+        solver="skfem", setup=DECK, coupling_args="{}", findings=FINDINGS))
+    neither = json.loads(await tools["submit_critic_review"](
+        solver="skfem", findings=FINDINGS))
+    assert both["accepted"] is False and neither["accepted"] is False
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_token_is_single_use(tools):
+    """The token path additionally bounds how many runs one review covers."""
+    tok = json.loads(await tools["submit_critic_review"](
+        solver="skfem", setup=DECK, findings=FINDINGS))["critic_token"]
+
+    first = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK, critic_token=tok))
+    assert first["trustworthy_result"] is True, first["verification"]
+
+    second = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK, critic_token=tok))
+    assert second["trustworthy_result"] is False
+    assert "already used" in second["critic_review"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_self_issued_token_is_refused(tools):
+    """An agent cannot mint its own: the store is server-side."""
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK,
+        critic_token="obviously-not-a-real-token"))
+    assert out["trustworthy_result"] is False
+    assert "not known to this server" in out["critic_review"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_an_expired_review_does_not_verify(tools):
+    await tools["submit_critic_review"](solver="skfem", setup=DECK,
+                                        findings=FINDINGS, ttl_s=-1.0)
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=DECK, critic_approved=True))
+    assert out["trustworthy_result"] is False
+
+
+# ── numbers come from the data, not from what the run said ────────────────
+@needs_skfem
+@pytest.mark.asyncio
+async def test_oasis_computes_the_numbers_from_the_runs_own_data(tools):
+    """The gate bound its verdict to the RUN but never to a NUMBER.
+
+    A deck that solves honestly and then prints a flattering value used to be
+    indistinguishable from one that printed the true one — nothing recomputed
+    it. Here the script prints a false L2 norm and writes real data; the value
+    OASiS reports must come from the data.
+    """
+    lying = DECK + "\nprint('L2 error = 1.0000e-12')\nprint('max u = 999.0')\n"
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=lying, job_name="attest_vs_narration"))
+
+    computed = out["oasis_computed"]
+    assert computed["max_abs"]["available"] is True, computed
+    # -laplace(u)=1 on the unit square with u=0 on the boundary peaks at about
+    # 0.0737; P1 on this mesh lands just under it. Nowhere near the 999 claimed.
+    assert 0.06 < computed["max_abs"]["value"] < 0.08, computed
+    assert computed["l2_norm"]["value"] > 1e-6, computed
+    # and it must say which artefact it came from, so the claim is checkable
+    assert computed["max_abs"]["from_file"].endswith(".vtu")
+    assert computed["max_abs"]["sha256"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_run_with_no_data_output_attests_nothing(tools):
+    """A script that only prints cannot have a number attested — the honest
+    outcome is "unattestable", never a value borrowed from stdout."""
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content="print('L2 error = 1e-12')\n",
+        job_name="attest_no_data"))
+    # No artefacts at all, so the run is not verified and nothing is computed.
+    assert out["trustworthy_result"] is False
+    assert "oasis_computed" not in out or not any(
+        v.get("available") for v in out["oasis_computed"].values()
+        if isinstance(v, dict))
+
+
+# ── does the output actually solve the problem? ───────────────────────────
+MMS_SOLVE = """
+import numpy as np, skfem
+from skfem import Basis, ElementTriP1, BilinearForm, LinearForm, asm, condense, solve
+from skfem.helpers import dot, grad
+
+m = skfem.MeshTri().refined(5)
+basis = Basis(m, ElementTriP1())
+
+@BilinearForm
+def a(u, v, w):
+    return dot(grad(u), grad(v))
+
+@LinearForm
+def L(v, w):
+    return 2*np.pi**2*np.sin(np.pi*w.x[0])*np.sin(np.pi*w.x[1]) * v
+
+A, b = asm(a, basis), asm(L, basis)
+x = solve(*condense(A, b, D=basis.get_dofs()))
+m.save('solution.vtu', {'u': x})
+"""
+
+# The eight-line fabricator. It never assembles anything: it writes the analytic
+# field straight to disk. The result is MORE accurate than the genuine solve and
+# passes a mesh-independence study, so accuracy cannot be the discriminator.
+MMS_FORGERY = """
+import numpy as np, skfem
+m = skfem.MeshTri().refined(5)
+p = m.p.T
+u = np.sin(np.pi*p[:, 0])*np.sin(np.pi*p[:, 1])
+m.save('solution.vtu', {'u': u})
+print('L2 error = 3.1e-06')
+"""
+
+PDE = json.dumps({"operator": "diffusion",
+                  "source": "2*pi**2*sin(pi*x)*sin(pi*y)",
+                  "dim": 2, "domain_measure": 1.0})
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_genuine_solve_satisfies_its_declared_equations(tools):
+    await tools["submit_critic_review"](solver="skfem", setup=MMS_SOLVE,
+                                        findings=FINDINGS)
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=MMS_SOLVE, verify_pde=PDE,
+        job_name="residual_genuine"))
+    assert out["residual_check"]["verdict"] == "SOLVES", out["residual_check"]
+    assert out["residual_check"]["relative_residual"] < 1e-8
+    assert out["trustworthy_result"] is True, out["verification"]
+    assert "SATISFIES the equations" in out["verification"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_verified_run_says_when_nothing_checked_the_physics(tools):
+    """The residual check is opt-in, so a run that skips it still verifies. If
+    the verdict were silent about that, "checked and solves the problem" and
+    "nothing looked" would read identically in the one place an agent reads."""
+    await tools["submit_critic_review"](solver="skfem", setup=MMS_SOLVE,
+                                        findings=FINDINGS)
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=MMS_SOLVE, job_name="residual_absent"))
+    assert out["trustworthy_result"] is True
+    assert "nothing here checked whether this output satisfies any equations" \
+        in out["verification"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_written_out_analytic_field_is_refused(tools):
+    """Reviewed, finite, structurally sane, more accurate than the real solve —
+    and not a solve. Nothing that inspects only the data can tell; the residual
+    can."""
+    await tools["submit_critic_review"](solver="skfem", setup=MMS_FORGERY,
+                                        findings=FINDINGS)
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=MMS_FORGERY, verify_pde=PDE,
+        job_name="residual_forgery"))
+    assert out["residual_check"]["verdict"] == "DOES_NOT_SOLVE", out["residual_check"]
+    assert out["trustworthy_result"] is False
+    assert "does NOT satisfy the equations" in out["verification"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_an_unsupported_problem_is_not_checked_rather_than_passed(tools):
+    """'Not checked' must never be reachable as 'checked and fine'."""
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=MMS_SOLVE, job_name="residual_unsupported",
+        verify_pde=json.dumps({"operator": "navier_stokes", "source": "0",
+                               "dim": 2})))
+    assert out["residual_check"]["verdict"] == "REFUSED"
+    assert "not one OASiS can assemble" in out["residual_check"]["detail"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_a_source_term_is_an_expression_not_a_program(tools):
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=MMS_SOLVE, job_name="residual_injection",
+        verify_pde=json.dumps({"operator": "diffusion", "dim": 2,
+                               "source": "__import__('os').system('true')"})))
+    assert out["residual_check"]["verdict"] == "REFUSED"
+
+
+# ── the bypass that was removed ───────────────────────────────────────────
+def test_no_environment_variable_can_lift_the_critic_requirement():
+    """OFA_DISABLE_CRITIC used to stamp unreviewed runs VERIFIED. A mandatory
+    gate with an environment-variable off-switch is not mandatory: any stray
+    export in a harness silently converts every verdict.
+
+    Checked on the AST, not the text: the comment recording WHY the switch was
+    removed necessarily names it, and a substring search would either fail on
+    that comment or force someone to delete the explanation to go green.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(consolidated))
+    reads = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        and node.value == "OFA_DISABLE_CRITIC"
+    ]
+    assert not reads, (
+        "the critic ablation switch is back in executable code at line(s) "
+        + ", ".join(str(n.lineno) for n in reads))
+    names = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+    assert "_ABLATE_CRITIC" not in names
+
+
+# ── the deck is not the whole setup ───────────────────────────────────────
+@needs_skfem
+@pytest.mark.asyncio
+async def test_changing_a_file_the_deck_imports_invalidates_the_review(tools, tmp_path):
+    """A review of the deck is not a review of the physics if the physics lives
+    in a file the deck imports.
+
+    Demonstrated against this gate before it was fixed: a reviewed deck importing
+    `SOURCE = 1.0` gave max|u| = 0.0728 and VERIFIED; rewriting only the imported
+    file to `SOURCE = 1000.0` gave 72.78 and VERIFIED again, on the same review.
+    A thousandfold change in the physics through a review of something else.
+
+    A sibling audit found the same shape in `couple`, where the digest covered
+    the participant COMMAND and never the script it named — 225x, same story. So
+    the fix is to the shape: files a deck references are fingerprinted into the
+    setup the review is bound to.
+    """
+    helper = tmp_path / "physics.py"
+    helper.write_text("SOURCE = 1.0\n")
+    deck = f"""
+import skfem, sys
+sys.path.insert(0, {str(tmp_path)!r})
+from physics import SOURCE
+from skfem import *
+from skfem.helpers import dot, grad
+m = skfem.MeshTri().refined(3); b = Basis(m, ElementTriP1())
+@BilinearForm
+def a(u, v, w): return dot(grad(u), grad(v))
+@LinearForm
+def L(v, w): return SOURCE * v
+x = solve(*condense(asm(a, b), asm(L, b), D=b.get_dofs()))
+m.save('solution.vtu', {{'u': x}})
+"""
+    await tools["submit_critic_review"](solver="skfem", setup=deck,
+                                        findings=FINDINGS)
+    first = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=deck, job_name="imported_before"))
+    assert first["trustworthy_result"] is True, first["verification"]
+
+    helper.write_text("SOURCE = 1000.0\n")          # deck text unchanged
+    second = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=deck, job_name="imported_after"))
+    assert second["trustworthy_result"] is False
+    assert "changed after it was reviewed" in second["critic_review"]
+
+
+@needs_skfem
+@pytest.mark.asyncio
+async def test_writing_a_referenced_file_after_review_invalidates_it(tools, tmp_path):
+    """The other direction, which is the same bypass wearing a hat: review a deck
+    whose helper does not exist yet, then create it."""
+    deck = f"""
+import sys
+sys.path.insert(0, {str(tmp_path)!r})
+print('placeholder')
+"""
+    await tools["submit_critic_review"](solver="skfem", setup=deck,
+                                        findings=FINDINGS)
+    (tmp_path / "physics.py").write_text("SOURCE = 1.0\n")
+    out = json.loads(await tools["run_simulation"](
+        solver="skfem", input_content=deck, job_name="created_after"))
+    assert out["trustworthy_result"] is False

--- a/tests/test_dealii_poisson3d_mixed.py
+++ b/tests/test_dealii_poisson3d_mixed.py
@@ -1,8 +1,8 @@
 """Gen-only tests for the deal.II poisson_3d_mixed_bc generator.
 
-Created 2026-08-01 (deliverable E1): 3D Poisson on the unit cube with
-MIXED Dirichlet-Neumann boundaries, manufactured solution (MMS),
-global refinement and per-cycle L2 error output.
+3D Poisson on the unit cube with MIXED Dirichlet-Neumann boundaries,
+manufactured solution (MMS), global refinement and per-cycle L2 error
+output.
 
 These tests do NOT require the deal.II library — they pin the
 *generator* contract only:
@@ -17,10 +17,11 @@ These tests do NOT require the deal.II library — they pin the
   * validate_parameters flags nonsensical inputs and the generator
     refuses to emit code for them.
 
-The live execution gate is the convergence smoke run (deal.II
-9.8.0-pre, 2026-08-01): degree=1 observed L2 orders 2.06/1.96/1.99/
-2.00, degree=2 observed 1.55(pre-asymptotic)/2.92/2.98/3.00 — the
-verified numbers are recorded in the module KNOWLEDGE.
+The live execution gate (outside pytest, deal.II 9.8.0-pre) is a
+convergence run whose per-cycle L2 errors must approach the
+theoretical order k+1 for FE_Q(k). Those measured orders are outputs
+of the run and are deliberately NOT recorded here or in the module
+KNOWLEDGE.
 """
 from __future__ import annotations
 

--- a/tests/test_dealii_tier2_claim_coverage.py
+++ b/tests/test_dealii_tier2_claim_coverage.py
@@ -1,0 +1,242 @@
+"""How much of the deal.II pitfall catalog has an executed fixture.
+
+Every entry of every ``pitfalls`` list in
+``backends.dealii.generators.*.KNOWLEDGE`` that carries a ``Signal:`` clause is
+a falsifiable claim. A claim with no fixture is a claim the project cannot
+defend, so this file measures the fraction that has one and refuses to let it
+fall.
+
+Measuring it needs a MAP rather than a directory count, because the two do not
+agree in either direction. One fixture can legitimately verify several claims,
+and — the direction that actually bit this backend — a fixture can sit in the
+directory while pointing at the WRONG claim. Five of the dealii fixtures did:
+``xdmf_degree_mismatch`` executed the XDMF degree-mismatch claim while keyed to
+the near-incompressible locking claim, so a real claim looked defended and the
+evidence was about something else entirely. Pitfall indices are POSITIONAL, so
+inserting an entry earlier in a list silently re-points every fixture after it,
+and the fixture keeps passing, because passing only means "the software printed
+what I expected".
+
+A fixture therefore declares what it covers::
+
+    "covers": ["poisson::3", "poisson::4"]
+
+Fixtures with no ``covers`` key fall back to their own
+``physics``/``pitfall_index`` pair, which is how the older ones are counted. An
+index past the end of a pitfall list is a SYNTHETIC key — the MMS convergence
+gates and the catalog-shape checks use one — and counts for nothing here, which
+is the point: a check that is not evidence for a stated claim must not be able
+to inflate the number.
+
+What this file does NOT do: judge whether a fixture is any good. That is the
+runner's job (``scripts/run_tier2_fixtures.py`` executes them) and the mutation
+driver's (``.t2check.py`` re-runs each with ``T2_MUTATE=1`` and requires an
+expectation to be lost). This file only answers "is there one at all, and does
+it point at the claim it tests".
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+BACKEND = "dealii"
+_FIXTURES = _REPO / "scripts" / "tier2_fixtures" / BACKEND
+
+# Raise this ONLY upward, and only with the fixtures that earned it in the same
+# commit. The project owner's target is 80 %; the constant tracks what is
+# actually MEASURED so every commit is green and the number here is never an
+# aspiration.
+#   2026-08-06  0.09 -> 0.44  (session's fixtures, minus four mis-keyed ones
+#                              whose claims went back to uncovered)
+MIN_COVERAGE_FRACTION = 0.42
+
+# Counted on 2026-08-06. Coverage is a fraction, so shrinking the denominator
+# is a way to "improve" it without writing anything.
+# Claim-bearing fixtures that predate the T2_MUTATE convention and would
+# therefore pass with the pathology absent. Measured 2026-08-06; may only
+# go DOWN.
+MUTATION_CONTROL_DEBT = 9
+
+CLAIM_INVENTORY_FLOOR = 136
+
+
+def _claim_inventory() -> dict[str, str]:
+    """Every falsifiable dealii claim, keyed the way ``covers`` names it.
+
+    Harvested through the backend API, which is the same path the agent uses to
+    serve the knowledge — so the denominator is what a user actually receives,
+    not what a grep of the source happens to find. (Those two differ here: an
+    AST sweep of the generator files counts 132 against the API's 136, because
+    some pitfall lists are composed at serve time.)
+    """
+    from core.registry import get_backend, load_all_backends       # noqa: E402
+
+    try:
+        load_all_backends()
+    except Exception:                                     # pragma: no cover
+        pass
+    backend = get_backend("dealii")
+    if backend is None:                                   # pragma: no cover
+        raise unittest.SkipTest("dealii backend not registered")
+
+    claims: dict[str, str] = {}
+    for physics in backend.supported_physics():
+        try:
+            knowledge = backend.get_knowledge(physics.name)
+        except Exception:                                 # pragma: no cover
+            continue
+        if not isinstance(knowledge, dict):
+            continue
+        for i, text in enumerate(knowledge.get("pitfalls", []) or []):
+            if isinstance(text, str) and "Signal:" in text:
+                claims[f"{physics.name}::{i}"] = text
+    return claims
+
+
+def _tracked_fixture_names() -> set[str]:
+    """Fixture directories git tracks.
+
+Only fixtures git TRACKS are counted. A fixture sitting untracked in the
+working tree has not been committed, which on this project means it has not
+been run through the mutation driver here — it is not evidence yet. Counting it
+would let half-written work inflate the number, and a fixture caught mid-write
+would turn this test red for reasons that have nothing to do with coverage.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(_REPO), "ls-files",
+             f"scripts/tier2_fixtures/{BACKEND}"],
+            capture_output=True, text=True, timeout=60).stdout.split()
+    except (OSError, subprocess.SubprocessError):        # pragma: no cover
+        return set()
+    names = set()
+    for path in out:
+        parts = path.split("/")
+        if len(parts) > 3:
+            names.add(parts[3])
+    return names
+
+
+def _fixture_claims(inventory: dict[str, str]):
+    """(claim -> fixtures naming it, fixtures whose key names no claim)."""
+    covered: dict[str, list[str]] = {}
+    synthetic: list[str] = []
+    tracked = _tracked_fixture_names()
+    for d in sorted(p.parent for p in _FIXTURES.glob("*/fixture.json")):
+        if tracked and d.name not in tracked:
+            continue
+        meta = json.loads((d / "fixture.json").read_text())
+        declared = meta.get("covers")
+        if declared is None:
+            key = f"{meta.get('physics')}::{meta.get('pitfall_index')}"
+            declared = [key] if key in inventory else []
+            if not declared:
+                synthetic.append(f"{d.name} ({key})")
+        elif not declared:
+            key = f"{meta.get('physics')}::{meta.get('pitfall_index')}"
+            synthetic.append(f"{d.name} ({key}, covers: [])")
+        for claim in declared:
+            covered.setdefault(str(claim), []).append(d.name)
+    return covered, synthetic
+
+
+class TestDealiiTier2ClaimCoverage(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inventory = _claim_inventory()
+        cls.covered, cls.synthetic = _fixture_claims(cls.inventory)
+
+    def test_every_covers_entry_names_a_real_claim(self) -> None:
+        """A `covers` list is a coverage CLAIM; it has to be checkable."""
+        bogus = {c: f for c, f in self.covered.items()
+                 if c not in self.inventory}
+        self.assertEqual(
+            bogus, {},
+            f"these fixtures claim to cover dealii pitfalls that do not "
+            f"exist: {bogus}. Pitfall indices are POSITIONAL — inserting an "
+            f"entry earlier in a list re-points every fixture after it — so a "
+            f"stale index here means the coverage number is fiction. Re-read "
+            f"the list in src/backends/dealii/generators/ and fix the index.")
+
+    def test_no_claim_is_counted_twice(self) -> None:
+        dupes = {c: f for c, f in self.covered.items() if len(f) > 1}
+        self.assertEqual(
+            dupes, {},
+            f"these claims are named by more than one fixture: {dupes}. "
+            f"Double-counting inflates the coverage fraction; pick one owner "
+            f"per claim and make the other synthetic or delete it.")
+
+    def test_coverage_meets_the_floor(self) -> None:
+        n_total = len(self.inventory)
+        n_covered = len([c for c in self.covered if c in self.inventory])
+        fraction = n_covered / n_total if n_total else 0.0
+        uncovered = sorted(set(self.inventory) - set(self.covered))
+        self.assertGreaterEqual(
+            fraction, MIN_COVERAGE_FRACTION,
+            f"dealii tier-2 claim coverage is {n_covered}/{n_total} = "
+            f"{fraction:.1%}, below the {MIN_COVERAGE_FRACTION:.0%} floor. "
+            f"Still uncovered:\n  " + "\n  ".join(uncovered))
+
+    def test_the_inventory_itself_did_not_shrink(self) -> None:
+        self.assertGreaterEqual(
+            len(self.inventory), CLAIM_INVENTORY_FLOOR,
+            f"the dealii claim inventory dropped to {len(self.inventory)} "
+            f"from the {CLAIM_INVENTORY_FLOOR} counted on 2026-08-06. If "
+            f"claims were retired because execution falsified them, lower "
+            f"this floor in the same commit and say which ones; do not let "
+            f"the coverage fraction rise by subtraction.")
+
+    def test_mutation_control_debt_does_not_grow(self) -> None:
+        """A fixture that counts toward coverage should FAIL when the pathology
+        is removed. The ones below predate that convention: they pass, but they
+        would pass with the pitfall absent too, so the claim they defend is
+        defended weakly. This test does not demand they be fixed today — it
+        pins the count so the debt cannot quietly grow while the coverage
+        fraction rises. Lower the number as controls are added.
+
+        The mutation control itself is `T2_MUTATE=1` in the fixture's source
+        (or in the shared translation unit its cmd.sh names), which runs the
+        CORRECT variant; the driver then requires an expectation to be lost.
+        """
+        import re
+        tracked = _tracked_fixture_names()
+        without = []
+        for d in sorted(p.parent for p in _FIXTURES.glob("*/fixture.json")):
+            if tracked and d.name not in tracked:
+                continue
+            meta = json.loads((d / "fixture.json").read_text())
+            declared = meta.get("covers")
+            if declared == []:
+                continue                      # synthetic: defends no claim
+            key = f"{meta.get('physics')}::{meta.get('pitfall_index')}"
+            if declared is None and key not in self.inventory:
+                continue                      # key names no claim: counts for 0
+            text = ""
+            for name in ("source.py", "cmd.sh"):
+                p = d / name
+                if p.exists():
+                    text += p.read_text()
+            shared = ""
+            m = re.search(r"run\.sh\"?\s+(\w+)", text)
+            if m:
+                cc = _FIXTURES / "_shared" / f"{m.group(1)}.cc"
+                if cc.exists():
+                    shared = cc.read_text()
+            if "T2_MUTATE" not in text + shared:
+                without.append(d.name)
+        self.assertLessEqual(
+            len(without), MUTATION_CONTROL_DEBT,
+            f"{len(without)} claim-bearing fixtures have no mutation control, "
+            f"above the recorded debt of {MUTATION_CONTROL_DEBT}. Every NEW "
+            f"fixture must carry one.\n  " + "\n  ".join(without))
+
+
+if __name__ == "__main__":                                # pragma: no cover
+    unittest.main()

--- a/tests/test_dune_poisson3d_mms.py
+++ b/tests/test_dune_poisson3d_mms.py
@@ -1,0 +1,251 @@
+"""Gen-only tests for the DUNE-fem poisson_3d_varcoeff generator.
+
+3D VARIABLE-COEFFICIENT Poisson on [0, L]^3 with manufactured
+solution, exact Dirichlet data, Lagrange order as a parameter, uniform
+refinement and per-level L2/H1 error lines. This is the first genuinely
+hard DUNE-fem family (the existing poisson_2d is a single
+constant-force instance with no error measurement).
+
+These tests do NOT require dune.fem — they pin the *generator*
+contract only:
+
+  * the template key is registered and reachable through the backend's
+    generate_input("poisson_mms", "3d_varcoeff", ...);
+  * the generated Python compiles and has no unresolved placeholders;
+  * every parameter is honoured in the emitted source;
+  * the EMITTED u*/kappa expression text is cross-checked by
+    ast-evaluating it at random points against independent reference
+    implementations (manufactured_solution_at / diffusion_at) — this
+    catches literal-formatting and operator-precedence bugs, the real
+    risk in a family whose source term is otherwise exact (UFL
+    differentiates u* symbolically, so there is no hand-derived f to
+    transcribe);
+  * the template uses the NON-deprecated dune-fem 2.10 API
+    (dune.fem.integrate, nonlinear.*/linear.* parameter keys);
+  * validate_parameters flags nonsensical inputs (including a
+    kappa-positivity/ellipticity guard) and the generator refuses to
+    emit code for them.
+
+The live execution gate (outside pytest, dune-fem 2.10) is a
+refinement run that must show the emitted L2/H1 EOCs approaching the
+theoretical rates for the chosen Lagrange order k -- L2 -> k+1 and
+H1 -> k. The EOCs themselves are outputs of that run and are
+deliberately NOT recorded here or in the module KNOWLEDGE.
+"""
+from __future__ import annotations
+
+import ast
+import math
+import random
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+from backends.dune.generators.poisson_mms3d import (  # noqa: E402
+    _DEFAULTS, diffusion_at, kappa_min, manufactured_solution_at,
+    validate_parameters)
+
+# Dev-draw parameter set exercising every knob (distinct from the
+# module defaults on purpose).
+DEV_PARAMS = {
+    "order": 2,
+    "levels": 4,
+    "n0": 2,
+    "L": 2.0,
+    "a": 2.0, "b": 1.0, "c": 1.5,
+    "d": 0.5, "amp": 1.3,
+    "k0": 2.0, "kx": -0.75, "ky": 0.5, "kz": 1.0,
+}
+
+
+def _extract_exprs(src: str) -> dict:
+    """ast-parse the generated script; return compiled u_exact/kappa
+    expressions plus the module-level L constant."""
+    tree = ast.parse(src)
+    found: dict = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                and isinstance(node.targets[0], ast.Name):
+            name = node.targets[0].id
+            if name in ("u_exact", "kappa", "L") and name not in found:
+                found[name] = compile(ast.Expression(node.value),
+                                      "<expr>", "eval")
+    return found
+
+
+def _eval_emitted(src: str, x: float, y: float, z: float) -> tuple:
+    exprs = _extract_exprs(src)
+    ns = {"sin": math.sin, "pi": math.pi}
+    L = eval(exprs["L"], ns)  # noqa: S307 — our own generated literal
+    ns.update({"L": L, "x": (x, y, z)})
+    return eval(exprs["u_exact"], ns), eval(exprs["kappa"], ns)  # noqa: S307
+
+
+class TestPoisson3dVarcoeffGenerator(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from core.registry import load_all_backends, get_backend
+        load_all_backends()
+        cls.backend = get_backend("dune")
+        if cls.backend is None:
+            raise unittest.SkipTest("dune backend not registered")
+
+    # ── registration / dispatch ─────────────────────────────────────
+
+    def test_template_key_registered(self) -> None:
+        from backends.dune.generators import GENERATORS
+        self.assertIn("poisson_mms_3d_varcoeff", GENERATORS)
+
+    def test_backend_advertises_variant(self) -> None:
+        caps = {c.name: c for c in self.backend.supported_physics()}
+        self.assertIn("poisson_mms", caps)
+        self.assertIn("3d_varcoeff", caps["poisson_mms"].template_variants)
+        self.assertIn(3, caps["poisson_mms"].spatial_dims)
+
+    def test_knowledge_registered_and_populated(self) -> None:
+        k = self.backend.get_knowledge("poisson_mms")
+        self.assertIsInstance(k, dict)
+        self.assertTrue(k.get("description"))
+        self.assertGreaterEqual(len(k.get("pitfalls", [])), 4)
+        self.assertIn("k+1", str(k.get("expected_order", "")))
+
+    def test_every_pitfall_has_signal_line(self) -> None:
+        # dune sits at the 100% Signal-coverage floor — a new pitfall
+        # without a Signal: clause would regress the coverage gate.
+        k = self.backend.get_knowledge("poisson_mms")
+        for i, pit in enumerate(k["pitfalls"]):
+            self.assertIn("Signal:", pit,
+                          f"pitfall #{i} lacks a Signal: clause")
+
+    # ── default generation ──────────────────────────────────────────
+
+    def test_default_generation_is_complete_python(self) -> None:
+        src = self.backend.generate_input("poisson_mms", "3d_varcoeff", {})
+        self.assertIsInstance(src, str)
+        for needle in ("structuredGrid", "lagrange", "galerkin",
+                       "DirichletBC", "SpatialCoordinate",
+                       "results_summary.json", "writeVTK", "EOC"):
+            self.assertIn(needle, src)
+        # machine-readable per-level error line
+        self.assertIn('f"level {level} n {n} dofs {space.size} "', src)
+        # compiles as Python and passes the backend's own validator
+        compile(src, "<gen>", "exec")
+        self.assertEqual(self.backend.validate_input(src), [])
+
+    def test_no_unresolved_placeholders(self) -> None:
+        src = self.backend.generate_input("poisson_mms", "3d_varcoeff",
+                                          DEV_PARAMS)
+        for tok in ("{order}", "{levels}", "{n0}", "{L}", "{a}", "{amp}",
+                    "{k0}", "{kx}", "None*", "*None"):
+            self.assertNotIn(tok, src)
+
+    def test_uses_modern_dune_fem_api(self) -> None:
+        # the deprecated spellings were observed live (see KNOWLEDGE);
+        # the template must emit the 2.10 replacements.
+        src = self.backend.generate_input("poisson_mms", "3d_varcoeff", {})
+        self.assertIn("from dune.fem import integrate", src)
+        self.assertNotIn("from dune.fem.function import integrate", src)
+        self.assertIn("nonlinear.tolerance", src)
+        self.assertNotIn("newton.tolerance", src)
+        self.assertNotIn("newton.linear", src)
+
+    # ── parameters honoured ─────────────────────────────────────────
+
+    def test_parameters_honoured(self) -> None:
+        src = self.backend.generate_input("poisson_mms", "3d_varcoeff",
+                                          DEV_PARAMS)
+        self.assertIn("order = 2", src)
+        self.assertIn("levels = 4", src)
+        self.assertIn("n0 = 2", src)
+        self.assertIn("L = 2", src)
+        for lit in ("1.3", "0.5", "-0.75", "1.5"):
+            self.assertIn(lit, src)
+
+    def test_emitted_expressions_match_reference(self) -> None:
+        """ast-eval the EMITTED u*/kappa text against the module's
+        independent reference evaluators at random points."""
+        rng = random.Random(20260801)
+        for params in ({}, DEV_PARAMS,
+                       {"L": 3.5, "a": -1.0, "b": 0.5, "c": 2.0,
+                        "d": -0.25, "amp": 0.7,
+                        "k0": 4.0, "kx": -1.5, "ky": -1.0, "kz": -0.5}):
+            src = self.backend.generate_input("poisson_mms", "3d_varcoeff",
+                                              params)
+            L = {**_DEFAULTS, **params}["L"]
+            for _ in range(25):
+                x, y, z = (rng.uniform(0, L) for _ in range(3))
+                u_e, kap_e = _eval_emitted(src, x, y, z)
+                self.assertAlmostEqual(
+                    u_e, manufactured_solution_at(params, x, y, z),
+                    delta=1e-12 * max(1.0, abs(u_e)))
+                self.assertAlmostEqual(
+                    kap_e, diffusion_at(params, x, y, z),
+                    delta=1e-12 * max(1.0, abs(kap_e)))
+
+    def test_kappa_min_is_exact_corner_minimum(self) -> None:
+        rng = random.Random(42)
+        for _ in range(50):
+            params = {"L": rng.uniform(0.5, 4.0),
+                      "k0": rng.uniform(0.1, 5.0),
+                      "kx": rng.uniform(-2, 2),
+                      "ky": rng.uniform(-2, 2),
+                      "kz": rng.uniform(-2, 2)}
+            L = params["L"]
+            corner_min = min(
+                diffusion_at(params, i * L, j * L, k * L)
+                for i in (0, 1) for j in (0, 1) for k in (0, 1))
+            self.assertAlmostEqual(kappa_min(params), corner_min,
+                                   places=12)
+
+    # ── validation guards ───────────────────────────────────────────
+
+    def test_defaults_and_dev_params_validate_clean(self) -> None:
+        self.assertEqual(validate_parameters({}), [])
+        self.assertEqual(validate_parameters(DEV_PARAMS), [])
+
+    def test_validation_rejects_bad_inputs(self) -> None:
+        cases = {
+            "order 0": {"order": 0},
+            "order 7": {"order": 7},
+            "order str": {"order": "two"},
+            "order bool": {"order": True},
+            "levels 0": {"levels": 0},
+            "levels 9": {"levels": 9},
+            "n0 too small": {"n0": 1},
+            "L zero": {"L": 0.0},
+            "L negative": {"L": -1.0},
+            "nan coefficient": {"a": float("nan")},
+            "inf amp": {"amp": float("inf")},
+            "zero solution": {"amp": 0.0, "d": 0.0},
+            "kappa nonpositive": {"k0": 1.0, "kx": -1.0, "ky": -0.5,
+                                  "kz": 0.0},
+            "cost guard": {"order": 4, "n0": 8, "levels": 5},
+        }
+        for label, params in cases.items():
+            with self.subTest(label):
+                problems = validate_parameters(params)
+                self.assertTrue(problems,
+                                f"{label}: expected rejection, got OK")
+                with self.assertRaises(ValueError):
+                    self.backend.generate_input("poisson_mms", "3d_varcoeff",
+                                                params)
+
+    def test_cost_guard_boundary(self) -> None:
+        # n0 * 2^(levels-1) * order == 96 is the largest admissible
+        self.assertEqual(
+            validate_parameters({"order": 3, "n0": 4, "levels": 4}), [])
+        self.assertTrue(
+            validate_parameters({"order": 4, "n0": 4, "levels": 4}))
+
+    def test_ellipticity_guard_message_names_the_minimum(self) -> None:
+        problems = validate_parameters(
+            {"k0": 0.5, "kx": -1.0, "ky": 0.0, "kz": 0.0})
+        self.assertTrue(any("ellipticity" in p for p in problems))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dune_tier2_claim_coverage.py
+++ b/tests/test_dune_tier2_claim_coverage.py
@@ -1,0 +1,158 @@
+"""How much of the DUNE-fem pitfall catalog has an executed fixture.
+
+The DUNE backend states 111 falsifiable claims — every entry of every
+``pitfalls`` list, all of which carry a ``Signal:`` clause, plus the
+``Signal*`` keys of the measured sections in ``_general``. A claim with
+no fixture is a claim the project cannot defend, so this file measures
+the fraction that has one and refuses to let it fall.
+
+Measuring it needs a MAP, because one fixture may legitimately verify
+several claims: DUNE JIT-compiles C++ for every distinct form, so
+splitting claims that share a compiled module into separate fixtures
+multiplies build time without adding evidence. A fixture therefore
+declares a ``covers`` list in its ``fixture.json``::
+
+    "covers": ["poisson:1", "poisson:2", "heat:2",
+               "_general:assemble_measured.Signal"]
+
+Fixtures without a ``covers`` key fall back to their own
+``physics``/``pitfall_index`` pair, which is how the older fixtures are
+counted. An index past the end of a pitfall list is a SYNTHETIC key
+(the MMS convergence gate uses one) and counts for nothing here.
+
+What this file does NOT do: judge whether a fixture is any good. That
+is the runner's job — ``scripts/run_tier2_fixtures.py`` executes them
+and ``test_signal_verification.py`` gates the pass count. This file
+only answers "is there one at all", and keeps the answer honest by
+rejecting a ``covers`` entry that names a claim which does not exist.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import unittest
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+_FIXTURES = _REPO / "scripts" / "tier2_fixtures" / "dune"
+
+# Raise this ONLY upward, and only with the fixtures that earned it in
+# the same commit. The project owner's target is 80 %; the constant
+# tracks what is actually MEASURED so every commit is green and the
+# number in the file is never an aspiration.
+#   2026-08-06  0.07 -> 0.31 (nine fixtures)
+#   2026-08-06  0.31 -> 0.63 (thirteen more; 71 of 111)
+#   2026-08-06  0.63 -> 0.65 (stokes solver cost; 73 of 111)
+#   2026-08-06  0.65 -> 0.80 (nine more fixtures; 89 of 111 — the target)
+#   2026-08-06  0.80 -> 0.82 (three more: poisson_mms:2, stokes:5,
+#               mixed_methods:6; 92 of 111. Measured against the
+#               REGISTRY — supported_physics() then the pitfalls list,
+#               counting DISTINCT claim texts — that same set is
+#               84 of 103 = 81.6 %.)
+MIN_COVERAGE_FRACTION = 0.82
+
+
+def _claim_inventory() -> dict[str, str]:
+    """Every falsifiable DUNE claim, keyed the way ``covers`` names it."""
+    from backends.dune.generators import KNOWLEDGE           # noqa: E402
+
+    claims: dict[str, str] = {}
+    for physics, entry in KNOWLEDGE.items():
+        pitfalls = entry.get("pitfalls")
+        if isinstance(pitfalls, list):
+            for i, text in enumerate(pitfalls):
+                if isinstance(text, str) and "Signal:" in text:
+                    claims[f"{physics}:{i}"] = text
+    general = KNOWLEDGE.get("_general", {})
+    for section, body in general.items():
+        if not isinstance(body, dict):
+            continue
+        for key, text in body.items():
+            # START_HERE points the reader AT the pitfall list; it is a
+            # lookup instruction, not a claim about the code.
+            if section == "START_HERE":
+                continue
+            if (isinstance(key, str) and key.startswith("Signal")
+                    or (isinstance(text, str) and "Signal:" in text
+                        and isinstance(key, str))):
+                if isinstance(text, str) and "Signal:" in text:
+                    claims[f"_general:{section}.{key}"] = text
+    return claims
+
+
+def _fixture_claims() -> tuple[dict[str, list[str]], list[str]]:
+    """(claim -> fixtures naming it, fixtures with a synthetic key)."""
+    covered: dict[str, list[str]] = {}
+    synthetic: list[str] = []
+    inventory = _claim_inventory()
+    for d in sorted(p.parent for p in _FIXTURES.glob("*/fixture.json")):
+        meta = json.loads((d / "fixture.json").read_text())
+        declared = meta.get("covers")
+        if declared is None:
+            key = f"{meta.get('physics')}:{int(meta.get('pitfall_index', -1))}"
+            declared = [key] if key in inventory else []
+            if not declared:
+                synthetic.append(f"{d.name} ({key})")
+        for claim in declared:
+            covered.setdefault(str(claim), []).append(d.name)
+    return covered, synthetic
+
+
+class TestDuneTier2ClaimCoverage(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inventory = _claim_inventory()
+        cls.covered, cls.synthetic = _fixture_claims()
+
+    def test_every_covers_entry_names_a_real_claim(self) -> None:
+        """A `covers` list is a coverage CLAIM; it has to be checkable."""
+        bogus = {c: f for c, f in self.covered.items()
+                 if c not in self.inventory}
+        self.assertEqual(
+            bogus, {},
+            f"these fixtures claim to cover DUNE pitfalls that do not "
+            f"exist: {bogus}. Pitfall indices are POSITIONAL — "
+            f"inserting an entry earlier in a list re-points every "
+            f"fixture after it — so a stale index here means the "
+            f"coverage number is fiction. Re-read the list in "
+            f"src/backends/dune/generators/ and fix the index.")
+
+    def test_no_claim_is_counted_twice(self) -> None:
+        dupes = {c: f for c, f in self.covered.items() if len(f) > 1}
+        self.assertEqual(
+            dupes, {},
+            f"these claims are named by more than one fixture: {dupes}. "
+            f"Double-counting inflates the coverage fraction; pick one "
+            f"owner per claim.")
+
+    def test_coverage_meets_the_floor(self) -> None:
+        n_total = len(self.inventory)
+        n_covered = len([c for c in self.covered if c in self.inventory])
+        fraction = n_covered / n_total if n_total else 0.0
+        uncovered = sorted(set(self.inventory) - set(self.covered))
+        self.assertGreaterEqual(
+            fraction, MIN_COVERAGE_FRACTION,
+            f"DUNE tier-2 claim coverage is {n_covered}/{n_total} = "
+            f"{fraction:.1%}, below the {MIN_COVERAGE_FRACTION:.0%} "
+            f"floor. Still uncovered:\n  " + "\n  ".join(uncovered))
+
+    def test_the_inventory_itself_did_not_shrink(self) -> None:
+        """Coverage is a fraction, so shrinking the denominator is a
+        way to 'improve' it without writing anything. 111 claims were
+        counted on 2026-08-06; deleting claims to raise the percentage
+        has to be a deliberate, visible edit."""
+        self.assertGreaterEqual(
+            len(self.inventory), 111,
+            f"the DUNE claim inventory dropped to "
+            f"{len(self.inventory)} from the 111 counted on "
+            f"2026-08-06. If claims were retired because execution "
+            f"falsified them, lower this number in the same commit and "
+            f"say which ones; do not let the coverage fraction rise by "
+            f"subtraction.")
+
+
+if __name__ == "__main__":                                  # pragma: no cover
+    unittest.main()

--- a/tests/test_dune_verified_api.py
+++ b/tests/test_dune_verified_api.py
@@ -1,0 +1,535 @@
+"""Regression gate for the EXECUTION-VERIFIED DUNE-fem API surface.
+
+`src/backends/dune/generators/verified_api.py` holds the part of the
+DUNE-fem catalog that was established by RUNNING scripts against the
+installed dune-fem (2.12.0.2) rather than by reading documentation.
+These tests pin that content so it cannot silently rot:
+
+  * the executed sections are actually reachable through
+    backend.get_knowledge("_general") and
+    backend.get_knowledge("poisson");
+  * every executed pitfall keeps its [Category] prefix, its Signal:
+    clause and its provenance date — dune sits at the 100%
+    Signal-coverage floor and a bare pitfall would regress the
+    verify_signal_clauses gate;
+  * the measured numbers that the Tier-2 fixtures assert against are
+    still recorded in the knowledge (a fixture without the matching
+    claim, or a claim without the matching fixture, is a half-finished
+    verification);
+  * the Tier-2 fixture pitfall_index values still point at the pitfall
+    they were written for. Indices are POSITIONAL, so inserting a
+    pitfall in the middle of the list silently re-points every fixture
+    after it — this test is the tripwire;
+  * claims FALSIFIED by execution stay falsified. Three catalog
+    statements were contradicted by the installed package and must not
+    creep back: the ~/.dune JIT cache path, the
+    dune.fem.space.product_space factory, and the lowercase
+    raviartthomas spelling.
+
+These tests do NOT require dune.fem — they pin the catalog only. The
+live gate is the Tier-2 fixture set under
+scripts/tier2_fixtures/dune/, which re-runs the measurements.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+from backends.dune.generators.verified_api import (  # noqa: E402
+    EXECUTED_API, EXECUTED_PITFALLS)
+
+_FIXTURES = _REPO / "scripts" / "tier2_fixtures" / "dune"
+
+# Sections that must survive any future edit — each is a distinct
+# execution campaign, not a restatement of the others.
+_REQUIRED_SECTIONS = (
+    "install_under_test",
+    "grid_cell_types_measured",
+    "ufl_cell_is_always_a_simplex",
+    "space_construction_measured",
+    "dirichlet_bc_measured",
+    "silent_wrong_traps_measured",
+    "solver_control_measured",
+    "integrate_measured",
+    "jit_compilation_measured",
+    "convergence_behaviour_2d_poisson",
+    "runtime_constants_measured",
+    "vtk_output_measured",
+    "phantom_apis_checked",
+    "module_inventory_2_12",
+    # added by the 2026-08-03 knowledge expansion
+    "natural_bc_measured",
+    "assemble_measured",
+    "companion_modules_measured",
+)
+
+
+class TestVerifiedApiModule(unittest.TestCase):
+
+    def test_all_required_sections_present(self) -> None:
+        missing = [s for s in _REQUIRED_SECTIONS if s not in EXECUTED_API]
+        self.assertEqual(
+            missing, [],
+            f"verified_api.EXECUTED_API lost sections {missing}. Each "
+            f"section is a separate execution campaign; deleting one "
+            f"discards evidence that cost a live run to obtain.")
+
+    def test_install_fingerprint_is_recorded(self) -> None:
+        # Without the version the measurements are unattributable.
+        self.assertIn("2.12.0.2", EXECUTED_API["install_under_test"])
+        self.assertIn("dune-fem", EXECUTED_API["install_under_test"])
+
+    def test_every_section_carries_a_provenance_date(self) -> None:
+        for name in _REQUIRED_SECTIONS:
+            blob = json.dumps(EXECUTED_API[name])
+            self.assertRegex(
+                blob, r"20\d\d-\d\d-\d\d",
+                f"section {name!r} has no provenance date — an "
+                f"undated measurement cannot be re-checked")
+
+    def test_sections_with_a_signal_use_the_category_prefix(self) -> None:
+        for name, body in EXECUTED_API.items():
+            if not isinstance(body, dict) or "Signal" not in body:
+                continue
+            sig = body["Signal"]
+            self.assertRegex(
+                sig, r"^\[(API|Numerical|Performance|Syntax|Input|"
+                     r"Integration)\]",
+                f"_general section {name!r} Signal lacks a "
+                f"[Category] prefix")
+
+
+class TestExecutedPitfalls(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from core.registry import get_backend, load_all_backends
+        load_all_backends()
+        cls.backend = get_backend("dune")
+        if cls.backend is None:                     # pragma: no cover
+            raise unittest.SkipTest("dune backend not registered")
+        cls.poisson = cls.backend.get_knowledge("poisson")["pitfalls"]
+
+    def test_executed_pitfalls_are_appended_to_poisson(self) -> None:
+        for pit in EXECUTED_PITFALLS:
+            self.assertIn(
+                pit, self.poisson,
+                "an executed pitfall is no longer reachable through "
+                "get_knowledge('poisson') — knowledge(topic='pitfalls') "
+                "walks supported_physics() and never sees _general, so "
+                "dropping it from poisson hides it from every model")
+
+    def test_every_executed_pitfall_is_well_formed(self) -> None:
+        for i, pit in enumerate(EXECUTED_PITFALLS):
+            with self.subTest(i=i):
+                self.assertRegex(
+                    pit, r"^\[(API|Numerical|Performance|Syntax|Input|"
+                         r"Integration)\] ",
+                    "missing [Category] prefix")
+                self.assertIn("Signal:", pit, "missing Signal: clause")
+                self.assertRegex(
+                    pit, r"Executed 20\d\d-\d\d-\d\d",
+                    "missing an 'Executed <date>' provenance note — "
+                    "this list is for claims proven by running code")
+
+    def test_general_knowledge_exposes_the_executed_sections(self) -> None:
+        general = self.backend.get_knowledge("_general")
+        for name in _REQUIRED_SECTIONS:
+            self.assertIn(
+                name, general,
+                f"_general lost {name!r}; generators/__init__.py must "
+                f"keep merging verified_api.EXECUTED_API")
+
+
+class TestMeasuredNumbersSurvive(unittest.TestCase):
+    """The specific numbers the Tier-2 fixtures re-measure.
+
+    If a future edit prettifies the prose and drops the numbers, the
+    claims become unfalsifiable again — which is the exact failure mode
+    this whole verification effort exists to prevent.
+    """
+
+    def _blob(self) -> str:
+        return json.dumps(EXECUTED_API) + "\n".join(EXECUTED_PITFALLS)
+
+    def test_silent_bc_trap_numbers_recorded(self) -> None:
+        blob = self._blob()
+        for needle in ("23935", "7.510512e+14", "1.899705e-03"):
+            self.assertIn(
+                needle, blob,
+                f"the measured value {needle} from the "
+                f"2026-08-03 silent-Dirichlet run is gone")
+
+    def test_solver_enumeration_recorded(self) -> None:
+        blob = self._blob()
+        self.assertIn("fem.solver.linear.method", blob)
+        for name in ("gmres", "cg", "bicgstab"):
+            self.assertIn(name, blob)
+
+    def test_grid_cell_counts_recorded(self) -> None:
+        blob = self._blob()
+        # 4x4 structuredGrid -> 16 quadrilaterals; aluConformGrid -> 32
+        # triangles. Both counts are what the fixture asserts.
+        self.assertIn("quadrilateral", blob)
+        self.assertIn("hexahedron", blob)
+        self.assertIn("tetrahedron", blob)
+
+    def test_quadrature_measurements_recorded(self) -> None:
+        blob = self._blob()
+        self.assertIn("0.405284734569", blob)
+        self.assertIn("5.3e-02", blob)
+
+    def test_no_measured_convergence_orders_in_reachable_knowledge(self):
+        """The inverse of what this test used to assert.
+
+        An earlier revision PINNED the measured MMS orders and the
+        finest absolute errors into EXECUTED_API, which meant the
+        knowledge an agent reaches through
+        knowledge(topic="overview", solver="dune") contained the answer
+        to a convergence study — and that a future purge could not
+        remove it without failing this file. Adversarial audit
+        2026-08-03 inverted it: the numbers belong to the Tier-2 gate
+        that re-measures them, not to the catalog. This is now the
+        guard that keeps them out.
+        """
+        from backends.dune.generators import KNOWLEDGE  # noqa: E402
+        blob = json.dumps(EXECUTED_API, default=str) + json.dumps(
+            KNOWLEDGE, default=str)
+        forbidden = (
+            # per-order observed EOCs
+            "1.989", "1.997", "2.979", "2.995", "3.985", "3.996",
+            "1.894", "1.972", "1.993", "2.981",
+            # finest absolute L2 errors the fixture floors derive from
+            "4.556318e-04", "3.846536e-06", "2.180413e-08",
+            "1.312335e-03", "8.602468e-06",
+            # the 3D variable-coefficient family's own rate sequences,
+            # which survived the 2026-08-03 audit inside
+            # KNOWLEDGE["poisson_mms"]["expected_order"] because that
+            # audit only swept verified_api.py. Widening the guard to
+            # the whole KNOWLEDGE dict is what caught them.
+            "1.984/1.996", "1.028/1.007", "1.628(pre-asymptotic)",
+            "1.059(pre-asymptotic)",
+        )
+        leaked = [n for n in forbidden if n in blob]
+        self.assertEqual(
+            leaked, [],
+            f"measured convergence results leaked back into "
+            f"agent-reachable DUNE knowledge: {leaked}. Knowledge "
+            f"states how the code behaves; a measured order is the "
+            f"ANSWER to a study the agent may be asked to run. Keep "
+            f"them in scripts/tier2_fixtures/dune/"
+            f"poisson_mms_convergence/ instead.")
+
+    def test_convergence_section_still_carries_its_guidance(self) -> None:
+        """Stripping the numbers must not strip the diagnostic value."""
+        conv = EXECUTED_API["convergence_behaviour_2d_poisson"]
+        blob = json.dumps(conv, default=str)
+        self.assertIn("Signal", conv)
+        for needle in ("k+1", "globalRefine", "linear.tolerance"):
+            self.assertIn(needle, blob,
+                          f"convergence guidance lost {needle!r}")
+
+
+class TestFalsifiedClaimsStayFalsified(unittest.TestCase):
+    """Three catalog statements were contradicted by the install."""
+
+    def _dune_catalog_text(self) -> str:
+        root = _REPO / "src" / "backends" / "dune"
+        return "\n".join(p.read_text(encoding="utf-8")
+                         for p in sorted(root.rglob("*.py")))
+
+    def test_no_home_dune_jit_cache_claim(self) -> None:
+        text = self._dune_catalog_text()
+        # The literal path ~/.dune/dune-py does not exist on dune-fem
+        # 2.12; getDunePyDir() yields <sys.prefix>/.cache/dune-py or
+        # ~/.cache/dune-py. Mentioning it as a NEGATIVE ("NOT ~/.dune")
+        # is fine; asserting it as the cache location is not.
+        bad = re.findall(r"~/\.dune/dune-py/python", text)
+        self.assertEqual(
+            bad, [],
+            "the falsified ~/.dune/dune-py/python cache path is back "
+            "in the dune catalog; the measured location is "
+            "<sys.prefix>/.cache/dune-py/python/dune/generated")
+        self.assertIn(".cache/dune-py", text)
+
+    # Markers that turn a `product_space` mention into a DENIAL rather
+    # than a claim: the template's own import alias, or prose saying
+    # the name is an alias / absent / falsified.
+    _PRODUCT_SPACE_DENIALS = (
+        "import product as product_space",
+        "NO dune.fem.space.product_space",
+        "alias",
+        "ABSENT",
+        "FALSIFIED",
+    )
+
+    def test_product_space_is_not_claimed_as_an_api(self) -> None:
+        text = self._dune_catalog_text()
+        for m in re.finditer(r"product_space", text):
+            window = text[max(0, m.start() - 300):m.start() + 160]
+            self.assertTrue(
+                any(d in window for d in self._PRODUCT_SPACE_DENIALS),
+                "product_space is being presented as a real "
+                "dune.fem.space API again; hasattr() is False on "
+                "dune-fem 2.12.0.2 and the string does not occur "
+                "anywhere in the installed package. Context:\n"
+                + window)
+
+    # A lowercase mention is benign only when the matched text sits
+    # INSIDE one of these exact literals. A nearby word like
+    # "lowercase" is not enough — any re-introduced API use would sit
+    # beside explanatory prose containing it, which would make the
+    # check unfalsifiable (audit finding 2026-08-03).
+    _RAVIART_BENIGN = (
+        "raviartthomas.hh",
+        "dune.fem.space.raviartthomas",
+        "'raviartthomas'",
+        '"raviartthomas"',
+    )
+
+    def test_lowercase_raviartthomas_absent(self) -> None:
+        text = self._dune_catalog_text()
+        spans = []
+        for lit in self._RAVIART_BENIGN:
+            start = text.find(lit)
+            while start != -1:
+                spans.append((start, start + len(lit)))
+                start = text.find(lit, start + 1)
+        for m in re.finditer(r"\braviartthomas\b", text):
+            self.assertTrue(
+                any(lo <= m.start() and m.end() <= hi
+                    for lo, hi in spans),
+                "the lowercase raviartthomas spelling is back as an "
+                "API name; the Python factory is raviartThomas. "
+                "Context:\n"
+                + text[max(0, m.start() - 200):m.start() + 160])
+
+
+class TestTier2FixtureWiring(unittest.TestCase):
+    """The fixtures and the pitfalls they verify must stay aligned."""
+
+    # fixture directory -> the substring that must appear in the
+    # pitfall sitting at that fixture's pitfall_index.
+    _EXPECTED = {
+        "dirichletbc_not_in_scheme_list_silent": "IN THE LIST",
+        "solver_name_not_validated": "fem.solver.linear.method",
+        "ufl_cell_reports_simplex_on_cube_grid": "SIMPLEX UFL cell",
+        "boundary_ids_are_geometric_and_one_based": "ds(id) works",
+        "companion_modules_not_installed": "dune.femdg",
+    }
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from core.registry import get_backend, load_all_backends
+        load_all_backends()
+        cls.backend = get_backend("dune")
+        if cls.backend is None:                     # pragma: no cover
+            raise unittest.SkipTest("dune backend not registered")
+
+    def test_fixtures_exist_and_are_parseable(self) -> None:
+        self.assertTrue(_FIXTURES.is_dir())
+        for name in (*self._EXPECTED,
+                     "poisson_mms_convergence",
+                     "raviartThomas_camelcase_not_lowercase",
+                     "preconditioner_enumeration_is_short",
+                     "componentwise_bc_corner_drops_a_constraint"):
+            d = _FIXTURES / name
+            self.assertTrue((d / "fixture.json").is_file(),
+                            f"missing fixture.json for {name}")
+            meta = json.loads((d / "fixture.json").read_text())
+            self.assertEqual(meta["backend"], "dune")
+            self.assertTrue(meta["expect_in_output"],
+                            f"{name} has no expect_in_output")
+
+    def test_fixture_indices_point_at_the_intended_pitfall(self) -> None:
+        pitfalls = self.backend.get_knowledge("poisson")["pitfalls"]
+        for name, needle in self._EXPECTED.items():
+            with self.subTest(name):
+                meta = json.loads(
+                    (_FIXTURES / name / "fixture.json").read_text())
+                self.assertEqual(meta["physics"], "poisson")
+                idx = int(meta["pitfall_index"])
+                self.assertLess(
+                    idx, len(pitfalls),
+                    f"{name}: pitfall_index {idx} is past the end of "
+                    f"the poisson pitfall list ({len(pitfalls)})")
+                self.assertIn(
+                    needle, pitfalls[idx],
+                    f"{name}: pitfall_index {idx} no longer points at "
+                    f"the pitfall this fixture verifies. Pitfall "
+                    f"indices are POSITIONAL — inserting an entry "
+                    f"earlier in the list re-points every fixture "
+                    f"after it. Fix the index in fixture.json (and "
+                    f"check the other dune fixtures too).")
+
+    def test_fixture_keys_are_unique(self) -> None:
+        seen: dict[tuple, str] = {}
+        for d in sorted(_FIXTURES.iterdir()):
+            if not (d / "fixture.json").is_file():
+                continue
+            meta = json.loads((d / "fixture.json").read_text())
+            key = (meta["backend"], meta["physics"],
+                   int(meta["pitfall_index"]))
+            self.assertNotIn(
+                key, seen,
+                f"fixture key collision {key}: {d.name} vs "
+                f"{seen.get(key)} — run_tier2_fixtures.py stores "
+                f"results per key, so the second would overwrite the "
+                f"first")
+            seen[key] = d.name
+
+    def test_mms_fixture_records_its_measured_orders(self) -> None:
+        meta = json.loads(
+            (_FIXTURES / "poisson_mms_convergence"
+             / "fixture.json").read_text())
+        comment = meta["_comment"]
+        for needle in ("1.989", "2.979", "3.985", "2.12.0.2"):
+            self.assertIn(
+                needle, comment,
+                "the MMS fixture must record the orders it was "
+                "calibrated against, so a future drift is legible")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestEveryPhysicsEntryIsSelfSufficient(unittest.TestCase):
+    """Structural gate, not a content gate.
+
+    Project-owner requirement (2026-08-03): the DUNE knowledge has to be
+    usable by a SMALL model that will not infer, will not hunt for a
+    second payload and will not recover from a partial answer. Three
+    properties make that possible and are pinned here:
+
+      * every physics entry opens with a COMPLETE runnable script, not
+        a fragment — before this gate the scripts existed only inside
+        the GENERATORS callables, which knowledge(topic="physics") does
+        not reach;
+      * the load-bearing keys come FIRST in the entry, because a model
+        that stops reading early must still have the answer;
+      * every entry names the other lookups, so nothing depends on the
+        reader already knowing a topic= string.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from backends.dune.generators import GENERATORS, KNOWLEDGE
+        cls.GENERATORS = GENERATORS
+        cls.KNOWLEDGE = KNOWLEDGE
+        cls.physics = [k for k in KNOWLEDGE if k != "_general"]
+
+    def test_every_physics_entry_leads_with_a_runnable_example(self):
+        for name in self.physics:
+            with self.subTest(name):
+                entry = self.KNOWLEDGE[name]
+                keys = list(entry)
+                self.assertEqual(
+                    keys[0], "READ_THIS_FIRST",
+                    f"{name}: the orientation line must come first")
+                self.assertEqual(
+                    keys[1], "minimal_working_example",
+                    f"{name}: the complete script must be the second "
+                    f"key; a model that stops reading after two keys "
+                    f"has to already have something it can run")
+                script = entry["minimal_working_example"]
+                self.assertIsInstance(script, str)
+                for needle in ("import", "print("):
+                    self.assertIn(needle, script,
+                                  f"{name}: example is not a script")
+                self.assertIn(
+                    "DUNE_TEMPLATE_COMPLETE", script,
+                    f"{name}: the example must print the terminal "
+                    f"sentinel — a DUNE run can exit 134 after "
+                    f"printing every correct result, so the sentinel "
+                    f"is what distinguishes 'finished' from 'died'")
+
+    def test_every_physics_entry_names_the_other_lookups(self):
+        for name in self.physics:
+            with self.subTest(name):
+                where = self.KNOWLEDGE[name].get("where_else_to_look")
+                self.assertIsInstance(
+                    where, dict,
+                    f"{name}: nothing tells the reader how to reach "
+                    f"the rest of the catalog")
+                blob = json.dumps(where)
+                for needle in ("topic='overview'", "topic='pitfalls'",
+                               "topic='physics'"):
+                    self.assertIn(needle, blob,
+                                  f"{name}: {needle} not advertised")
+
+    def test_general_leads_with_start_here(self):
+        general = self.KNOWLEDGE["_general"]
+        self.assertEqual(list(general)[0], "START_HERE")
+        start = general["START_HERE"]
+        self.assertIn("complete_runnable_poisson", start)
+        script = start["complete_runnable_poisson"]
+        for needle in ("from dune.grid import structuredGrid",
+                       "from dune.fem.scheme import galerkin",
+                       "scheme.solve(target=uh)"):
+            self.assertIn(needle, script)
+        self.assertIn("REQUIRED_imports", start)
+        self.assertIn("OPTIONAL_imports", start)
+
+    def test_every_generator_emits_the_terminal_sentinel(self):
+        for variant, gen in self.GENERATORS.items():
+            with self.subTest(variant):
+                script = gen({})
+                self.assertIn(
+                    "DUNE_TEMPLATE_COMPLETE", script,
+                    f"{variant} does not print the terminal sentinel")
+                self.assertTrue(
+                    script.rstrip().endswith(
+                        'print("DUNE_TEMPLATE_COMPLETE")'),
+                    f"{variant}: the sentinel must be the LAST "
+                    f"statement, otherwise it does not prove the run "
+                    f"reached the end")
+
+
+class TestAdvertisedButAbsentStaysRetired(unittest.TestCase):
+    """dune-fem-dg and dune-vem are not importable on a dune-fem install.
+
+    The catalog advertised "Comprehensive DG methods via dune-fem-dg"
+    and "VEM (Virtual Element Method) support" as backend capabilities,
+    and named DIRK23 / SDIRK22 / Heun / SSP-RK steppers with no API
+    anywhere. Execution on 2026-08-03 refuted the premise: `import
+    dune.femdg`, `import dune.fem.dg` and `import dune.vem` all raise
+    ModuleNotFoundError. This keeps the capability claims from creeping
+    back as bare assertions.
+    """
+
+    def _catalog_text(self) -> str:
+        root = _REPO / "src" / "backends" / "dune"
+        return "\n".join(p.read_text(encoding="utf-8")
+                         for p in sorted(root.rglob("*.py")))
+
+    def test_dune_fem_dg_is_named_only_as_absent(self) -> None:
+        text = self._catalog_text()
+        self.assertTrue(
+            re.search(r"dune\.femdg.{0,400}ModuleNotFoundError", text,
+                      re.S) or
+            re.search(r"ModuleNotFoundError.{0,400}dune\.femdg", text,
+                      re.S),
+            "the catalog no longer records that dune.femdg is "
+            "unimportable on this install")
+        for m in re.finditer(r"pip install dune-fem-dg", text):
+            self.fail("the catalog tells the reader to pip install "
+                      "dune-fem-dg as if that made it part of this "
+                      "backend; it is a separate package and was "
+                      "measured absent")
+
+    def test_vem_claim_is_negative(self) -> None:
+        from backends.dune.generators import KNOWLEDGE
+        vem = KNOWLEDGE["_general"]["vem"]
+        self.assertIn("NOT AVAILABLE", vem)
+        self.assertIn("ModuleNotFoundError", vem)
+
+
+if __name__ == "__main__":                                  # pragma: no cover
+    unittest.main()

--- a/tests/test_expectations_assert_values.py
+++ b/tests/test_expectations_assert_values.py
@@ -1,0 +1,120 @@
+"""A fixture whose every expectation is a bare `key=` prefix asserts no value.
+
+WHY THIS EXISTS
+---------------
+A mutation control proves a fixture's output DEPENDS on the pathology. It cannot
+prove the assertion measures what its name says, and two independent passes put
+that failure rate at roughly 5% of fixtures. The cheapest large slice of it is
+mechanical: an expectation written as a bare prefix —
+
+    "features_on="        matches features_on=<anything>
+    "max_error="          matches max_error=<anything>
+
+matches whatever value the run produced. It cannot tell the pathological value
+from the correct one, so it is satisfied identically before and after the bug is
+removed.
+
+The worst instance found, `dealii/install_feature_flags_visible`: all five of its
+expectations are bare prefixes. Its own `_comment` states MPI, P4EST, PETSC,
+TRILINOS and SLEPC are undefined in that install and cites itself as the evidence
+for a "this cannot be verified here" finding. Re-run, it measured all five as ON
+and passed. Pointed at a second install with the flags inverted, it passes too.
+It is the stated evidence for a claim it cannot distinguish from its opposite.
+
+WHAT THIS CHECKS, AND WHAT IT DOES NOT
+--------------------------------------
+It fails a fixture where EVERY expectation is a bare prefix — one that asserts
+no value anywhere, so all of its discrimination rests on `forbid_in_output`.
+That is a real property and a cheap one to see.
+
+It deliberately does NOT fail a fixture that merely CONTAINS bare prefixes. 192
+of 10847 expectations corpus-wide are bare, and most sit beside a sibling that
+does pin a value; printing a path or a version alongside a real assertion is
+reasonable. Failing those would bury the eleven that matter.
+
+It also cannot catch the harder half of the class — an expectation that pins a
+value which happens to be true either way. `constrained_flux_matches_prescribed`
+asserting `G == G`, or a boolean computed from an exception string that is empty
+exactly when the co-asserted flag holds. Only a person reading the probe finds
+those. This gate takes the mechanical slice so that attention can go to the rest.
+
+THE BASELINE
+------------
+Ratchets. The eleven below are recorded so the gate fails on a NEW one
+immediately, while the known set is worked down. Nine of the eleven are the MMS
+convergence fixtures, whose expectations are `max_error=` / `observed_order=`
+style — those are also deliberately unpinned to avoid leaking measured values
+into the corpus, so fixing them means asserting a BOUND rather than a number.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+
+# Known value-blind fixtures, recorded 2026-08-07. Expected to shrink to empty.
+# Each entry is a fixture whose expectations cannot distinguish any value from
+# any other, so its verdict rests entirely on forbid_in_output.
+BASELINE = {
+    # The stated evidence for a capability claim it cannot tell from its
+    # opposite. Fix by asserting the specific flags, not their presence.
+    "dealii/install_feature_flags_visible",
+    # MMS convergence: `max_error=` / `observed_order=` are left unpinned on
+    # purpose, so that measured values do not leak into the corpus and become
+    # answers an evaluated agent could quote. The fix is to assert a BOUND
+    # (order within a tolerance of the theoretical rate) rather than a number.
+    "fenics/elasticity_mms_convergence",
+    "fenics/poisson_mms_convergence",
+    "fenics/stokes_mms_convergence",
+    "ngsolve/elasticity_mms_convergence",
+    "ngsolve/poisson_mms_convergence",
+    "ngsolve/stokes_mms_convergence",
+    "skfem/elasticity_mms_convergence",
+    "skfem/poisson_mms_convergence",
+    "skfem/stokes_mms_convergence",
+    # Blames a missing gmsh package; gmsh 4.15.1 imports fine on this host and
+    # dolfinx 0.10 merely renamed the submodule to dolfinx.io.gmsh. All three
+    # asserted strings are labels the script prints unconditionally.
+    "fenics/gmshio_install_gap_diagnostic",
+}
+
+
+def _value_blind() -> list[str]:
+    out = []
+    for fj in sorted(FIXTURES.glob("*/*/fixture.json")):
+        try:
+            spec = json.loads(fj.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        exp = [str(e) for e in (spec.get("expect_in_output") or [])]
+        if exp and all(e.rstrip().endswith("=") for e in exp):
+            out.append(f"{fj.parent.parent.name}/{fj.parent.name}")
+    return out
+
+
+def test_no_new_fixture_asserts_only_bare_prefixes() -> None:
+    new = sorted(set(_value_blind()) - BASELINE)
+    assert not new, (
+        f"{len(new)} fixture(s) assert only bare `key=` prefixes, so every "
+        f"expectation matches whatever value the run produced and none can "
+        f"distinguish the pathology from its absence:\n    "
+        + "\n    ".join(new)
+        + "\n\nPin a value, or a bound on one. If the value must stay unpinned "
+          "to keep measured numbers out of the corpus, assert a bound instead "
+          "(e.g. the observed order within a tolerance of the theoretical "
+          "rate) rather than the bare key."
+    )
+
+
+def test_baseline_only_shrinks() -> None:
+    """A fixture that has been fixed must leave the baseline.
+
+    Otherwise the list becomes a graveyard, and a fixture that regresses to
+    value-blind is silently re-permitted by its own stale entry.
+    """
+    fixed = sorted(BASELINE - set(_value_blind()))
+    assert not fixed, (
+        "these fixtures now assert values and must be removed from BASELINE, "
+        "so it cannot re-permit them later:\n    " + "\n    ".join(fixed))

--- a/tests/test_fabrication_gate.py
+++ b/tests/test_fabrication_gate.py
@@ -1,0 +1,197 @@
+"""Regression tests for the anti-fabrication checks.
+
+Every test corresponds to a forgery that was demonstrated to pass an earlier
+version of these checks, or to an honest case that an earlier version wrongly
+refused. They exist so those routes cannot silently reopen.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+skfem = pytest.importorskip("skfem")
+
+from core.fabrication_gate import (check_field_sanity, check_mesh_sanity,
+                                   check_probe_coverage, select_artefact,
+                                   select_field)
+from core.residual_check import check_residual
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+def unit_square(refine: int = 4):
+    m = skfem.MeshTri().refined(refine)
+    return m.p.T.copy(), [("triangle", m.t.T.copy())], m
+
+
+def poisson_source(x):
+    return 2 * np.pi ** 2 * np.sin(np.pi * x[0]) * np.sin(np.pi * x[1])
+
+
+def exact(px):
+    return np.sin(np.pi * px[:, 0]) * np.sin(np.pi * px[:, 1])
+
+
+def genuine_solution(m):
+    from skfem import Basis, ElementTriP1, asm, condense, solve, BilinearForm, LinearForm
+    from skfem.helpers import dot, grad
+    basis = Basis(m, ElementTriP1())
+
+    @BilinearForm
+    def a(u, v, w):
+        return dot(grad(u), grad(v))
+
+    @LinearForm
+    def L(v, w):
+        return poisson_source(w.x) * v
+
+    A, b = asm(a, basis), asm(L, basis)
+    return solve(*condense(A, b, D=basis.get_dofs()))
+
+
+# ── the discriminator: does the field satisfy the equations? ──────────────
+def test_genuine_solve_satisfies_the_discrete_equations():
+    p, c, m = unit_square(5)
+    v = check_residual(p, c, genuine_solution(m), dim=2,
+                       source_fn=poisson_source, domain_measure_expected=1.0)
+    assert v.supported and v.solver_like
+    assert v.relative_residual < 1e-8
+
+
+def test_exact_solution_sampled_at_nodes_is_not_a_solve():
+    """The most seductive forgery: perfectly accurate, and still not a solve.
+
+    An analytic field misses the discrete system by the truncation error, which
+    is orders of magnitude above solver tolerance.
+    """
+    p, c, m = unit_square(5)
+    v = check_residual(p, c, exact(p), dim=2, source_fn=poisson_source,
+                       domain_measure_expected=1.0)
+    assert v.supported and not v.solver_like
+    assert v.relative_residual > 1e-6
+
+
+def test_perturbed_analytic_field_is_not_a_solve():
+    """The eight-line fabricator: analytic field plus an h-dependent wobble.
+    It is MORE accurate than the genuine solve and passes a mesh-independence
+    study, so accuracy cannot be the discriminator."""
+    p, c, m = unit_square(5)
+    vals = exact(p) * (1 - 0.9 * (1 / 32) ** 2)
+    v = check_residual(p, c, vals, dim=2, source_fn=poisson_source,
+                       domain_measure_expected=1.0)
+    assert v.supported and not v.solver_like
+
+
+def test_constant_field_is_not_a_solve():
+    p, c, m = unit_square(4)
+    v = check_residual(p, c, np.full(len(p), 0.5), dim=2,
+                       source_fn=poisson_source, domain_measure_expected=1.0)
+    assert not v.solver_like
+
+
+def test_wrong_domain_is_refused_by_residual_check():
+    p, c, m = unit_square(4)
+    v = check_residual(p * 0.5, c, genuine_solution(m), dim=2,
+                       source_fn=poisson_source, domain_measure_expected=1.0)
+    assert v.relative_residual is None and not v.solver_like
+    assert "domain" in v.detail
+
+
+# ── mesh sanity ───────────────────────────────────────────────────────────
+def test_four_node_mesh_has_no_interior_and_is_refused():
+    """Four nodes and one constant cover the unit square exactly and can hit
+    any target value. Geometrically valid, so only the interior-node
+    requirement catches it."""
+    p = np.array([[0, 0], [1, 0], [0, 1], [1, 1]], float)
+    c = [("triangle", np.array([[0, 1, 2], [1, 3, 2]]))]
+    v = check_mesh_sanity(p, c, dim=2, domain_measure_expected=1.0)
+    assert not v.accepted and "interior" in v.reasons[0]
+
+
+def test_scaled_coordinates_are_refused():
+    p, c, _ = unit_square(4)
+    v = check_mesh_sanity(p * 1e-6, c, dim=2, domain_measure_expected=1.0)
+    assert not v.accepted and "domain" in v.reasons[0]
+
+
+def test_degenerate_cell_is_refused():
+    p, c, m = unit_square(4)
+    cells = [("triangle", np.vstack([m.t.T, [[0, 0, 0]]]))]
+    v = check_mesh_sanity(p, cells, dim=2)
+    assert not v.accepted and "degenerate" in v.reasons[0]
+
+
+def test_unreferenced_node_is_refused():
+    p, c, _ = unit_square(4)
+    v = check_mesh_sanity(np.vstack([p, [[9, 9]]]), c, dim=2)
+    assert not v.accepted and "not referenced" in v.reasons[0]
+
+
+def test_honest_mesh_is_accepted():
+    p, c, _ = unit_square(4)
+    v = check_mesh_sanity(p, c, dim=2, domain_measure_expected=1.0)
+    assert v.accepted and v.checks["n_interior_nodes"] > 0
+
+
+# ── field sanity ──────────────────────────────────────────────────────────
+def test_partially_nan_field_is_refused():
+    """A norm can come out finite while most nodes are NaN."""
+    p, _, _ = unit_square(4)
+    vals = np.ones(len(p))
+    vals[3:8] = np.nan
+    v = check_field_sanity(vals, n_points=len(p))
+    assert not v.accepted and "not finite" in v.reasons[0]
+
+
+def test_finite_field_is_accepted():
+    p, _, _ = unit_square(4)
+    assert check_field_sanity(np.ones(len(p)), n_points=len(p)).accepted
+
+
+# ── selection: never guess, never substitute ──────────────────────────────
+def test_missing_requested_field_is_not_substituted():
+    name, why = select_field({"tiny_helper": 1, "u": 2}, "error")
+    assert name is None and "does not substitute" in why
+
+
+def test_vtk_metadata_arrays_are_never_graded():
+    name, _ = select_field({"vtkGhostType": 1, "u": 2}, "")
+    assert name == "u"
+
+
+def test_ambiguous_field_is_refused():
+    name, why = select_field({"u": 1, "p": 2}, "")
+    assert name is None and "does not guess" in why
+
+
+def test_multiple_artefacts_require_an_explicit_choice(tmp_path):
+    """A decoy named to sort first once pre-empted the genuine result, and an
+    honest time series was graded at its initial condition."""
+    for n in ("a_checkpoint.vtu", "solution.vtu"):
+        (tmp_path / n).write_text("x")
+    got, why = select_artefact(sorted(tmp_path.glob("*.vtu")), None)
+    assert got is None and "explicitly" in why
+
+
+def test_single_artefact_is_unambiguous(tmp_path):
+    (tmp_path / "solution.vtu").write_text("x")
+    got, _ = select_artefact(sorted(tmp_path.glob("*.vtu")), None)
+    assert got is not None
+
+
+# ── probe coverage: a bounding box is not coverage ────────────────────────
+def test_slivers_spanning_the_bounding_box_are_refused():
+    p = np.array([[0, 0], [.05, 0], [0, .05], [.95, .95], [1, .95], [.95, 1]], float)
+    c = [("triangle", np.array([[0, 1, 2], [3, 4, 5]]))]
+    v = check_probe_coverage(p, c, [[0.5, 0.5]], dim=2)
+    assert not v.accepted and "no cell" in v.reasons[0]
+
+
+def test_one_dangling_node_does_not_reopen_the_hole():
+    p, c, _ = unit_square(4)
+    v = check_probe_coverage(np.vstack([p, [[10, 10]]]), c, [[5, 5]], dim=2)
+    assert not v.accepted
+
+
+def test_probe_inside_the_mesh_is_accepted():
+    p, c, _ = unit_square(4)
+    assert check_probe_coverage(p, c, [[0.5, 0.5]], dim=2).accepted

--- a/tests/test_febio_elasticity_mms.py
+++ b/tests/test_febio_elasticity_mms.py
@@ -1,7 +1,11 @@
 """Gen-only tests for the FEBio 3D linear-elasticity MMS family.
 
-No FEBio binary is available on this install, so these tests verify
-everything that CAN be verified offline:
+These tests verify everything that CAN be verified offline, without a
+FEBio binary. They deliberately assert NO measured quantity: the
+theoretical hex8 displacement L2 order is 2, and whether a given sweep
+attains it is a result to be measured by whoever runs the sweep, never a
+number pinned in a test. What is pinned here is deck structure and the
+MMS algebra:
 
   - the emitted deck is well-formed FEBio 4.0 XML with no unresolved
     placeholders,

--- a/tests/test_febio_signal_strings.py
+++ b/tests/test_febio_signal_strings.py
@@ -1,0 +1,326 @@
+"""Regression: every FEBio `Signal:` string must be one FEBio can emit.
+
+FEBio is a C++ binary, so every diagnostic it can ever print is a
+string literal inside febio4 or one of its shared libraries. That makes
+"can this message actually appear?" a decidable question, unlike the
+Python backends where a message can be built at runtime.
+
+It needed to be decidable, because it was not being decided. Twenty-five
+`Signal:` strings in this catalog named messages the binary cannot
+produce. Six of them were `NOX` / `DIVERGED` / `DIVERGED_LINE_SEARCH` /
+`DIVERGED_FNORM_NAN` — Trilinos NOX status names — and one was
+`KSPSolve`, a PETSc entry point. FEBio links neither library. Those
+strings were imported from other FEM codes by a model writing plausible
+text instead of reading output, and a consumer that greps for them waits
+forever for a message that will never come.
+
+Two layers, deliberately:
+
+  * OFFLINE (runs everywhere) — a deny-list of foreign-toolkit tokens.
+    No FEBio message contains them, so their appearance anywhere in the
+    FEBio knowledge is proof of imported text. This is the layer that
+    would have caught the original 25.
+
+  * LIVE (needs febio4) — the general check. Every backticked literal
+    inside a `Signal:` clause is split into static fragments, and each
+    fragment must occur in the strings of febio4 plus every .so beside
+    it. FEBio messages are printf templates (`invalid value for
+    attribute "%s"`), so whole-string matching is impossible and
+    fragment matching is the correct granularity.
+
+CONVENTION THIS TEST ENFORCES, and which every FEBio pitfall must
+follow: **inside a `Signal:` clause, backticks mean "text FEBio
+printed".** Nothing else may be backticked there. Deck text the author
+wrote, type names FEBio rejected, file names, shell commands — all of
+those go in plain double quotes, in the WRONG:/RIGHT: part of the entry,
+or after the Signal clause closes. Without that rule the check cannot
+tell a real diagnostic from a string being quoted as an example of what
+not to write, and a phantom hides behind the ambiguity. Text FEBio
+echoes back out of the deck (through a %s, and therefore always inside
+double quotes in the message) is exempt — it is a runtime value, not a
+literal.
+
+WHAT A GREEN RUN OF THIS FILE DOES AND DOES NOT MEAN. Measured on the
+catalog 2026-08-05: of 269 backticked literals inside Signal clauses,
+205 (76%) reach the fragment check. The other 64 are invisible to it —
+50 reduce to no checkable fragment at all (dominated by the spaced
+banners `N O R M A L   T E R M I N A T I O N` and
+`E R R O R   T E R M I N A T I O N`, where the placeholder rule treats
+every isolated capital as a substitution slot, plus short names like
+`LU`), and 14 are skipped by the flag rule. A further 20 of the 97
+pitfalls carry no backticked Signal literal, so the check never looks at
+them. The check is also blind to punctuation: `Reading file ...FAILED!`
+and a four-dot `Reading file ....FAILED!` produce identical fragments,
+so a wrong dot count passes.
+
+And it can only ever rule out INVENTION, never mis-ATTRIBUTION. A string
+that exists in the corpus passes even when it belongs to a different
+trigger than the entry claims. Nothing about grepping a binary can catch
+that; only running the stated WRONG: case and reading the message can.
+So "zero unmatchable Signals" is a floor, not a certificate.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import string
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+_PRINTABLE = set(string.printable[:-5].encode())
+
+# Everywhere a runtime value can sit inside a FEBio message. Used to cut
+# a quoted Signal into the static runs that must exist in the binary.
+_PLACEHOLDER = re.compile(r'"[^"]*"|<[^>]*>|\.\.\.|\b[A-Z]\b|%\w')
+
+
+def _find_febio() -> Path | None:
+    """FEBIO_BINARY is AUTHORITATIVE when set — see the note in
+    tests/test_febio_source_of_truth.py. A set-but-invalid value returns
+    None instead of falling through to the search path, which used to
+    make `FEBIO_BINARY=/nonexistent` resolve to the real binary and so
+    silently void any absence-behaviour test. (Fixed 2026-08-05.)"""
+    env = os.environ.get("FEBIO_BINARY")
+    if env is not None:
+        p = Path(env)
+        return p if p.is_file() else None
+    for c in (Path.home() / "FEBio" / "bin" / "febio4",
+              Path.home() / "FEBioStudio" / "bin" / "febio4",
+              Path("/opt/febio/bin/febio4"),
+              Path("/usr/local/bin/febio4")):
+        if c.is_file():
+            return c
+    w = shutil.which("febio4") or shutil.which("febio")
+    return Path(w) if w else None
+
+
+def _strings(path: Path, minlen: int = 6):
+    """Pure-python `strings -n <minlen>`; no external tool needed."""
+    out, cur = [], bytearray()
+    with open(path, "rb") as fh:
+        while chunk := fh.read(1 << 20):
+            for b in chunk:
+                if b in _PRINTABLE:
+                    cur.append(b)
+                else:
+                    if len(cur) >= minlen:
+                        out.append(cur.decode("ascii", "replace"))
+                    cur.clear()
+    if len(cur) >= minlen:
+        out.append(cur.decode("ascii", "replace"))
+    return out
+
+
+def _corpus(binary: Path) -> str:
+    """febio4 plus every shared library that ships with it.
+
+    FEBio's messages are spread across libfecore / libfebiomech /
+    libfebiomix / libfebiofluid / ... — checking only the executable
+    would report almost everything as a phantom.
+    """
+    files = [binary]
+    real = binary.resolve()
+    for d in {real.parent, real.parent.parent / "lib", binary.parent}:
+        if d.is_dir():
+            files += sorted(d.glob("*.so")) + sorted(d.glob("*.so.*"))
+    seen, parts = set(), []
+    for f in files:
+        r = f.resolve()
+        if r in seen or not r.is_file():
+            continue
+        seen.add(r)
+        parts.extend(_strings(r))
+    return "\n".join(parts)
+
+
+def _febio_pitfalls():
+    """Every pitfall string anywhere in the FEBio knowledge.
+
+    Recurses: pitfall lists live both at the topic level and inside
+    nested reference blocks (e.g. _general/adaptive_mesh_refinement),
+    and a check that only looked one level down would leave the nested
+    ones unguarded.
+    """
+    from backends.febio import generators as G
+
+    def walk(node, path):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == "pitfalls" and isinstance(v, (list, tuple)):
+                    for i, p in enumerate(v):
+                        if isinstance(p, str):
+                            yield path, i, p
+                else:
+                    yield from walk(v, f"{path}/{k}" if path else str(k))
+
+    for topic, entry in sorted(G.KNOWLEDGE.items()):
+        yield from walk(entry, topic)
+
+
+def _signal_literals():
+    """(topic, index, literal) for every backticked run of text that
+    sits inside a `Signal:` clause."""
+    for topic, i, p in _febio_pitfalls():
+        for m in re.finditer(r"Signal:(.*?)(?=\(Executed|\(Live-verified"
+                             r"|\(Verified|\(Source walk|$)", p, re.S):
+            for lit in re.findall(r"`([^`]+)`", m.group(1)):
+                yield topic, i, lit
+
+
+# Tokens that belong to other finite-element toolkits. FEBio links none
+# of them, so any occurrence is text imported from another code rather
+# than read out of FEBio.
+FOREIGN_TOKENS = (
+    "NOX",                  # Trilinos nonlinear solver
+    "DIVERGED_",            # Trilinos/PETSc status enums
+    "CONVERGED_",
+    "KSPSolve", "KSPSetUp", "SNESSolve",   # PETSc
+    "PETSC", "PetscError",
+    "Trilinos", "Epetra", "Tpetra", "Belos", "Amesos", "AztecOO",
+    "dolfinx", "DOLFIN", "UFLException",   # FEniCS
+    "deal.II ExcMessage", "ExcDimensionMismatch",   # deal.II
+    "KratosMultiphysics",   # Kratos
+    "ngsolve.", "NgException",              # NGSolve
+    "write_vtu",            # not a FEBio concept: FEBio writes .xplt
+)
+
+
+class TestNoForeignSolverTokens(unittest.TestCase):
+    """Offline. Runs on any host, with or without FEBio installed."""
+
+    def test_no_foreign_toolkit_token_in_any_febio_pitfall(self) -> None:
+        hits = []
+        for topic, i, p in _febio_pitfalls():
+            for tok in FOREIGN_TOKENS:
+                if tok in p:
+                    hits.append(f"{topic}#{i}: {tok!r}")
+        self.assertEqual(
+            hits, [],
+            "FEBio knowledge names a symbol from a different FEM "
+            "toolkit. FEBio links neither PETSc nor Trilinos, so a "
+            "message containing these can never appear and a consumer "
+            "grepping for it waits forever. Read the real diagnostic "
+            "off a failing run instead of writing a plausible one.\n  "
+            + "\n  ".join(hits))
+
+    def test_every_pitfall_has_a_signal_clause(self) -> None:
+        missing = [f"{t}#{i}" for t, i, p in _febio_pitfalls()
+                   if "Signal:" not in p]
+        self.assertEqual(
+            missing, [],
+            "every FEBio pitfall must state the observable symptom "
+            f"under a 'Signal:' clause: {missing}")
+
+    def test_no_falsified_annotation_left_inline(self) -> None:
+        """A phantom must be DELETED, not annotated.
+
+        An earlier audit corrected phantom Signals by leaving the
+        phantom string in place and appending a bracketed
+        `[FALSIFIED ...]` note. The consumer of this catalog is a small
+        model that does not read the bracket; it reads the phantom and
+        greps for it. Corrections must replace the text, not argue
+        with it.
+        """
+        bad = []
+        for topic, i, p in _febio_pitfalls():
+            for marker in ("[FALSIFIED", "[CORRECTED"):
+                if marker in p:
+                    bad.append(f"{topic}#{i}: {marker}")
+        self.assertEqual(
+            bad, [],
+            "an inline [FALSIFIED]/[CORRECTED] bracket is still "
+            "sitting next to the text it falsifies. Delete the wrong "
+            "string and state only what the binary really emits; the "
+            "history belongs in the commit message.\n  "
+            + "\n  ".join(bad))
+
+
+class TestSignalStringsExistInBinary(unittest.TestCase):
+    """Live. Needs febio4; skipped otherwise."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.binary = _find_febio()
+        cls.blob = _corpus(cls.binary) if cls.binary else ""
+
+    def setUp(self) -> None:
+        if self.binary is None:
+            self.skipTest(
+                "febio4 not installed; set FEBIO_BINARY or symlink "
+                "~/FEBio/bin/febio4 to run the phantom-Signal check")
+
+    def test_corpus_is_plausible(self) -> None:
+        """Guard the guard: if the corpus came back tiny we would
+        report every Signal as a phantom."""
+        self.assertGreater(
+            len(self.blob), 200_000,
+            "the FEBio string corpus is implausibly small — the "
+            "shared libraries were probably not found, which would "
+            "make every Signal look like a phantom")
+        for known in ('invalid value for attribute "%s"',
+                      "N O R M A L   T E R M I N A T I O N",
+                      "failed to converge at time"):
+            self.assertIn(
+                known, self.blob,
+                f"corpus is missing a message FEBio certainly emits "
+                f"({known!r}) — the corpus build is broken, not the "
+                f"catalog")
+
+    def test_every_signal_fragment_occurs_in_the_binary(self) -> None:
+        lower = self.blob.lower()
+        phantoms = []
+        for topic, i, lit in _signal_literals():
+            s = lit.strip()
+            # Shell commands and XML the USER writes are not FEBio
+            # output; only solver messages are checked here.
+            if re.match(r"^(printf|grep|strings|febio4|python|\$)", s):
+                continue
+            # Skip our own XML notation and genuine command-line FLAGS
+            # (`-nosplash`, `--help`, `-DUSE_MKL=ON`). The old rule was
+            # a bare startswith("--"), which also skipped FEBio's own
+            # `------- failed to converge at time :` — a real message
+            # quoted in four pitfalls that was therefore never checked.
+            # A flag has a letter right after the dashes; a banner rule
+            # does not. (Narrowed 2026-08-05.)
+            if s.startswith("<") or re.match(r"^--?[A-Za-z]", s):
+                continue
+            # FEBio messages are printf templates, so only the STATIC
+            # runs between substitutions survive into the binary.
+            # Replace every place a runtime value can sit with a
+            # separator, so the static runs on either side are checked
+            # independently and never joined across a hole:
+            #   "..."   a %s slot, always double-quoted in FEBio output
+            #   <...>   our own placeholder notation
+            #   ...     an elision
+            #   N X D   a bare capital standing for a number
+            #   %d %s   a template written out literally
+            # Without the separator, `Component "" needs to have
+            # property "solver" defined` would be searched for as one
+            # run and reported as a phantom although both halves are
+            # real. With it, the check needs no per-word escape hatch —
+            # and that hatch was the hole: every long word of "element
+            # inversion detected in porous domain" occurs somewhere in
+            # the corpus, so an invented sentence passed.
+            s = _PLACEHOLDER.sub("|", s)
+            for frag in re.split(r"[^A-Za-z_ ]+", s):
+                frag = frag.strip()
+                if len(re.sub(r"[^A-Za-z]", "", frag)) < 6:
+                    continue
+                if frag.lower() in lower:
+                    continue
+                phantoms.append(f"{topic}#{i}: {frag!r} (in {lit!r})")
+        self.assertEqual(
+            phantoms, [],
+            "a Signal: names text that occurs nowhere in febio4 or "
+            "its shared libraries, so FEBio cannot print it and the "
+            "Signal can never match. Capture the real message from a "
+            "failing run.\n  " + "\n  ".join(phantoms))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_febio_source_of_truth.py
+++ b/tests/test_febio_source_of_truth.py
@@ -1,0 +1,407 @@
+"""Regression: FEBio catalog type strings vs the installed binary.
+
+FEBio is an XML-input solver, so every "API name" the catalog can
+get wrong is a string inside a .feb file: a module name, a
+material type, a boundary-condition type, a plot variable. A
+wrong string is either a parse error or — for <Module type=...> —
+a segmentation fault with no diagnostic at all.
+
+Unlike the Python backends, FEBio can be introspected directly:
+febio4 ships an interactive console whose `list` command dumps
+every registered factory as "<module>.<type string>
+[SUPER_CLASS_ID]", and `list -m` dumps the module names. That
+dump IS the source of truth for the installed BUILD — better than
+grepping REGISTER_FECORE_CLASS out of a source tree, because a
+source tree registers features that a given cmake configuration
+never compiles (e.g. `pardiso` exists in the sources but not in a
+USE_MKL=OFF build).
+
+This test pins two things:
+
+  (a) OFFLINE — the module list hard-coded in
+      backends.febio.generators.deck_structure.FEBIO_MODULES and
+      the per-module <analysis> enum table must stay in sync with
+      what the catalog's own templates emit. Runs everywhere.
+
+  (b) LIVE (skipped when no febio4 is installed) — that same
+      hard-coded module list must equal what the binary reports.
+      This is the check that catches version drift: the catalog
+      carried `heat` and `biphasic-FSI` module names for months;
+      FEBio 4.12 registers neither, and feeding either to
+      <Module type=...> crashes the process.
+
+Established 2026-08-03 against FEBio 4.12.0.86045466d.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+
+def _find_febio() -> Path | None:
+    """Locate febio4.
+
+    FEBIO_BINARY is AUTHORITATIVE when set: if it names something that is
+    not a file we return None rather than falling through to the search
+    path. The fall-through silently defeated every acceptance test that
+    sets FEBIO_BINARY to a nonexistent path to prove absence-behaviour —
+    `FEBIO_BINARY=/nonexistent/febio4` used to resolve to the real
+    binary, so such a test measured nothing. (Fixed 2026-08-05.)
+    """
+    env = os.environ.get("FEBIO_BINARY")
+    if env is not None:
+        p = Path(env)
+        return p if p.is_file() else None
+    for c in (Path.home() / "FEBio" / "bin" / "febio4",
+              Path.home() / "FEBioStudio" / "bin" / "febio4",
+              Path("/opt/febio/bin/febio4"),
+              Path("/usr/local/bin/febio4")):
+        if c.is_file():
+            return c
+    w = shutil.which("febio4") or shutil.which("febio")
+    return Path(w) if w else None
+
+
+def _live_modules(binary: Path) -> set[str]:
+    """Ask the binary for its registered module names."""
+    p = subprocess.run([str(binary), "-nosplash"],
+                       input="list -m\nquit\n",
+                       capture_output=True, text=True, timeout=60)
+    out = (p.stdout or "") + (p.stderr or "")
+    # Lines look like "  1: solid" — the numbering restarts at 1
+    # and the list is terminated by a blank line.
+    names = set()
+    for line in out.splitlines():
+        m = re.match(r"^\s*(?:febio>)?\s*(\d+):\s*(\S.*?)\s*$", line)
+        if m:
+            names.add(m.group(2))
+    return names
+
+
+class TestFebioModuleCatalogOffline(unittest.TestCase):
+    """No binary required."""
+
+    def test_no_template_emits_an_unregistered_module(self) -> None:
+        """GUARD: every shipped template must name a module FEBio
+        actually registers.
+
+        This assertion used to run the other way round. It pinned
+        `offenders == {"heat_3d_bar": "heat",
+        "biphasic_fsi_3d_block": "biphasic-FSI"}`, i.e. the suite
+        REQUIRED those two templates to keep segfaulting the solver
+        and went red if either was repaired. That is a test that
+        certifies a defect. Both templates were repaired on
+        2026-08-03 — heat_3d_bar now emits `thermo-fluid` (FEBio
+        4.12 has no `heat` module and no solid-conduction solver;
+        holding the fluid at rest reduces the thermo-fluid energy
+        equation to Fourier conduction) — so the assertion is now
+        the guard it should always have been: the offender set must
+        be EMPTY.
+
+        An unregistered <Module type> is not diagnosed. FEBio dies
+        with SIGSEGV, no ERROR box, no .log file, and stdout frozen
+        mid-line at `Reading file <name>.feb ...`. So a template
+        that trips this test is not merely wrong, it is
+        undebuggable from the outside."""
+        from backends.febio.generators import (
+            GENERATORS, FEBIO_MODULES)
+
+        offenders: dict[str, str] = {}
+        for key, gen in GENERATORS.items():
+            root = ET.fromstring(gen({}))
+            mod_el = root.find("Module")
+            self.assertIsNotNone(
+                mod_el, f"{key}: template has no <Module> tag; "
+                        f"FEBio rejects the deck with 'First tag "
+                        f"must be the Module section.'")
+            mtype = mod_el.attrib.get("type")
+            if mtype not in FEBIO_MODULES:
+                offenders[key] = mtype
+        self.assertEqual(
+            offenders, {},
+            "a shipped template names a module FEBio 4.12 does not "
+            "register. Feeding one to <Module type=...> SEGFAULTS "
+            "the solver with no diagnostic at all. Fix the template "
+            f"to use one of {list(FEBIO_MODULES)}; do NOT re-pin the "
+            "offender.")
+
+    def test_analysis_enum_table_covers_every_module(self) -> None:
+        from backends.febio.generators import (
+            FEBIO_MODULES, FEBIO_ANALYSIS_VALUES)
+        self.assertEqual(
+            set(FEBIO_ANALYSIS_VALUES), set(FEBIO_MODULES),
+            "every registered module installs its own <analysis> "
+            "enum vocabulary (FE*Analysis setEnums), so the table "
+            "must cover exactly the registered modules")
+        for mod, vals in FEBIO_ANALYSIS_VALUES.items():
+            self.assertTrue(
+                vals, f"{mod}: empty <analysis> vocabulary")
+            for v in vals:
+                self.assertEqual(
+                    v, v.upper(),
+                    f"{mod}: analysis enum words are upper-case in "
+                    f"FEBio's setEnums tables ({v!r})")
+
+    def test_templates_declare_analysis_legal_for_their_module(
+            self) -> None:
+        """A word from another module's vocabulary is a hard parse
+        error (`tag "analysis" (line N) : invalid value: X`)."""
+        from backends.febio.generators import (
+            GENERATORS, FEBIO_ANALYSIS_VALUES)
+        bad: list[str] = []
+        for key, gen in GENERATORS.items():
+            root = ET.fromstring(gen({}))
+            mod_el = root.find("Module")
+            ctrl = root.find("Control")
+            if mod_el is None or ctrl is None:
+                continue
+            mtype = mod_el.attrib.get("type")
+            an = ctrl.find("analysis")
+            if an is None or an.text is None:
+                continue
+            legal = FEBIO_ANALYSIS_VALUES.get(mtype)
+            if legal is None:
+                # phantom module — covered by the test above
+                continue
+            word = an.text.strip()
+            if word.upper() not in legal and not word.isdigit():
+                bad.append(f"{key}: <analysis>{word}</analysis> "
+                           f"not legal in module {mtype!r} "
+                           f"(legal: {legal})")
+        self.assertEqual(bad, [], "; ".join(bad))
+
+
+class TestFebioModuleCatalogLive(unittest.TestCase):
+    """Requires the febio4 binary; skipped otherwise."""
+
+    def setUp(self) -> None:
+        self.binary = _find_febio()
+        if self.binary is None:
+            self.skipTest(
+                "febio4 not installed; set FEBIO_BINARY or symlink "
+                "~/FEBio/bin/febio4 to run the live source-of-truth "
+                "check")
+
+    def test_pinned_module_list_matches_the_binary(self) -> None:
+        from backends.febio.generators import FEBIO_MODULES
+        live = _live_modules(self.binary)
+        self.assertTrue(
+            live, "could not read a module list out of febio4 — the "
+                  "`list -m` console command changed shape?")
+        self.assertEqual(
+            set(FEBIO_MODULES), live,
+            "deck_structure.FEBIO_MODULES has drifted from the "
+            "installed FEBio build. This list is what the catalog "
+            "uses to decide whether a <Module type=...> value is "
+            "safe; a value outside the live set SEGFAULTS FEBio "
+            "with no diagnostic, so the pinned list must be "
+            "updated (and any affected template knowledge with "
+            f"it). live={sorted(live)}")
+
+    def test_repaired_templates_actually_run(self) -> None:
+        """GUARD, the live half of the inversion above.
+
+        `heat_3d_bar` and `biphasic_fsi_3d_block` were the two
+        templates the suite used to require to stay broken. Passing
+        the XML check is not enough — a module name can be
+        registered and the deck still solve nothing. So run them and
+        judge on PROGRESS: the process must not be killed by a
+        signal, a termination banner must appear, and at least one
+        time step must be completed.
+
+        A `N O R M A L   T E R M I N A T I O N` banner alone is
+        explicitly NOT accepted as evidence: a deck with no
+        <Control> and a deck using <linear_solver type="test"/> both
+        produce clean-looking runs that solved nothing (see the
+        tier-2 fixtures missing_control_silent_zero_result and
+        null_test_linear_solver_reports_success)."""
+        import tempfile
+        from backends.febio.generators import GENERATORS
+
+        for key in ("heat_3d_bar", "biphasic_fsi_3d_block"):
+            with self.subTest(template=key):
+                self.assertIn(key, GENERATORS)
+                deck = GENERATORS[key]({})
+                with tempfile.TemporaryDirectory() as td:
+                    feb = Path(td) / f"{key}.feb"
+                    feb.write_text(deck)
+                    p = subprocess.run(
+                        [str(self.binary), "-i", str(feb), "-nosplash"],
+                        capture_output=True, text=True, timeout=600,
+                        cwd=td)
+                    blob = (p.stdout or "") + (p.stderr or "")
+                    log = Path(td) / f"{key}.log"
+                    if log.is_file():
+                        blob += log.read_text(errors="replace")
+                    csv_name = ("heat_bar_T.csv"
+                                if key == "heat_3d_bar"
+                                else f"{key}_nodes.csv")
+                    cf = Path(td) / csv_name
+                    csv = cf.read_text() if cf.is_file() else ""
+
+                self.assertGreaterEqual(
+                    p.returncode, 0,
+                    f"{key}: febio4 was killed by signal "
+                    f"{-p.returncode}. An unregistered <Module type> "
+                    f"segfaults with no diagnostic; this template "
+                    f"must never do that again.")
+                self.assertTrue(
+                    "N O R M A L   T E R M I N A T I O N" in blob
+                    or "E R R O R   T E R M I N A T I O N" in blob,
+                    f"{key}: no termination banner at all — the run "
+                    f"died before FEBio could report anything.")
+                m = re.search(
+                    r"Number of time steps completed\s*\.*\s*:\s*(\d+)",
+                    blob)
+                self.assertIsNotNone(
+                    m, f"{key}: FEBio never printed a completed-step "
+                       f"count, so the solver did not start.")
+                self.assertGreaterEqual(
+                    int(m.group(1)), 1,
+                    f"{key}: 0 time steps completed. The deck parsed "
+                    f"but solved nothing — that is a broken template, "
+                    f"whatever the banner says.")
+
+                # ---- and now a NUMERIC check, because the four
+                # structural ones above are all satisfiable by a deck
+                # that returns nonsense. Adversarial audit 2026-08-05:
+                # flipping heat_3d_bar's <analysis> to DYNAMIC leaves
+                # every assertion above green while the steady field
+                # undershoots its own 300 K cold boundary by 26.44 K
+                # and misses the analytic profile by 113.94 K. So the
+                # docstring's promise that a banner is "not accepted as
+                # evidence" was only kept against the crudest failures.
+                if key == "heat_3d_bar":
+                    self.assertTrue(
+                        csv, f"{key}: no {csv_name} written, so the "
+                             f"documented <Output> block is wrong")
+                    rows = [r.split(",") for r in
+                            csv.split("*Step")[-1].splitlines()]
+                    temps = [float(r[1]) for r in rows
+                             if len(r) == 2 and r[0].strip().isdigit()]
+                    self.assertTrue(
+                        temps, f"{key}: could not parse temperatures")
+                    # Pure conduction between two Dirichlet ends obeys a
+                    # maximum principle: nothing may leave [T_cold,
+                    # T_hot]. The deck prescribes 300 and 400.
+                    self.assertGreater(
+                        min(temps), 300.0 - 1e-6,
+                        f"{key}: a node reached {min(temps)} K, below "
+                        f"the 300 K cold boundary. Conduction between "
+                        f"two Dirichlet ends cannot undershoot both of "
+                        f"them — the run is unphysical however clean "
+                        f"the banner is.")
+                    self.assertLess(
+                        max(temps), 400.0 + 1e-6,
+                        f"{key}: a node reached {max(temps)} K, above "
+                        f"the 400 K hot boundary.")
+                    # The exact solution is linear in x and hex8 is
+                    # trilinear, so it lies IN the FE space: the only
+                    # error is the iterative solver's. See the
+                    # `verification` entry for the measured range
+                    # (0 to 7.3e-8 over n = 2..96).
+                    xs = {int(mm.group(1)): float(mm.group(2))
+                          for mm in re.finditer(
+                              r'<node id="(\d+)">([-0-9.eE+]+),', deck)}
+                    err = max(
+                        abs(float(r[1]) - (300.0 + 100.0 * xs[int(r[0])]))
+                        for r in rows
+                        if len(r) == 2 and r[0].strip().isdigit())
+                    self.assertLess(
+                        err, 1e-5,
+                        f"{key}: max deviation from the analytic "
+                        f"profile T = 300 + 100*x is {err} K. The exact "
+                        f"solution lies in the trilinear space, so this "
+                        f"must sit at solver tolerance, not at "
+                        f"discretization error.")
+
+    def test_the_baseline_deck_in_knowledge_actually_runs(self) -> None:
+        """GUARD: the deck the catalog calls 'the safest thing to
+        mutate from' must be copy-and-run correct.
+
+        It used to be an abbreviated skeleton with `...` standing in
+        for the nodes, the elements, the boundary conditions and the
+        load curve. The consumer of this catalog is a small model that
+        will not fill those in and will not go looking for a second
+        payload, so an elided baseline is worse than none — it looks
+        authoritative and cannot work. This test extracts the XML from
+        the knowledge string exactly as a reader would and runs it."""
+        import subprocess
+        import tempfile
+        from backends.febio.generators import KNOWLEDGE
+
+        txt = KNOWLEDGE["_general"]["deck_authoring"][
+            "verified_working_baseline"]
+        m = re.search(r"(<\?xml[\s\S]*?</febio_spec>)", txt)
+        self.assertIsNotNone(
+            m, "verified_working_baseline no longer contains a complete "
+               "<?xml ...</febio_spec> deck. It must hold one that can "
+               "be copied out and run without edits.")
+        deck = m.group(1)
+        self.assertNotIn(
+            "...", deck,
+            "the baseline deck contains an elision. A reader cannot "
+            "run it, and this entry exists precisely to be run.")
+
+        with tempfile.TemporaryDirectory() as td:
+            feb = Path(td) / "baseline.feb"
+            feb.write_text(deck)
+            p = subprocess.run(
+                [str(self.binary), "-i", str(feb), "-nosplash"],
+                capture_output=True, text=True, timeout=300, cwd=td)
+            blob = (p.stdout or "") + (p.stderr or "")
+            log = Path(td) / "baseline.log"
+            if log.is_file():
+                blob += log.read_text(errors="replace")
+            pos = Path(td) / "pos.csv"
+            positions = pos.read_text() if pos.is_file() else ""
+
+        self.assertEqual(p.returncode, 0, f"baseline deck failed:\n{blob}")
+        self.assertIn("N O R M A L   T E R M I N A T I O N", blob)
+        m = re.search(r"Number of time steps completed\s*\.*\s*:\s*(\d+)",
+                      blob)
+        self.assertIsNotNone(m)
+        self.assertGreaterEqual(
+            int(m.group(1)), 1,
+            "baseline deck completed 0 time steps — it parsed but "
+            "solved nothing")
+        # Judge on physics, not on the banner: the prescribed face has
+        # to have actually moved.
+        self.assertTrue(positions,
+                        "baseline deck wrote no pos.csv, so the <Output> "
+                        "block in the documented deck is wrong")
+        zs = [float(r.split(",")[3])
+              for r in positions.split("*Step")[-1].splitlines()
+              if len(r.split(",")) == 4 and r.split(",")[0].strip().isdigit()]
+        self.assertTrue(zs, "could not parse node positions out of pos.csv")
+        self.assertGreater(
+            max(zs), 1.0 + 1e-6,
+            "the baseline deck prescribes a 10% stretch along z, so the "
+            "top face must end above z = 1. Nothing moved.")
+
+    def test_backend_reports_available_and_versioned(self) -> None:
+        """check_availability() must find the same binary this
+        test found, so the catalog and the tests agree on which
+        FEBio the knowledge describes."""
+        from core.registry import get_backend, load_all_backends
+        load_all_backends()
+        be = get_backend("febio")
+        self.assertIsNotNone(be)
+        status, msg = be.check_availability()
+        self.assertEqual(
+            str(getattr(status, "name", status)), "AVAILABLE",
+            f"febio backend reports {status}: {msg}")
+        self.assertIn(str(self.binary), msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fenics_tier2_claim_coverage.py
+++ b/tests/test_fenics_tier2_claim_coverage.py
@@ -1,0 +1,243 @@
+"""How much of the FEniCSx pitfall catalog has an executed fixture.
+
+Every entry of every ``pitfalls`` list in
+``backends.fenics.generators.*.KNOWLEDGE`` that carries a ``Signal:`` clause is
+a falsifiable claim. A claim with no fixture is a claim the project cannot
+defend, so this file measures the fraction that has one and refuses to let it
+fall.
+
+Measuring it needs a MAP rather than a directory count, because the two do not
+agree in either direction. One fixture can legitimately verify several claims,
+and — the direction that actually bit this backend — a fixture can sit in the
+directory while pointing at the WRONG claim. Five of the fenics fixtures did:
+``xdmf_degree_mismatch`` executed the XDMF degree-mismatch claim while keyed to
+the near-incompressible locking claim, so a real claim looked defended and the
+evidence was about something else entirely. Pitfall indices are POSITIONAL, so
+inserting an entry earlier in a list silently re-points every fixture after it,
+and the fixture keeps passing, because passing only means "the software printed
+what I expected".
+
+A fixture therefore declares what it covers::
+
+    "covers": ["poisson::3", "poisson::4"]
+
+Fixtures with no ``covers`` key fall back to their own
+``physics``/``pitfall_index`` pair, which is how the older ones are counted. An
+index past the end of a pitfall list is a SYNTHETIC key — the MMS convergence
+gates and the catalog-shape checks use one — and counts for nothing here, which
+is the point: a check that is not evidence for a stated claim must not be able
+to inflate the number.
+
+What this file does NOT do: judge whether a fixture is any good. That is the
+runner's job (``scripts/run_tier2_fixtures.py`` executes them) and the mutation
+driver's (``.t2check.py`` re-runs each with ``T2_MUTATE=1`` and requires an
+expectation to be lost). This file only answers "is there one at all, and does
+it point at the claim it tests".
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+BACKEND = "fenics"
+_FIXTURES = _REPO / "scripts" / "tier2_fixtures" / BACKEND
+
+# Raise this ONLY upward, and only with the fixtures that earned it in the same
+# commit. The project owner's target is 80 %; the constant tracks what is
+# actually MEASURED so every commit is green and the number here is never an
+# aspiration.
+#   2026-08-06  0.06 -> 0.69  (session fixtures, minus five mis-keyed ones
+#                              whose claims went back to uncovered)
+#   2026-08-06  0.69 -> 0.86  (31 more fixtures; 169 of 196 — past the target)
+MIN_COVERAGE_FRACTION = 0.86
+
+# Counted on 2026-08-06. Coverage is a fraction, so shrinking the denominator
+# is a way to "improve" it without writing anything.
+# Claim-bearing fixtures that predate the T2_MUTATE convention and would
+# therefore pass with the pathology absent. Measured 2026-08-06; may only
+# go DOWN.
+MUTATION_CONTROL_DEBT = 6
+
+CLAIM_INVENTORY_FLOOR = 196
+
+
+def _claim_inventory() -> dict[str, str]:
+    """Every falsifiable fenics claim, keyed the way ``covers`` names it.
+
+    Harvested through the backend API, which is the same path the agent uses to
+    serve the knowledge — so the denominator is what a user actually receives,
+    not what a grep of the source happens to find. (Those two differ here: an
+    AST sweep of the generator files counts 202, because some pitfall lists are
+    not reachable from any supported_physics() entry.)
+    """
+    from core.registry import get_backend, load_all_backends       # noqa: E402
+
+    try:
+        load_all_backends()
+    except Exception:                                     # pragma: no cover
+        pass
+    backend = get_backend("fenics")
+    if backend is None:                                   # pragma: no cover
+        raise unittest.SkipTest("fenics backend not registered")
+
+    claims: dict[str, str] = {}
+    for physics in backend.supported_physics():
+        try:
+            knowledge = backend.get_knowledge(physics.name)
+        except Exception:                                 # pragma: no cover
+            continue
+        if not isinstance(knowledge, dict):
+            continue
+        for i, text in enumerate(knowledge.get("pitfalls", []) or []):
+            if isinstance(text, str) and "Signal:" in text:
+                claims[f"{physics.name}::{i}"] = text
+    return claims
+
+
+def _tracked_fixture_names() -> set[str]:
+    """Fixture directories git tracks.
+
+Only fixtures git TRACKS are counted. A fixture sitting untracked in the
+working tree has not been committed, which on this project means it has not
+been run through the mutation driver here — it is not evidence yet. Counting it
+would let half-written work inflate the number, and a fixture caught mid-write
+would turn this test red for reasons that have nothing to do with coverage.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(_REPO), "ls-files",
+             f"scripts/tier2_fixtures/{BACKEND}"],
+            capture_output=True, text=True, timeout=60).stdout.split()
+    except (OSError, subprocess.SubprocessError):        # pragma: no cover
+        return set()
+    names = set()
+    for path in out:
+        parts = path.split("/")
+        if len(parts) > 3:
+            names.add(parts[3])
+    return names
+
+
+def _fixture_claims(inventory: dict[str, str]):
+    """(claim -> fixtures naming it, fixtures whose key names no claim)."""
+    covered: dict[str, list[str]] = {}
+    synthetic: list[str] = []
+    tracked = _tracked_fixture_names()
+    for d in sorted(p.parent for p in _FIXTURES.glob("*/fixture.json")):
+        if tracked and d.name not in tracked:
+            continue
+        meta = json.loads((d / "fixture.json").read_text())
+        declared = meta.get("covers")
+        if declared is None:
+            key = f"{meta.get('physics')}::{meta.get('pitfall_index')}"
+            declared = [key] if key in inventory else []
+            if not declared:
+                synthetic.append(f"{d.name} ({key})")
+        elif not declared:
+            key = f"{meta.get('physics')}::{meta.get('pitfall_index')}"
+            synthetic.append(f"{d.name} ({key}, covers: [])")
+        for claim in declared:
+            covered.setdefault(str(claim), []).append(d.name)
+    return covered, synthetic
+
+
+class TestFenicsTier2ClaimCoverage(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inventory = _claim_inventory()
+        cls.covered, cls.synthetic = _fixture_claims(cls.inventory)
+
+    def test_every_covers_entry_names_a_real_claim(self) -> None:
+        """A `covers` list is a coverage CLAIM; it has to be checkable."""
+        bogus = {c: f for c, f in self.covered.items()
+                 if c not in self.inventory}
+        self.assertEqual(
+            bogus, {},
+            f"these fixtures claim to cover fenics pitfalls that do not "
+            f"exist: {bogus}. Pitfall indices are POSITIONAL — inserting an "
+            f"entry earlier in a list re-points every fixture after it — so a "
+            f"stale index here means the coverage number is fiction. Re-read "
+            f"the list in src/backends/fenics/generators/ and fix the index.")
+
+    def test_no_claim_is_counted_twice(self) -> None:
+        dupes = {c: f for c, f in self.covered.items() if len(f) > 1}
+        self.assertEqual(
+            dupes, {},
+            f"these claims are named by more than one fixture: {dupes}. "
+            f"Double-counting inflates the coverage fraction; pick one owner "
+            f"per claim and make the other synthetic or delete it.")
+
+    def test_coverage_meets_the_floor(self) -> None:
+        n_total = len(self.inventory)
+        n_covered = len([c for c in self.covered if c in self.inventory])
+        fraction = n_covered / n_total if n_total else 0.0
+        uncovered = sorted(set(self.inventory) - set(self.covered))
+        self.assertGreaterEqual(
+            fraction, MIN_COVERAGE_FRACTION,
+            f"fenics tier-2 claim coverage is {n_covered}/{n_total} = "
+            f"{fraction:.1%}, below the {MIN_COVERAGE_FRACTION:.0%} floor. "
+            f"Still uncovered:\n  " + "\n  ".join(uncovered))
+
+    def test_the_inventory_itself_did_not_shrink(self) -> None:
+        self.assertGreaterEqual(
+            len(self.inventory), CLAIM_INVENTORY_FLOOR,
+            f"the fenics claim inventory dropped to {len(self.inventory)} "
+            f"from the {CLAIM_INVENTORY_FLOOR} counted on 2026-08-06. If "
+            f"claims were retired because execution falsified them, lower "
+            f"this floor in the same commit and say which ones; do not let "
+            f"the coverage fraction rise by subtraction.")
+
+    def test_mutation_control_debt_does_not_grow(self) -> None:
+        """A fixture that counts toward coverage should FAIL when the pathology
+        is removed. The ones below predate that convention: they pass, but they
+        would pass with the pitfall absent too, so the claim they defend is
+        defended weakly. This test does not demand they be fixed today — it
+        pins the count so the debt cannot quietly grow while the coverage
+        fraction rises. Lower the number as controls are added.
+
+        The mutation control itself is `T2_MUTATE=1` in the fixture's source
+        (or in the shared translation unit its cmd.sh names), which runs the
+        CORRECT variant; the driver then requires an expectation to be lost.
+        """
+        import re
+        tracked = _tracked_fixture_names()
+        without = []
+        for d in sorted(p.parent for p in _FIXTURES.glob("*/fixture.json")):
+            if tracked and d.name not in tracked:
+                continue
+            meta = json.loads((d / "fixture.json").read_text())
+            declared = meta.get("covers")
+            if declared == []:
+                continue                      # synthetic: defends no claim
+            key = f"{meta.get('physics')}::{meta.get('pitfall_index')}"
+            if declared is None and key not in self.inventory:
+                continue                      # key names no claim: counts for 0
+            text = ""
+            for name in ("source.py", "cmd.sh"):
+                p = d / name
+                if p.exists():
+                    text += p.read_text()
+            shared = ""
+            m = re.search(r"run\.sh\"?\s+(\w+)", text)
+            if m:
+                cc = _FIXTURES / "_shared" / f"{m.group(1)}.cc"
+                if cc.exists():
+                    shared = cc.read_text()
+            if "T2_MUTATE" not in text + shared:
+                without.append(d.name)
+        self.assertLessEqual(
+            len(without), MUTATION_CONTROL_DEBT,
+            f"{len(without)} claim-bearing fixtures have no mutation control, "
+            f"above the recorded debt of {MUTATION_CONTROL_DEBT}. Every NEW "
+            f"fixture must carry one.\n  " + "\n  ".join(without))
+
+
+if __name__ == "__main__":                                # pragma: no cover
+    unittest.main()

--- a/tests/test_fixture_keys_point_at_real_claims.py
+++ b/tests/test_fixture_keys_point_at_real_claims.py
@@ -1,0 +1,271 @@
+"""A fixture's key must name the claim it actually exercises.
+
+WHY, and it is not hypothetical
+-------------------------------
+The runner key is the ONLY link between a piece of evidence and the claim it
+defends. Nothing else connects them, so when the key is wrong the failure is
+completely silent: the claim looks covered, the evidence points elsewhere, and
+every test still passes.
+
+Both halves of that have happened here, in the same week:
+
+  * FEBio — three of its six pre-existing fixtures were keyed to the wrong
+    claim. `missing_control_silent_zero_result` executed the dropped-<Control>
+    claim while pointing at the Poisson-ratio claim, and the catalog
+    self-consistency gate sat on index 0, which made the real
+    `linear_elasticity#0` claim appear covered by something that never touched
+    it. Two claims defended by nothing, two others credited twice.
+  * Kratos — moving 53 entries out of the pitfall lists SHIFTED INDICES, which
+    would have repointed 18 fixtures at the wrong claims. They were renumbered
+    atomically, and a second pass then caught that the prose in each fixture's
+    `_comment` still quoted the OLD index — the human-readable evidence record
+    disagreeing with the machine-readable field, which is the half that
+    misleads a person reading the file.
+
+So this gate answers one question per fixture: does the claim your key names
+exist? It cannot tell whether the fixture exercises the RIGHT claim — only a
+reader comparing the fixture to the entry can do that — but it catches every
+key that points at nothing, which is the failure that made a claim look
+defended when it was not.
+
+It also protects the coverage metric. `covers` lists let one fixture attest to
+several claims, which is correct (DUNE JIT-compiles per form, so splitting
+claims that share a module buys build time and no evidence). But an unchecked
+`covers` list is a coverage number anyone can raise by inventing keys, and the
+freeze criterion reads that number.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+BACKENDS_DIR = REPO / "src" / "backends"
+
+# A key may legitimately point past the end of a pitfall list: the MMS
+# convergence harnesses use a high sentinel because they verify a whole family
+# rather than one entry. Counting those as coverage overstated two backends by
+# 9 fixtures, so they are recognised here and excluded from the claim count
+# rather than being reported as broken keys.
+SENTINEL_FLOOR = 90
+
+
+def _claim_counts(backend: str) -> dict[str, int]:
+    """How many pitfall entries each physics of this backend declares.
+
+    THE REGISTRY IS THE AUTHORITY, and getting this wrong made the first
+    version of this gate accuse 13 good deal.II fixtures. A static AST walk saw
+    10 deal.II physics with pitfall lists and missed `dg_transport`, `poisson`
+    and `helmholtz` — which have 7, 7 and 6 pitfalls respectively when asked
+    through `get_knowledge()`. Backends assemble their knowledge dicts by
+    merging, aliasing and importing across modules, and no static reader
+    follows that; 4C and FEniCSx yielded zero physics at all.
+
+    Accusing a correct fixture of pointing at a non-existent claim is the worst
+    possible failure for this gate: it sends someone renumbering fixtures that
+    were already right. So ask the backend, and fall back to the AST only when
+    the backend cannot be loaded here — in which case a MISS is not reported as
+    drift, because the reader is the thing that is blind.
+    """
+    counts: dict[str, int] = {}
+    try:
+        from core.registry import get_backend, load_all_backends
+        load_all_backends()
+        be = get_backend(backend)
+    except Exception:
+        be = None
+
+    if be is not None:
+        try:
+            for cap in be.supported_physics():
+                k = be.get_knowledge(cap.name)
+                if isinstance(k, dict):
+                    pit = k.get("pitfalls")
+                    if isinstance(pit, (list, tuple)):
+                        counts[cap.name.lstrip("_")] = len(pit)
+        except Exception:
+            counts = {}
+    if counts:
+        return counts
+
+    # Fallback only. Marked so the caller can refuse to report drift from it.
+    be_dir = BACKENDS_DIR / backend
+    if not be_dir.is_dir():
+        return counts
+    for py in be_dir.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(errors="ignore"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            # KNOWLEDGE = {"<physics>": {..., "pitfalls": [...]}}
+            if not isinstance(node, ast.Dict):
+                continue
+            for key, value in zip(node.keys, node.values):
+                if not (isinstance(key, ast.Constant)
+                        and isinstance(key.value, str)
+                        and isinstance(value, ast.Dict)):
+                    continue
+                for k2, v2 in zip(value.keys, value.values):
+                    if (isinstance(k2, ast.Constant) and k2.value == "pitfalls"
+                            and isinstance(v2, (ast.List, ast.Tuple))):
+                        n = len(v2.elts)
+                        name = key.value.lstrip("_")
+                        counts[name] = max(counts.get(name, 0), n)
+    return counts
+
+
+def _fixture_keys(backend: str) -> list[tuple[str, str, list[str]]]:
+    """(fixture name, source of key, keys) for every fixture of a backend."""
+    out = []
+    fx = FIXTURES / backend
+    if not fx.is_dir():
+        return out
+    for d in sorted(fx.iterdir()):
+        manifest = d / "fixture.json"
+        if not manifest.is_file():
+            continue
+        try:
+            spec = json.loads(manifest.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        covers = spec.get("covers")
+        if isinstance(covers, list) and covers:
+            out.append((d.name, "covers", [str(c) for c in covers]))
+        elif spec.get("physics") is not None and spec.get("pitfall_index") is not None:
+            out.append((d.name, "physics/pitfall_index",
+                        [f"{spec['physics']}:{spec['pitfall_index']}"]))
+    return out
+
+
+BACKENDS = sorted(p.name for p in BACKENDS_DIR.iterdir()
+                  if p.is_dir() and not p.name.startswith("_")) \
+    if BACKENDS_DIR.is_dir() else []
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_every_fixture_key_names_an_existing_claim(backend):
+    """A key pointing at nothing credits coverage to no claim at all."""
+    counts = _claim_counts(backend)
+    keys = _fixture_keys(backend)
+    if not keys:
+        pytest.skip(f"{backend} has no fixtures with claim keys")
+    if not counts:
+        pytest.skip(f"{backend} declares no pitfall lists this can read")
+
+    broken = []
+    for name, source, ks in keys:
+        for k in ks:
+            m = re.match(r"^(.+?):(\d+)$", k)
+            if not m:
+                # Non-numeric keys (e.g. "_general:assemble.Signal") address
+                # named fields rather than list indices; not checkable here.
+                continue
+            physics, idx = m.group(1).lstrip("_"), int(m.group(2))
+            if idx >= SENTINEL_FLOOR:
+                continue  # documented family-level sentinel
+            if physics not in counts:
+                # NOT reported as drift. A physics this reader cannot see is
+                # far more likely to be a limit of the reader than a broken
+                # key — that mistake accused 13 correct deal.II fixtures whose
+                # physics the registry resolves perfectly well. Only an index
+                # PAST A LIST WE CAN COUNT is evidence of drift.
+                continue
+            elif idx >= counts[physics]:
+                broken.append(
+                    f"{name} ({source}) -> {k}: {physics} declares only "
+                    f"{counts[physics]} pitfalls (valid 0..{counts[physics]-1})")
+
+    assert not broken, (
+        f"{backend}: {len(broken)} fixture keys name a claim that does not "
+        f"exist, so those fixtures defend nothing and the claims they were "
+        f"meant to cover are uncovered:\n  " + "\n  ".join(broken[:20])
+        + "\n\nThis is what index drift looks like. Moving or removing a "
+          "pitfall renumbers the ones after it; renumber the fixtures in the "
+          "same commit, and check the prose in each fixture's _comment too — "
+          "Kratos found the machine-readable field fixed and the comment still "
+          "quoting the old index.")
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_no_two_fixtures_claim_the_same_key(backend):
+    """Double-counting one claim inflates coverage and hides an uncovered one.
+
+    Exactly how FEBio's count was wrong: the self-consistency gate sat on
+    index 0 alongside the real fixture for it, so one claim was credited twice
+    while another had nothing.
+    """
+    keys = _fixture_keys(backend)
+    if not keys:
+        pytest.skip(f"{backend} has no fixtures with claim keys")
+
+    owners: dict[str, list[str]] = {}
+    for name, _src, ks in keys:
+        for k in ks:
+            owners.setdefault(k, []).append(name)
+    clashes = {k: v for k, v in owners.items() if len(v) > 1}
+
+    assert not clashes, (
+        f"{backend}: {len(clashes)} claims are keyed by more than one fixture, "
+        f"which credits them twice and leaves others uncounted:\n  "
+        + "\n  ".join(f"{k}: {', '.join(v)}" for k, v in
+                      list(clashes.items())[:12]))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_every_fixture_records_what_it_did(backend):
+    """The evidence record must not be a placeholder.
+
+    `_comment` is where a fixture says which claim it defends, what was run, and
+    what the software printed. It is the only part a person reads when deciding
+    whether the fixture actually exercises the claim its key names — and that
+    judgement cannot be automated, because a key can be syntactically valid and
+    still point at the wrong claim. Kratos hit exactly that: when moving 53
+    entries shifted 18 fixtures' indices, the machine-readable field was fixed
+    while the prose still quoted the OLD claim. The prose is the half that
+    misleads a human.
+
+    So a fixture whose comment reads PLACEHOLDER is a fixture nobody can audit
+    by reading. Measured when this was added: 63 FEniCSx and 25 deal.II
+    fixtures, the two backends whose authoring runs were interrupted most often;
+    every other backend was already at zero, which is why this is worth holding
+    rather than waiving.
+    """
+    fx = FIXTURES / backend
+    if not fx.is_dir():
+        pytest.skip(f"{backend} has no fixtures")
+
+    empty = []
+    for d in sorted(fx.iterdir()):
+        manifest = d / "fixture.json"
+        if not manifest.is_file():
+            continue
+        try:
+            spec = json.loads(manifest.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        comment = str(spec.get("_comment", "")).strip()
+        if not comment:
+            empty.append(f"{d.name}: no _comment")
+        elif comment.upper().startswith("PLACEHOLDER"):
+            empty.append(f"{d.name}: _comment is PLACEHOLDER")
+        elif len(comment) < 40:
+            empty.append(f"{d.name}: _comment too short to be a record "
+                         f"({len(comment)} chars)")
+
+    assert not empty, (
+        f"{backend}: {len(empty)} fixtures do not record what they did, so "
+        f"nobody can tell by reading whether they defend the claim their key "
+        f"names:\n  " + "\n  ".join(empty[:20])
+        + (f"\n  ... and {len(empty) - 20} more" if len(empty) > 20 else "")
+        + "\n\nState the claim in one line, what was run, and what the software "
+          "printed. Measured numbers belong here — the fixture is exactly "
+          "where they are allowed, unlike the knowledge text.")

--- a/tests/test_fixtures_cannot_pass_vacuously.py
+++ b/tests/test_fixtures_cannot_pass_vacuously.py
@@ -1,0 +1,177 @@
+"""A fixture must not pass on a machine that cannot run it.
+
+OASiS is meant to be cloned, run and picked apart by other people. That makes
+"green on this workstation" worth very little on its own: what matters is
+whether a stranger's run tells them the truth.
+
+The defect this guards against was found twice. A DUNE fixture exited 0 with the
+catalog tree absent. Five FEBio fixtures do this:
+
+    fixture.json:  expect_in_output = ["degenerate_hex8="]
+                   forbid_in_output = ["Traceback", "FAIL:"]
+    source.py:     print("degenerate_hex8=skipped_no_binary")
+
+With no FEBio installed, the fixture prints its key, the expectation matches,
+neither forbidden string appears, and it PASSES — having verified nothing. The
+same five raised the tier-2 floor from 108 to 113, so the floor now certifies
+five phantom passes on any host without the binary.
+
+Skipping when a backend is missing is correct and necessary. Reporting a PASS
+for it is not. A fixture must either fail loudly or be recorded as skipped, and
+the difference has to be visible in the run's own output — otherwise absence of
+a backend is indistinguishable from presence of a working one, which is the same
+class of silent-wrong the fixtures exist to catch.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+
+# Markers a fixture prints when it declines to do the real work.
+_ABSENT_MARKER = re.compile(
+    r"=\s*(skipped\w*|no_binary|not_available|unavailable|missing_\w+)\b",
+    re.IGNORECASE)
+
+# The same defect wearing different clothes. The marker above only matches a
+# `key=value` shape, so a fixture that announces its skip as a bare sentence
+# walked straight through:
+#
+#     print("SKIP: no SPARTA binary found — generator execution not attempted")
+#
+# With no binary that fixture exits 0, its expectations (which assert unrelated
+# payload-hygiene facts) still match, `SKIP:` is in nobody's forbid list, and a
+# fixture whose NAME is "generators execute on installed build" is recorded as a
+# PASS having generated and run nothing. Found 2026-08-07 while auditing the
+# SPARTA fixtures; zero fixtures in this tree print such a line, so this pattern
+# costs nothing here and closes the shape before it arrives.
+_BARE_SKIP = re.compile(
+    r"""["'](\s*(?:SKIP|SKIPPED)\s*[:\-])""", re.IGNORECASE)
+
+
+def _fixture_dirs():
+    if not FIXTURES.exists():
+        return []
+    return sorted(p.parent for p in FIXTURES.glob("*/*/fixture.json"))
+
+
+def _sources(d: pathlib.Path) -> str:
+    text = ""
+    for name in ("source.py", "cmd.sh", "run.sh"):
+        p = d / name
+        if p.exists():
+            text += p.read_text(errors="ignore") + "\n"
+    return text
+
+
+def _vacuous(d: pathlib.Path) -> list[str]:
+    """Lines where this fixture prints an EXPECTED key with an absent-marker
+    value, and nothing in forbid_in_output catches it."""
+    meta = json.loads((d / "fixture.json").read_text())
+    expect = [str(s) for s in meta.get("expect_in_output", [])]
+    forbid = [str(s).lower() for s in meta.get("forbid_in_output", [])]
+    if not expect:
+        return []
+    # Does any forbidden string catch a skip? Then the fixture is guarded.
+    # `fixture_abort` is the other accepted guard: a fixture that aborts with
+    # that marker and forbids it cannot report a pass on an absent backend.
+    if any(re.search(r"skip|no_binary|unavailable|not_available|fixture_abort", f)
+           for f in forbid):
+        return []
+    bad = []
+    for line in _sources(d).splitlines():
+        # A bare "SKIP: ..." announcement is unconditional evidence: unlike the
+        # key=value form there is no expectation to cross-check it against,
+        # because the fixture is declining to run while its expectations are
+        # satisfied by something else it printed.
+        if _BARE_SKIP.search(line):
+            bad.append(line.strip()[:120])
+            continue
+        m = _ABSENT_MARKER.search(line)
+        if not m:
+            continue
+        # The printed key must be one the expectation would match.
+        prefix = line[:m.start() + 1]
+        if any(e.rstrip() and e.rstrip() in prefix + "=" or
+               (e.endswith("=") and e[:-1] in prefix)
+               for e in expect):
+            bad.append(line.strip()[:120])
+    return bad
+
+
+@pytest.mark.parametrize("d", _fixture_dirs(),
+                         ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_fixture_cannot_report_a_pass_without_running(d):
+    bad = _vacuous(d)
+    assert not bad, (
+        f"{d.parent.name}/{d.name} satisfies its own expectation while "
+        f"declining to run: it prints an expected key with a skip marker, and "
+        f"nothing in forbid_in_output catches that. On a machine without this "
+        f"backend the fixture PASSES having verified nothing.\n  "
+        + "\n  ".join(bad)
+        + "\n\nFix by one of: add the skip marker to forbid_in_output; expect "
+          "a substantive value rather than a bare key; or make the absent path "
+          "exit non-zero so the runner records a failure instead of a pass.")
+
+
+def test_the_guard_itself_detects_the_known_case():
+    """Proof the predicate discriminates, using the shape of the real defect
+    rather than trusting that a green run means anything."""
+    import tempfile
+
+    d = pathlib.Path(tempfile.mkdtemp()) / "backend" / "fx"
+    d.mkdir(parents=True)
+    (d / "fixture.json").write_text(json.dumps({
+        "expect_in_output": ["degenerate_hex8="],
+        "forbid_in_output": ["Traceback", "FAIL:"],
+    }))
+    (d / "source.py").write_text('print("degenerate_hex8=skipped_no_binary")\n')
+    assert _vacuous(d), "the guard fails to catch the defect it was written for"
+
+    # …and does not fire once the skip is forbidden.
+    (d / "fixture.json").write_text(json.dumps({
+        "expect_in_output": ["degenerate_hex8="],
+        "forbid_in_output": ["Traceback", "FAIL:", "skipped_no_binary"],
+    }))
+    assert not _vacuous(d), "the guard fires on a properly guarded fixture"
+
+
+def test_the_guard_detects_a_bare_skip_announcement():
+    """The same defect in prose form rather than key=value.
+
+    A fixture that prints `SKIP: no <backend> binary found` while its
+    expectations are satisfied by unrelated lines exits 0 and is recorded as a
+    pass on a host where nothing ran. Proven against the real shape rather than
+    trusting that a green run means anything.
+    """
+    import tempfile
+
+    d = pathlib.Path(tempfile.mkdtemp()) / "backend" / "fx"
+    d.mkdir(parents=True)
+    (d / "fixture.json").write_text(json.dumps({
+        "expect_in_output": ["knowledge_has_no_host_paths=True"],
+        "forbid_in_output": ["Traceback", "FAIL:", "UNEXPECTED:"],
+    }))
+    (d / "source.py").write_text(
+        'print("knowledge_has_no_host_paths=True")\n'
+        'print("SKIP: no SPARTA binary found - execution not attempted")\n')
+    assert _vacuous(d), (
+        "the guard misses a bare SKIP: announcement — the shape that let a "
+        "fixture named for executing on the installed build pass with no "
+        "binary present")
+
+    # An abort-and-fail fixture is the correct pattern and must stay green.
+    (d / "fixture.json").write_text(json.dumps({
+        "expect_in_output": ["knowledge_has_no_host_paths=True"],
+        "forbid_in_output": ["Traceback", "FAIL:", "FIXTURE_ABORT"],
+    }))
+    (d / "source.py").write_text(
+        'print("FIXTURE_ABORT=no_binary"); raise SystemExit(1)\n')
+    assert not _vacuous(d), (
+        "the guard must not punish a fixture that aborts loudly and forbids "
+        "its own abort marker")

--- a/tests/test_fixtures_carry_a_mutation_control.py
+++ b/tests/test_fixtures_carry_a_mutation_control.py
@@ -1,0 +1,131 @@
+"""A fixture must ship the proof that it detects its own pathology.
+
+WHAT A FIXTURE IS, AND WHY THIS IS THE WHOLE GAME
+------------------------------------------------
+A fixture is two files:
+
+    fixture.json   backend, physics, pitfall_index (the claim it defends),
+                   expect_in_output (strings the runner greps stdout for),
+                   forbid_in_output (strings that must NOT appear, e.g.
+                   "Traceback"), and _comment, the evidence record
+    source.py      the executable — or cmd.sh for 4C, source.cpp + cmd.sh
+                   for deal.II, plus any data files the deck needs
+
+The runner executes the artefact and matches its stdout against those two
+lists. That is the entire mechanism. Nothing in it can tell a fixture that
+prints the right strings for the RIGHT reason from one that prints them for the
+wrong reason — a script that hardcodes its expected output passes exactly as
+well as one that measures.
+
+The mutation control is what closes that hole: remove the pathology, and the
+fixture must go red. Without it a fixture is a script that happens to pass.
+
+THE STATE THAT MOTIVATED THIS, measured across all worktrees:
+
+    fourc      354/373  95%   `_mutation` field in fixture.json
+    fenics     183/200  92%   T2_MUTATE env hook inside the source
+    dealii     104/119  87%   T2_MUTATE env hook
+    coupling    18/18  100%   `_mutation` field
+    skfem, kratos, ngsolve, febio, dune, sparta   0%   — 542 fixtures
+
+Every one of those campaigns reported its fixtures mutation-proven, and their
+reports name the specific mutation and the expectation it removed. The runs
+almost certainly happened. But the evidence lived only in session transcripts,
+so nobody could re-run it — which in this project is the same class of problem
+as an unverified knowledge claim: probably true, and unauditable.
+
+TWO CONVENTIONS, BOTH ACCEPTED
+------------------------------
+`_mutation` in fixture.json describes an edit somebody must reapply by hand.
+A `T2_MUTATE` environment hook in the source IS the edit, already written and
+already tested, so the proof re-runs with one command:
+
+    T2_MUTATE=1 python scripts/tier2_fixtures/<backend>/<name>/source.py
+
+The hook is the better of the two and was not imposed — FEniCSx and deal.II
+arrived at it independently. It matters because three separate staging defects
+silently voided mutation verdicts in a single day: a shared helper written as a
+bare `_couplinglib.py` that the harness never staged, a missing
+`_lib/preamble.sh` that made 174 fixtures report vacuous baselines, and a
+`parents[N]` path resolution that could not find the checkout from /tmp. An
+in-source hook has none of those failure modes.
+
+WHAT THIS GATE CANNOT DO, stated plainly
+----------------------------------------
+It checks that a control EXISTS, not that it discriminates. It cannot, because
+whether a mutation changes the verdict is a property of a run.
+
+And no gate catches the worst case. `stokes_lbb_and_pressure_constraints` (DUNE)
+PASSED while asserting a false statement: its inlet mask interpolated
+`[x[0], x[1], 0]` and sliced the pressure leg, returning the constant-0 third
+component, so every pressure dof tested as lying on the boundary. Coverage
+counted it. Mutation evidence would NOT have caught it either — the mutation
+changes the assertion either way, so an internally consistent, externally false
+fixture is still killed by its own mutant. Only a person re-reading the probe
+caught it. Pretending a gate could is the same error one level up.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+
+# Sources where an in-source hook can live.
+_SOURCE_SUFFIXES = (".py", ".sh", ".cpp", ".cc", ".c")
+
+BACKENDS = sorted(p.name for p in FIXTURES.iterdir() if p.is_dir()) \
+    if FIXTURES.is_dir() else []
+
+
+def _has_control(d: Path) -> bool:
+    """Either convention counts: a `_mutation` field or a T2_MUTATE hook."""
+    manifest = d / "fixture.json"
+    try:
+        spec = json.loads(manifest.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    if spec.get("_mutation") or spec.get("mutations"):
+        return True
+    for f in d.iterdir():
+        if f.is_file() and f.suffix in _SOURCE_SUFFIXES:
+            try:
+                if "T2_MUTATE" in f.read_text(errors="ignore"):
+                    return True
+            except OSError:
+                continue
+    return False
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_every_fixture_ships_its_mutation_control(backend):
+    """Without it, a fixture is a script that happens to pass."""
+    be = FIXTURES / backend
+    if not be.is_dir():
+        pytest.skip(f"{backend} has no fixtures")
+
+    fixtures = [d for d in sorted(be.iterdir())
+                if (d / "fixture.json").is_file()]
+    if not fixtures:
+        pytest.skip(f"{backend} has no fixtures in this tree")
+
+    missing = [d.name for d in fixtures if not _has_control(d)]
+
+    assert not missing, (
+        f"{backend}: {len(missing)} of {len(fixtures)} fixtures ship no "
+        f"mutation control, so nothing in the tree shows they detect the "
+        f"pathology they claim:\n  " + "\n  ".join(missing[:15])
+        + (f"\n  ... and {len(missing) - 15} more" if len(missing) > 15 else "")
+        + "\n\nAdd a T2_MUTATE branch to the source — the pathology removed "
+          "when the variable is set — so the proof re-runs with\n"
+          "    T2_MUTATE=1 python scripts/tier2_fixtures/<backend>/<name>/source.py\n"
+          "and record in `_comment` WHICH expectation disappears under it. "
+          "A `_mutation` field in fixture.json is also accepted.\n\n"
+          "If a fixture genuinely cannot be mutated, say so in `_mutation` "
+          "with the reason — DUNE's helmholtz_indefinite_no_diagnostic is the "
+          "honest example: its claim is that the solver's report is "
+          "UNINFORMATIVE, which is true at every k, so removing the pathology "
+          "would require the library to emit a diagnostic it does not have.")

--- a/tests/test_fixtures_do_not_assert_on_wall_clock.py
+++ b/tests/test_fixtures_do_not_assert_on_wall_clock.py
@@ -1,0 +1,129 @@
+"""A fixture must not pass or fail depending on how busy the machine is.
+
+WHAT HAPPENED
+-------------
+A deal.II fixture asserted `assembly_fraction_in_claimed_60_to_80_band=false`.
+On a quiet host, assembly was 32% of the loop, so the catalog's claimed band did
+not reproduce and the author correctly pinned that. Under load a later run
+landed INSIDE the band and the fixture went red — not because anything changed
+in deal.II, but because other worktrees were compiling at the time.
+
+That is a pinned measurement wearing a boolean's clothes. It looks like a
+property of the software and is actually a property of the afternoon.
+
+WHY IT MATTERS MORE THAN ORDINARY FLAKINESS
+-------------------------------------------
+This project's whole claim is that a green fixture is evidence a knowledge claim
+holds. A fixture that goes red under load teaches the opposite lesson twice
+over: first someone re-runs it and it passes, so red stops meaning "the claim
+failed"; then the next genuine failure gets re-run too. The value of the suite
+is that its verdicts are trustworthy, and one flaky verdict is worth more than
+one fixture of damage.
+
+WHAT IS AND IS NOT ALLOWED
+--------------------------
+Timing may be MEASURED and PRINTED — it is often the whole point of a
+performance pitfall, and a reader wants the number. What it may not do is decide
+the verdict. `expect_in_output` is the verdict, so a wall-clock comparison must
+not appear there.
+
+The distinction is between a property of the algorithm and a property of the
+run. "The block solver touches 4x the non-zeros" is structural and holds on any
+host. "The block solver is 1.3x slower" is not: it depends on cache, on core
+count, on what else is running. Assert the first; print the second.
+
+Measured when this was written: 16 such assertions across fenics (7), dealii
+(4), ngsolve (4) and skfem (1) — including a contact-search fixture asserting
+which of two algorithms wins at a few hundred facets, which is precisely the
+regime where the answer flips between machines.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+
+# Verdict keys whose truth is decided by elapsed time. Deliberately narrow: an
+# over-eager pattern here would flag physics claims that merely contain the word
+# "time" (second-ORDER in time, time-step size, Crank-Nicolson), and a checker
+# that cries wolf gets switched off. A first draft matched 133 expectations of
+# which 117 were exactly that kind of false positive.
+_WALL_CLOCK = re.compile(
+    r"speedup|slower|faster|wall_?clock|elapsed"
+    r"|_secs?=|_ms=|assembly_fraction|time_ratio|throughput|per_second",
+    re.IGNORECASE)
+
+# Things the pattern above would otherwise catch that are NOT about elapsed
+# time: convergence order in time, time-step choices, and a timing key merely
+# being present in a returned dict.
+#
+# `iterations_grow_faster` is the same kind of false positive, found when the
+# DUNE fixtures landed. "GMRES iterations grow faster than the problem" compares
+# an ITERATION COUNT against a DOF COUNT across a refinement — 10.4x iterations
+# for 3.7x dofs — which is exactly the structural, host-independent verdict this
+# gate's own remedy text asks authors to move to. Only the word "faster" is
+# shared with a wall-clock claim. Kept narrow to iteration counts on purpose: a
+# bare `grow.*faster` would also exempt `runtime_grows_faster_than_dofs`, which
+# IS a clock and must keep failing.
+_NOT_WALL_CLOCK = re.compile(
+    r"second[_ ]order|second_third|time[_ ]step|timestep|time_dependent"
+    r"|crank|timing'|'timing|iterations?_grow\w*_faster"
+    # A RESIDUAL drop rate per Newton iteration is a convergence property, not
+    # a clock: `continuum_drop_per_iter_faster_than_factor_2` is max(residual
+    # ratio) < 0.5, and `..._rate_is_slower_than_...` compares mean residual
+    # ratios. Both hold on any host. Anchored on the quantity's own name
+    # (drop_per_iter / _rate_is_) rather than on faster|slower, so a genuine
+    # `solve_is_slower_than` still fails.
+    r"|drop_per_iter|_rate_is_(?:slower|faster)"
+    # Two more quantities that borrow the vocabulary of speed without being
+    # clocks. `envelope_shrinks_slower_than_0p98_per_iteration` is
+    # (r_n/r_0)**(1/20) over the RESIDUAL history; `still_relaxing_faster_after
+    # _20_steps` is a ratio of ENERGY released per step between two runs.
+    # Both are properties of the iteration, identical on any host.
+    r"|envelope_shrinks_(?:slower|faster)|still_relaxing_(?:slower|faster)",
+    re.IGNORECASE)
+
+BACKENDS = sorted(p.name for p in FIXTURES.iterdir() if p.is_dir()) \
+    if FIXTURES.is_dir() else []
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_no_expectation_is_decided_by_elapsed_time(backend):
+    """Timing may be printed; it may not decide pass or fail."""
+    fx = FIXTURES / backend
+    if not fx.is_dir():
+        pytest.skip(f"{backend} has no fixtures")
+
+    offenders = []
+    for d in sorted(fx.iterdir()):
+        manifest = d / "fixture.json"
+        if not manifest.is_file():
+            continue
+        try:
+            spec = json.loads(manifest.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        for exp in (spec.get("expect_in_output") or []):
+            text = str(exp)
+            if _WALL_CLOCK.search(text) and not _NOT_WALL_CLOCK.search(text):
+                offenders.append(f"{d.name}: {text[:80]}")
+
+    assert not offenders, (
+        f"{backend}: {len(offenders)} expectations decide the verdict from "
+        f"elapsed time, so the fixture's colour depends on what else the "
+        f"machine is doing:\n  " + "\n  ".join(offenders[:15])
+        + (f"\n  ... and {len(offenders) - 15} more"
+           if len(offenders) > 15 else "")
+        + "\n\nKeep measuring and printing the timing — a performance pitfall "
+          "usually needs it, and a reader wants the number. Move the VERDICT "
+          "onto something structural that holds on any host: operation counts, "
+          "non-zero counts, iteration counts, memory footprint, or the "
+          "asymptotic trend across refinements rather than a ratio at one "
+          "size. A fixture that goes red under load teaches everyone that red "
+          "means 're-run it', which costs more than the fixture is worth.")

--- a/tests/test_fourc_audit_corrections_2026_08_03.py
+++ b/tests/test_fourc_audit_corrections_2026_08_03.py
@@ -1,0 +1,223 @@
+"""Regression: adversarial re-audit of the 2026-08-03 4C execution sweep.
+
+Every correction pinned here was produced by RE-RUNNING the deployed
+binary ``/home/alexander/4C/build/4C`` (4C 2026.2.0-dev, git 89519cf)
+against the claim as written, and finding that the claim as written did
+not survive.  Each test therefore guards a statement that was measured
+to be FALSE once, so that it cannot quietly come back.
+
+The five corrections, and the command that falsified the original text:
+
+1. ``capture_note`` / input_format "block-buffered" pitfall claimed that
+   redirecting 4C to a FILE preserves the RESULT DESCRIPTION failure
+   diagnostic.  It does not — a regular file is fully buffered too::
+
+       $ for i in 1 2 3; do 4C bad.4C.yaml out > f.log 2>&1; \\
+             echo "rc=$? isWRONG=$(grep -c 'is WRONG' f.log)"; done
+       rc=1 isWRONG=0
+       rc=1 isWRONG=0
+       rc=1 isWRONG=0
+       $ stdbuf -oL -eL 4C bad.4C.yaml out > f.log 2>&1
+       rc=1 isWRONG=1
+
+2. The runtime-VTK pitfall claimed that the parent section plus
+   ``IO/RUNTIME VTK OUTPUT/STRUCTURE`` with ``OUTPUT_STRUCTURE: true``
+   yields 3 ``.vtu`` files.  With no field flag set it exits 1::
+
+       OUTPUT_STRUCTURE only        -> rc=1, "No data was written or
+                                       writer was already in final
+                                       phase." (io_vtk_writer_base)
+       OUTPUT_STRUCTURE+DISPLACEMENT-> rc=0, 3 .vtu / 3 .pvtu / 1 .pvd
+       DISPLACEMENT only            -> rc=0, 0 files
+
+   The branch's own Tier-2 fixture already used ``DISPLACEMENT: true``;
+   only the prose omitted it.
+
+3. The WALL ``EAS`` pitfall claimed EAS changes the answer *silently*.
+   ``EAS full`` with ``KINEM linear`` is a hard error::
+
+       ERROR: No EAS for geometrically linear WALL element   (rc=1)
+
+4. ``result_description`` understated two key lists, both re-read from
+   ``4C --parameters``: an ``ELEMENT`` selector is accepted by four
+   groups (ARTNET, FLUID, POROFLUIDMULTIPHASE, RED_AIRWAY), and
+   ``SPECIAL`` by nine, not three.
+
+5. ``4C --parameters`` emits 2 926 432 bytes on stdout; the recorded
+   2 926 462 was measured with ``2>&1`` and included 30 bytes of local
+   X11 warning.
+
+Plus one newly executed finding: ``NUE: -1.0`` passes the
+``in_range[-1,0.5)`` validator (closed at the low end) and is then
+killed by SIGFPE with no material diagnostic.
+
+GEN-ONLY: no 4C binary needed, so this runs in CI.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+for p in (str(ROOT), str(ROOT / "src")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _knowledge():
+    """Load the catalogue dict directly — result_description is not a
+    registered physics name, so the backend accessor cannot reach it."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "_fourc_knowledge_audit", ROOT / "data" / "fourc_knowledge.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.FOURC_KNOWLEDGE
+
+
+class TestCaptureAdviceIsNotWrong(unittest.TestCase):
+    """A file redirect does NOT preserve the result-test diagnostic."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.k = _knowledge()
+
+    def test_capture_note_does_not_recommend_a_plain_file_redirect(self):
+        note = self.k["result_description"]["capture_note"]
+        self.assertIn("stdbuf", note)
+        # The falsified phrasing: "(stdbuf -oL -eL) or redirect to a file".
+        self.assertNotIn("or redirect to a file", note)
+        # It must positively say that a file does not help.
+        self.assertRegex(note.lower(), r"(does not rescue|does not help|not )")
+        self.assertIn("buffered", note.lower())
+
+    def test_buffering_pitfall_does_not_offer_a_file_as_an_alternative(self):
+        pits = [p for p in self.k["input_format"]["pitfalls"]
+                if "block-buffered" in p]
+        self.assertEqual(len(pits), 1, "the buffering pitfall went missing")
+        p = pits[0]
+        self.assertNotIn("or to a file", p)
+        self.assertIn("stdbuf -oL -eL", p)
+        self.assertIn("fully buffered", p)
+
+
+class TestRuntimeVtkNeedsAFieldFlag(unittest.TestCase):
+    """OUTPUT_STRUCTURE alone crashes the VTK writer; it is not enough."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.k = _knowledge()
+
+    def test_vtk_pitfall_names_a_field_flag(self):
+        pits = [p for p in self.k["input_format"]["pitfalls"]
+                if "RUNTIME VTK OUTPUT" in p and "INTERVAL_STEPS" in p]
+        self.assertTrue(pits, "the runtime-VTK pitfall went missing")
+        p = pits[0]
+        self.assertIn("DISPLACEMENT", p)
+        # and it must carry the observable signal for the loud branch
+        self.assertIn("No data was written", p)
+        self.assertIn("io_vtk_writer_base", p)
+
+    def test_vtk_pitfall_no_longer_claims_output_structure_alone_works(self):
+        pits = [p for p in self.k["input_format"]["pitfalls"]
+                if "RUNTIME VTK OUTPUT" in p and "INTERVAL_STEPS" in p]
+        p = pits[0]
+        # The falsified sentence said either half alone produces ZERO
+        # files and exit 0.  The sub-section-with-no-field case is exit 1.
+        self.assertIn("exit 1", p)
+
+
+class TestEasIsNotSilentUnderLinearKinematics(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.k = _knowledge()
+
+    def test_eas_pitfall_records_the_hard_error(self):
+        pits = [p for p in self.k["structural_mechanics"]["pitfalls"]
+                if "On the WALL element EAS and" in p]
+        self.assertTrue(pits, "the WALL EAS pitfall went missing")
+        p = pits[0]
+        self.assertIn("No EAS for geometrically linear WALL element", p)
+        self.assertIn("KINEM nonlinear", p)
+        # The falsified claim was that NEITHER keyword emits a warning.
+        self.assertNotIn("neither emits a warning", p)
+
+    def test_eas_numbers_are_same_node_same_kinematics(self):
+        pits = [p for p in self.k["structural_mechanics"]["pitfalls"]
+                if "On the WALL element EAS and" in p]
+        self.assertTrue(pits, "the WALL EAS pitfall went missing")
+        p = pits[0]
+        # The corrected entry must state the probe node, otherwise the
+        # percentages are not reproducible (the original mixed node 3 /
+        # KINEM linear with node 2 / KINEM nonlinear).
+        self.assertIn("node 2", p)
+        self.assertIn("4.33567955849997223e-03", p)   # EAS none,  nonlinear
+        self.assertIn("5.33749404753981662e-03", p)   # EAS full,  nonlinear
+
+
+class TestResultDescriptionKeyListsAreComplete(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rd = _knowledge()["result_description"]
+
+    def test_element_selector_lists_all_four_groups(self):
+        sel = self.rd["required_keys"]["NODE | LINE | SURFACE | VOLUME"]
+        for g in ("ARTNET", "FLUID", "POROFLUIDMULTIPHASE", "RED_AIRWAY"):
+            self.assertIn(g, sel)
+
+    def test_special_lists_all_nine_groups(self):
+        sp = self.rd["optional_keys"]["SPECIAL"]
+        for g in ("CARDIOVASCULAR0D", "FSI", "PARTICLEWALL",
+                  "POROFLUIDMULTIPHASE", "SCATRA", "SSI", "SSTI", "STI",
+                  "STRUCTURE"):
+            self.assertIn(g, sp)
+
+    def test_op_lists_its_actual_enum_choices(self):
+        op = self.rd["optional_keys"]["OP"]
+        for c in ("sum", "max", "min", "unknown"):
+            self.assertIn(c, op)
+
+
+class TestExecutedConstantsAreTheReproducibleOnes(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.k = _knowledge()
+
+    def test_result_description_uses_the_fixture_value(self):
+        pits = [p for p in self.k["input_format"]["pitfalls"]
+                if "RESULT DESCRIPTION is 4C's own numerical" in p]
+        self.assertTrue(pits)
+        p = pits[0]
+        # The fixture's own executed value, re-measured 2026-08-03.
+        self.assertIn("4.47909266337460053e-03", p)
+
+    def test_parameters_byte_count_is_the_stdout_only_one(self):
+        pits = [p for p in self.k["input_format"]["pitfalls"]
+                if "--parameters" in p and "top-level keys" in p]
+        self.assertTrue(pits)
+        p = pits[0]
+        self.assertIn("2 926 432", p)
+        self.assertIn("478", p)   # the section count on this build
+
+
+class TestNueLowerBoundIsFatal(unittest.TestCase):
+
+    def test_nue_minus_one_sigfpe_is_documented(self):
+        k = _knowledge()
+        pits = [p for p in k["input_format"]["pitfalls"]
+                if "in_range[-1,0.5)" in p and "SIGFPE" in p]
+        self.assertTrue(
+            pits,
+            "NUE: -1.0 passes the validator and is then killed by SIGFPE "
+            "(verified by execution 2026-08-03); the pitfall must stay.")
+        p = pits[0]
+        self.assertIn("signal 8", p)
+        self.assertIn("136", p)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fourc_execution_sweep_2026_08_03.py
+++ b/tests/test_fourc_execution_sweep_2026_08_03.py
@@ -1,0 +1,240 @@
+"""Regression: the 2026-08-03 4C execution sweep.
+
+Every claim pinned here was produced by writing a minimal .4C.yaml,
+running the deployed binary ``/home/alexander/4C/build/4C``
+(4C 2026.2.0-dev, git 89519cf) and recording what actually happened.
+The full probe log lives in the Tier-2 fixtures under
+``scripts/tier2_fixtures/fourc/``:
+
+  * ``result_description_gates_the_exit_code``
+  * ``runtime_vtk_output_needs_both_sections``
+  * ``thermo_prefixed_dirich_silently_ignored``
+  * ``maxtime_truncates_numstep_silently``
+  * ``restartevery_section_placement``
+  * ``material_parameter_validation_bounds``
+  * ``problem_size_is_optional_and_inert``
+  * ``neumann_type_enum_vs_element_support``
+  * ``structural_2d_solid_quad4_not_wall`` (rewritten era-agnostic)
+
+This test is GEN-ONLY — it needs no 4C binary, so it runs in CI. It
+guards the three things that a later edit could silently undo:
+
+  1. the knowledge entries themselves are still present and still
+     carry the executed-provenance marker, so nobody can quietly
+     replace an executed claim with an inherited one;
+  2. the Tier-2 fixture ``pitfall_index`` values still point at the
+     pitfalls they were written for — index drift is invisible at
+     review time and silently decouples a fixture from its claim
+     (exactly the bug found in ``structural_dynamic_dynamictype_enum``
+     on 2026-08-03, whose index 7 pointed past the end of a 7-entry
+     list);
+  3. the corrections this sweep made are not re-reverted: PROBLEM
+     SIZE stays out of the mandatory-section list, and the
+     ``result_description`` reference block keeps all 18 field-group
+     names that ``valid_result_lines()`` actually registers.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+_FIXTURE_DIR = _REPO / "scripts" / "tier2_fixtures" / "fourc"
+
+# Marker every entry added by the sweep carries. Chosen so that a
+# re-worded claim keeps the marker only if it is still backed by a run.
+_PROVENANCE = "Verified by execution 2026-08-03"
+
+# (physics, pitfall_index, substring that must still be in that entry)
+EXECUTED_ENTRIES = [
+    ("input_format", 17, "RESULT DESCRIPTION"),
+    ("input_format", 18, "line-buffered"),
+    ("input_format", 19, "loose TOLERANCE"),
+    ("input_format", 20, "expected 1 tests but performed 0"),
+    ("input_format", 21, "PROBLEM SIZE is OPTIONAL"),
+    ("input_format", 22, "not available."),
+    ("input_format", 23, "has incorrect size"),
+    ("input_format", 24, "not in range"),
+    ("input_format", 25, "Unknown type of SurfaceNeumann condition"),
+    ("input_format", 26, "INTERVAL_STEPS"),
+    ("input_format", 27, "RESTARTEVERY"),
+    ("input_format", 28, "--parameters"),
+    # 2026-08-03 (second sweep): three corrected/added element-line
+    # pitfalls were inserted ahead of these, so the sweep entries moved
+    # from 7..12 to 9..14. The entries themselves are unchanged and still
+    # carry the provenance marker; only their position shifted.
+    ("structural_mechanics", 9, "VERSION-DEPENDENT"),
+    ("structural_mechanics", 10, "EAS"),
+    ("structural_mechanics", 11, "Expected parameter 'DENS'"),
+    ("structural_mechanics", 12, "in_range[-1,0.5)"),
+    ("structural_mechanics", 13, "Floating point exception (8)"),
+    ("structural_mechanics", 14, "KINEM nonlinear"),
+    # thermal was reordered so the silent-drop trap is read FIRST; it is
+    # now index 0 rather than 3.
+    ("thermal", 0, "SILENTLY DROPPED"),
+    ("structural_dynamics", 7, "singular matrix"),
+    ("structural_dynamics", 8, "Finalised step"),
+    ("structural_dynamics", 9, "RESTARTEVERY"),
+]
+
+# The 18 groups registered by valid_result_lines() in
+# src/global_legacy_module/4C_global_legacy_module.cpp. 4C echoes this
+# exact list when an unknown group name is used, so it is directly
+# checkable against the binary.
+RESULT_GROUPS = {
+    "STRUCTURE", "FLUID", "XFLUID", "ALE", "THERMAL", "LUBRICATION",
+    "POROFLUIDMULTIPHASE", "SCATRA", "SSI", "SSTI", "STI",
+    "RED_AIRWAY", "ARTNET", "FSI", "PARTICLE", "PARTICLEWALL",
+    "RIGIDBODY", "CARDIOVASCULAR0D",
+}
+
+
+def _backend():
+    from core.registry import load_all_backends, get_backend
+    load_all_backends()
+    return get_backend("fourc")
+
+
+class TestExecutedEntriesPresent(unittest.TestCase):
+    """Each swept claim is still there, still marked as executed."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.backend = _backend()
+        if cls.backend is None:
+            raise unittest.SkipTest("fourc backend not registered")
+
+    def test_entries_present_and_carry_execution_provenance(self):
+        for physics, idx, needle in EXECUTED_ENTRIES:
+            with self.subTest(physics=physics, index=idx):
+                pitfalls = self.backend.get_knowledge(physics).get(
+                    "pitfalls", [])
+                self.assertGreater(
+                    len(pitfalls), idx,
+                    f"fourc::{physics} shrank to {len(pitfalls)} "
+                    f"pitfalls; index {idx} no longer exists. If an "
+                    f"entry was intentionally removed, remove it from "
+                    f"EXECUTED_ENTRIES and from the Tier-2 fixture "
+                    f"that references it in the same commit.")
+                entry = pitfalls[idx]
+                self.assertIn(
+                    needle, entry,
+                    f"fourc::{physics}#{idx} no longer contains "
+                    f"{needle!r} — the pitfall list was probably "
+                    f"reordered, which silently decouples the Tier-2 "
+                    f"fixtures from their claims.")
+                self.assertIn(
+                    _PROVENANCE, entry,
+                    f"fourc::{physics}#{idx} lost its "
+                    f"{_PROVENANCE!r} marker. Executed claims must "
+                    f"keep the note that says what was run; an "
+                    f"unverified entry is worse than no entry.")
+
+    def test_every_executed_entry_is_signal_parseable(self):
+        """The sweep must not weaken the Signal: discipline."""
+        sys.path.insert(0, str(_REPO / "scripts"))
+        from verify_signal_clauses import _split_pitfall
+        for physics, idx, _ in EXECUTED_ENTRIES:
+            with self.subTest(physics=physics, index=idx):
+                entry = self.backend.get_knowledge(physics)["pitfalls"][idx]
+                cat, sig = _split_pitfall(entry)
+                self.assertIsNotNone(
+                    cat, f"fourc::{physics}#{idx} lost its [Category] "
+                         f"prefix")
+                self.assertTrue(
+                    sig, f"fourc::{physics}#{idx} lost its parseable "
+                         f"'Signal:' clause")
+
+
+class TestFixtureIndicesStillPoint(unittest.TestCase):
+    """Tier-2 fixture pitfall_index values must stay in range.
+
+    A fixture whose index runs off the end of its pitfall list still
+    'passes' the runner but verifies nothing, because the Signal
+    harness looks the result up by ``backend::physics::index``. That
+    is how ``structural_dynamic_dynamictype_enum`` sat at index 7 of a
+    7-entry list until 2026-08-03.
+    """
+
+    def test_all_fourc_fixture_indices_are_in_range(self):
+        backend = _backend()
+        if backend is None:
+            self.skipTest("fourc backend not registered")
+        supported = {p.name for p in backend.supported_physics()}
+        for fixture in sorted(_FIXTURE_DIR.glob("*/fixture.json")):
+            meta = json.loads(fixture.read_text(encoding="utf-8"))
+            physics = meta.get("physics", "")
+            idx = int(meta.get("pitfall_index", -1))
+            with self.subTest(fixture=fixture.parent.name):
+                if physics not in supported:
+                    # Legacy '_'-prefixed names never resolved to a
+                    # physics row; they are recorded but unlinked.
+                    self.assertTrue(
+                        physics.startswith("_"),
+                        f"{fixture.parent.name} targets physics "
+                        f"{physics!r}, which fourc does not support "
+                        f"and which is not a legacy '_' name.")
+                    continue
+                pitfalls = backend.get_knowledge(physics).get(
+                    "pitfalls", [])
+                self.assertLess(
+                    idx, len(pitfalls),
+                    f"{fixture.parent.name} points at "
+                    f"fourc::{physics}#{idx} but that list only has "
+                    f"{len(pitfalls)} entries — the fixture verifies "
+                    f"nothing. Fix pitfall_index (and prefer appending "
+                    f"new pitfalls at the END of a list so existing "
+                    f"indices stay valid).")
+
+
+class TestSweepCorrectionsHold(unittest.TestCase):
+    """The two catalogue corrections must not be re-reverted."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "_fourc_knowledge", _REPO / "data" / "fourc_knowledge.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        cls.knowledge = mod.FOURC_KNOWLEDGE
+
+    def test_problem_size_is_not_listed_as_mandatory(self):
+        mandatory = self.knowledge["input_format"]["mandatory_sections"]
+        for entry in mandatory:
+            self.assertNotIn(
+                "PROBLEM SIZE", entry,
+                "PROBLEM SIZE is declared {.required = false} in "
+                "4C_global_legacy_module_validparameters.cpp and a "
+                "deck without it runs to completion (verified by "
+                "execution 2026-08-03, fixture "
+                "problem_size_is_optional_and_inert). It must not go "
+                "back into mandatory_sections.")
+        self.assertIn(
+            "PROBLEM SIZE",
+            self.knowledge["input_format"]["optional_sections"])
+
+    def test_result_description_block_is_complete(self):
+        rd = self.knowledge["result_description"]
+        self.assertEqual(set(rd["field_groups"]), RESULT_GROUPS)
+        # THERMAL, not THERMO — the single most likely wrong guess.
+        self.assertIn("THERMAL", rd["field_groups"])
+        self.assertNotIn("THERMO", rd["field_groups"])
+        for q in ("dispx", "dispy", "dispz", "reactx", "stress",
+                  "strain", "press"):
+            self.assertIn(q, rd["structure_quantities"])
+        for key in ("exit_semantics", "capture_note", "agent_recipe",
+                    "required_keys", "yaml_example"):
+            self.assertIn(key, rd)
+        # No 'pitfalls' key here on purpose: the orphan audit in
+        # tests/test_signal_verification.py counts catalogue rows that
+        # carry pitfalls but are not registered physics names.
+        self.assertNotIn("pitfalls", rd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fourc_inline_tsi.py
+++ b/tests/test_fourc_inline_tsi.py
@@ -115,16 +115,16 @@ class TestFourcInlineTsiMonolithic(unittest.TestCase):
 
 
 class TestFourcTsiPlaneStrain(unittest.TestCase):
-    """tsi/plane_strain_2d — the pseudo-2D thin-slab route added after the
-    T14 evaluation campaign (2026-07): agents given a 2D plane-strain
-    thermo-mechanical problem dead-ended, because 4C has no 2D TSI
-    elements, WALL QUAD4 rejects MAT_Struct_ThermoStVenantK ('Invalid
-    type of material law for wall element', 4C_w1_mat.cpp:179) and the
-    deployed binary rejects SOLID QUAD4 outright ("Element 'SOLID' does
-    not seem to know cell type 'quad4'"). Verified live against
-    /home/alexander/4C/build/4C 2026-08-01: rc=0 and max|u| = 2.462e-3 m
-    vs the analytic plane-strain estimate (1+nu)*alpha*int(T-Tref)dx =
-    2.449e-3 m (0.5%). GEN-ONLY here so CI needs no binary."""
+    """tsi/plane_strain_2d — the pseudo-2D thin-slab route for 2D
+    plane-strain thermo-mechanics. 4C has no 2D TSI elements: WALL QUAD4
+    rejects MAT_Struct_ThermoStVenantK ('Invalid type of material law for
+    wall element', 4C_w1_mat.cpp:179) and current builds reject SOLID
+    QUAD4 outright ("Element 'SOLID' does not seem to know cell type
+    'quad4'"), so the route is a one-element-thick 3D SOLIDSCATRA slab.
+    Verified live against a built 4C binary: rc=0, and the tip
+    displacement tracks the analytic plane-strain thermal-expansion
+    estimate (1+nu)*alpha*int(T-Tref)dx. GEN-ONLY here so CI needs no
+    binary."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -145,8 +145,8 @@ class TestFourcTsiPlaneStrain(unittest.TestCase):
         self.assertNotIn("FILE:", content)
 
     def test_no_2d_eletypes(self) -> None:
-        """The exact eletypes that dead-ended the T14 agents must NOT
-        appear — the route is a 3D SOLIDSCATRA slab."""
+        """The 2D eletypes that 4C rejects for TSI must NOT appear —
+        the route is a 3D SOLIDSCATRA slab."""
         content = self._gen()
         self.assertIn("SOLIDSCATRA HEX8", content)
         self.assertNotIn("WALL QUAD4", content)
@@ -201,9 +201,10 @@ class TestFourcTsiPlaneStrain(unittest.TestCase):
 
 class TestFourcTsiOnewayVariant(unittest.TestCase):
     """tsi/oneway_3d — the pre-existing inline one-way input, now exposed
-    as a variant and carrying the COUPVARIABLE Temperature fix (it
-    produced max|u| = 0.0 with the 4C default; 9.12e-4 after the fix,
-    both verified live 2026-08-01)."""
+    as a variant and carrying the COUPVARIABLE Temperature fix: with the
+    4C default the deck runs rc=0 and produces exactly zero
+    displacement, and only with COUPVARIABLE Temperature does the
+    thermal field actually load the structure (both verified live)."""
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/test_fourc_thermo_transient_mms.py
+++ b/tests/test_fourc_thermo_transient_mms.py
@@ -1,18 +1,20 @@
 """Gen-only regression: fourc thermo_transient_mms/temporal_mms_2d.
 
-Created 2026-08-01 (deliverable E3). Unsteady-heat MMS extension family
-on 4C graded on TEMPORAL convergence order: manufactured solution
+Unsteady-heat MMS extension family on 4C graded on TEMPORAL
+convergence order: manufactured solution
 u*(x,y,t) = temp_offset + (amp*sin(kx x)*sin(ky y) + grad_amp*x/lx)*f(t)
 on a FIXED QUAD4 mesh, exact volumetric source rho*c*du*/dt -
 kappa*lap(u*) as a SYMBOLIC_FUNCTION_OF_SPACE_TIME body load,
 time-dependent Dirichlet u* on the whole boundary, initial field
 u*(x,0), One-Step-Theta time integration.
 
-Verified live against the deployed binary /home/alexander/4C/build/4C
-on 2026-08-01 (dt-halving to the same T_end on a fixed mesh):
-    theta=0.5: Richardson orders ||u_dt - u_dt/2|| 2.018 / 2.004
-               (error vs exact saturates at the spatial Q1 floor)
-    theta=1.0: orders vs exact 0.95 / 1.00 / 1.05
+The live gate is a dt-halving study against a built 4C binary: the
+Richardson orders ||u_dt - u_dt/2|| must approach the theoretical
+One-Step-Theta rates (2 at theta=0.5, 1 at theta=1.0). The error
+against the exact solution saturates at the spatial Q1 floor, so it is
+Richardson -- not error-vs-exact -- that grades the time integrator.
+The measured orders are outputs of that run and are deliberately not
+recorded here.
 
 The load-bearing 4C fact these decks encode: the volumetric source in
 STANDALONE Thermo must use the PLAIN "DESIGN SURF NEUMANN CONDITIONS"
@@ -20,12 +22,12 @@ STANDALONE Thermo must use the PLAIN "DESIGN SURF NEUMANN CONDITIONS"
 "DESIGN SURF/VOL THERMO NEUMANN CONDITIONS" are registered under
 "ThermoSurfaceNeumann"/"ThermoVolumeNeumann" and are SILENTLY dropped
 by both Discretization::evaluate_neumann and TemperImpl::radiation()
-(probe 2026-08-01: rc=0, no warning, field converged to the
-source-free solution). These tests pin the plain section so the deck
-never regresses to the silently-ignored variant.
+(probed live: rc=0, no warning, field converged to the source-free
+solution). These tests pin the plain section so the deck never
+regresses to the silently-ignored variant.
 
 Tests are GEN-ONLY (no 4C binary needed) so they run in CI; the live
-execution gate is the dt-halving smoke recorded in the E3 report.
+execution gate is the separate dt-halving study.
 """
 from __future__ import annotations
 
@@ -118,8 +120,8 @@ class TestFourcThermoTransientMMS(unittest.TestCase):
         """THE 4C trap this family exists to encode: the volumetric
         source must go through the PLAIN Neumann section. The
         THERMO-prefixed one is silently ignored in standalone Thermo
-        (verified live 2026-08-01: rc=0, no warning, RMS error 0.55
-        vs 5e-4 after the switch)."""
+        (verified live: rc=0, no warning, and a field that converged to
+        the SOURCE-FREE solution until the plain section was used)."""
         content = self._gen()
         parsed = yaml.safe_load(content)
         self.assertIn("DESIGN SURF NEUMANN CONDITIONS", parsed)

--- a/tests/test_gate_cannot_see_answers.py
+++ b/tests/test_gate_cannot_see_answers.py
@@ -1,0 +1,141 @@
+"""Structural guard: nothing the agent touches may see an exact solution.
+
+Three surfaces must stay clean, and this test enforces the separation
+structurally rather than by inspection, so it cannot quietly regress:
+
+  1. THE VERIFICATION GATE — its checks must work from the PROBLEM STATEMENT
+     (source term, coefficients, domain) and from the run's own output. They
+     must never receive a reference or exact solution, because a gate that
+     needs the answer cannot verify a real engineering problem, where no
+     answer exists. This is also why the gate's convergence evidence is a
+     residual and a mesh-refinement study: both are reference-free.
+  2. THE SYSTEM PROMPTS — the agent must not be handed a solution.
+  3. THE KNOWLEDGE — covered by test_knowledge_not_contaminated.py.
+
+Comparing against a manufactured exact solution is legitimate ONLY in the
+external grader, after the fact, which the agent never sees.
+
+Word boundaries matter here: "resolution" contains "solution", and flagging it
+would pressure someone into mangling correct code.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+# The verification gate and the reference-free checks it relies on.
+GATE_MODULES = [
+    REPO / "src" / "core" / "quality_checks.py",
+    REPO / "src" / "core" / "residual_check.py",
+    REPO / "src" / "core" / "fabrication_gate.py",
+    REPO / "src" / "core" / "mesh_independence.py",
+]
+
+# Everything the agent is told, in either arm.
+PROMPT_SOURCES = [
+    REPO / "langgraph_eval" / "agent.py",
+    REPO / "src" / "server.py",
+]
+
+# Names that would mean "the answer was handed in". \b prevents "resolution".
+ANSWER_NAMES = re.compile(
+    r"\b(exact_solution|u_exact|uexact|analytic_solution|analytical_solution|"
+    r"reference_solution|true_solution|ground_truth|manufactured_solution)\b",
+    re.IGNORECASE)
+
+# A parameter of a gate function must not be an answer.
+ANSWER_PARAM = re.compile(
+    r"^(exact|u_exact|analytic|analytical|reference|truth|ground_truth|"
+    r"expected_solution|exact_fn|analytic_fn|reference_fn)$", re.IGNORECASE)
+
+
+def _functions(path: Path):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            names = [a.arg for a in
+                     (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+            if args.vararg:
+                names.append(args.vararg.arg)
+            if args.kwarg:
+                names.append(args.kwarg.arg)
+            yield node.name, names
+
+
+@pytest.mark.parametrize("module", GATE_MODULES, ids=lambda p: p.name)
+def test_gate_functions_never_accept_a_solution(module: Path):
+    """No verification-gate function may take the answer as an argument.
+
+    The gate's inputs are the problem statement and the run's own output. A
+    residual needs the source term, not the solution; a refinement study needs
+    neither.
+    """
+    if not module.exists():
+        pytest.skip(f"{module.name} not present")
+    offenders = [f"{fn}({', '.join(params)})"
+                 for fn, params in _functions(module)
+                 if any(ANSWER_PARAM.match(p) for p in params)]
+    assert not offenders, (
+        f"{module.name}: a verification-gate function accepts an exact "
+        f"solution. The gate must verify without knowing the answer, or it "
+        f"cannot verify a real problem.\n  " + "\n  ".join(offenders))
+
+
+@pytest.mark.parametrize("module", GATE_MODULES, ids=lambda p: p.name)
+def test_gate_code_contains_no_solution(module: Path):
+    if not module.exists():
+        pytest.skip(f"{module.name} not present")
+    text = module.read_text()
+    hits = []
+    for m in ANSWER_NAMES.finditer(text):
+        line_no = text[:m.start()].count("\n") + 1
+        line = text.splitlines()[line_no - 1].strip()
+        # Prose explaining WHY the gate must not see the answer is fine.
+        if line.lstrip().startswith(("#", '"', "'", "*")):
+            continue
+        hits.append(f"{module.name}:{line_no}: {line[:100]}")
+    assert not hits, (
+        "A verification-gate module references an exact solution in code.\n  "
+        + "\n  ".join(hits))
+
+
+@pytest.mark.parametrize("source", PROMPT_SOURCES, ids=lambda p: p.name)
+def test_prompts_hand_the_agent_no_solution(source: Path):
+    """Neither arm's instructions may contain a solution."""
+    if not source.exists():
+        pytest.skip(f"{source.name} not present")
+    text = source.read_text()
+    hits = [f"{source.name}:{text[:m.start()].count(chr(10)) + 1}"
+            for m in ANSWER_NAMES.finditer(text)]
+    assert not hits, (
+        f"{source.name} mentions an exact solution in agent-facing text.\n  "
+        + "\n  ".join(hits))
+
+
+def test_gate_cannot_import_the_answer_key():
+    """The gate must have no path to a sealed key or a problem builder."""
+    forbidden = re.compile(r"\b(keys|answer_key|build_problems|build_coupled|"
+                           r"build_extra|grade_blind)\b")
+    offenders = []
+    for module in GATE_MODULES:
+        if not module.exists():
+            continue
+        tree = ast.parse(module.read_text())
+        for node in ast.walk(tree):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [node.module or ""] + [a.name for a in node.names]
+            for n in names:
+                if forbidden.search(n or ""):
+                    offenders.append(f"{module.name} imports {n}")
+    assert not offenders, (
+        "A verification-gate module can reach the answer key.\n  "
+        + "\n  ".join(offenders))

--- a/tests/test_knowledge_is_discoverable.py
+++ b/tests/test_knowledge_is_discoverable.py
@@ -1,0 +1,205 @@
+"""Knowledge an agent cannot find is knowledge nobody has.
+
+WHY THIS GATE EXISTS
+--------------------
+Kratos held 41 knowledge areas and advertised 20. The other 21 carried 65
+verified pitfall entries — geomechanics, RANS, IGA, ROM, topology optimisation,
+chimera, FEM-to-DEM, FSI — and no surface enumerated any of them. Each had been
+researched, executed and written down, and none could be reached by an agent
+that did not already know the key to guess. That is worse than a gap: the work
+was done and then lost, and the loss is invisible because every test passed.
+
+It happened by drift, not decision. `supported_physics()` is a capability claim
+and correctly excludes areas with no generator; the pitfalls surface enumerated
+`supported_physics()`; so knowledge-only areas fell between the two. Nobody
+chose that. With hundreds of new entries landing from concurrent work, the same
+drift will recur every time an area is written without a template — so the
+check has to be mechanical rather than remembered.
+
+WHAT IS ENFORCED
+----------------
+Every knowledge area holding pitfall entries must be reachable from a surface
+that ENUMERATES it, not merely fetchable by an agent that guessed the key.
+Either it is in `supported_physics()`, or the pitfalls surface lists it as
+reference-only. Nothing may hold verified content and appear nowhere.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+from core import pitfall_index  # noqa: E402
+from core.registry import get_backend, load_all_backends  # noqa: E402
+
+BACKENDS = ["fourc", "kratos", "dealii", "fenics", "ngsolve", "skfem",
+            "dune", "febio", "sparta"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _loaded():
+    load_all_backends()
+
+
+def _pitfall_count(value) -> int:
+    return len([s for s in pitfall_index._strings_under(value)
+                if "Signal:" in s])
+
+
+@pytest.mark.parametrize("solver", BACKENDS)
+def test_every_knowledge_area_with_pitfalls_is_enumerated(solver):
+    """No area may hold pitfall entries while appearing on no surface."""
+    be = get_backend(solver)
+    if be is None:
+        pytest.skip(f"{solver} backend not registered on this install")
+
+    keys = pitfall_index.knowledge_keys(solver)
+    if not keys:
+        pytest.skip(f"{solver} keeps knowledge where knowledge_keys() cannot "
+                    f"enumerate it; covered by the per-backend audits instead")
+
+    advertised = {p.name for p in be.supported_physics()}
+    reference = set(pitfall_index.reference_only_areas(solver, advertised))
+
+    # REACHABILITY IS ABOUT THE TEXT, NOT THE KEY. An earlier version of this
+    # test compared area NAMES and accused 4C of hiding 154 subjects. It hides
+    # none: those names are aliases (`elasticity` -> `structure`, `scatra`,
+    # `xfem`, ...) whose 942 entry slots resolve to 248 texts that the
+    # advertised path already serves in full. Counting names would have driven
+    # a large pointless edit and shipped a payload with 942 duplicate entries.
+    #
+    # The question an agent actually cares about is whether the WORDS of a
+    # pitfall can reach it. So collect every entry served by any enumerated
+    # surface, then look for entries that appear on none of them.
+    served: set[str] = set()
+    for area in advertised | reference:
+        k = be.get_knowledge(area)
+        if isinstance(k, dict):
+            served.update(s for s in pitfall_index._strings_under(k)
+                          if "Signal:" in s)
+
+    hidden = []
+    for key in keys:
+        if key.startswith("_"):
+            continue  # `_general` is served by topic='overview'
+        k = be.get_knowledge(key)
+        if not isinstance(k, dict):
+            continue
+        unreachable = [s for s in pitfall_index._strings_under(k)
+                       if "Signal:" in s and s not in served]
+        if unreachable:
+            hidden.append(f"{key} ({len(unreachable)} entries reachable "
+                          f"nowhere else)")
+
+    assert not hidden, (
+        f"{solver}: these knowledge areas hold verified pitfall entries but no "
+        f"surface enumerates them, so no agent can discover they exist:\n  "
+        + "\n  ".join(hidden)
+        + "\n\nEither declare the area in supported_physics() (only if a "
+          "generator can build a runnable input for it) or let it be picked up "
+          "as reference-only. Do not leave researched content unreachable.")
+
+
+@pytest.mark.parametrize("solver", BACKENDS)
+def test_reference_only_areas_really_have_no_generator(solver):
+    """A reference-only label must be true, not a way to dodge the first test.
+
+    If a generator CAN build a runnable input for an area, the area belongs in
+    `supported_physics()` where discover() will show it. Labelling it
+    reference-only would then understate the backend — the mirror image of the
+    fabrication this project guards against, and just as misleading.
+    """
+    be = get_backend(solver)
+    if be is None:
+        pytest.skip(f"{solver} backend not registered on this install")
+    advertised = {p.name for p in be.supported_physics()}
+    areas = pitfall_index.reference_only_areas(solver, advertised)
+    if not areas:
+        pytest.skip(f"{solver} has no reference-only areas")
+
+    runnable = []
+    for area in areas:
+        try:
+            out = be.generate_input(area, "default", {})
+        except Exception:
+            continue  # correct: no generator, so reference-only is accurate
+        if isinstance(out, str) and len(out) > 200 and "NOT a runnable" not in out:
+            runnable.append(area)
+
+    assert not runnable, (
+        f"{solver}: these areas are served as reference-only yet "
+        f"generate_input() produced a substantive input for them: "
+        f"{runnable}. If they are runnable they belong in supported_physics() "
+        f"so discover() advertises them.")
+
+
+@pytest.mark.parametrize("solver", BACKENDS)
+def test_pitfalls_surface_actually_serves_the_reference_areas(solver):
+    """End to end: the entries must appear in what the tool returns.
+
+    The first test checks enumeration; this one checks delivery. They are
+    different failures and both have happened — a branch once enumerated an
+    area whose content the assembling code then dropped, and every enumeration
+    test still passed.
+    """
+    be = get_backend(solver)
+    if be is None:
+        pytest.skip(f"{solver} backend not registered on this install")
+    advertised = {p.name for p in be.supported_physics()}
+    areas = [a for a in pitfall_index.reference_only_areas(solver, advertised)
+             if isinstance(be.get_knowledge(a), dict)
+             and be.get_knowledge(a).get("pitfalls")]
+    if not areas:
+        pytest.skip(f"{solver} has no reference-only areas carrying pitfalls")
+
+    # Rebuild what the tool assembles, then confirm each area's own text is in
+    # it. Comparing counts would pass on a section that arrived empty.
+    all_pitfalls = {}
+    for p in be.supported_physics():
+        k = be.get_knowledge(p.name)
+        if k and "pitfalls" in k:
+            all_pitfalls[p.name] = k["pitfalls"]
+    for area in areas:
+        k = be.get_knowledge(area)
+        all_pitfalls[f"{area} [reference only — no generator; "
+                     f"write the input yourself]"] = k["pitfalls"]
+
+    served = json.dumps(all_pitfalls)
+    missing = []
+    for area in areas:
+        entries = [s for s in pitfall_index._strings_under(
+            be.get_knowledge(area)["pitfalls"]) if "Signal:" in s]
+        for e in entries:
+            probe = json.dumps(e)[1:60]
+            if probe not in served:
+                missing.append(f"{area}: {e[:70]}")
+                break
+
+    assert not missing, (
+        f"{solver}: reference-only areas were enumerated but their entries are "
+        f"not in the assembled payload:\n  " + "\n  ".join(missing))
+
+
+def test_the_label_reaches_the_agent():
+    """The reference-only caveat must travel with the content.
+
+    Serving FSI pitfalls without saying there is no FSI generator invites an
+    agent to try to run it and blame itself when it cannot. The label is part
+    of the knowledge, not decoration around it.
+    """
+    be = get_backend("kratos")
+    if be is None:
+        pytest.skip("kratos not registered on this install")
+    advertised = {p.name for p in be.supported_physics()}
+    areas = pitfall_index.reference_only_areas("kratos", advertised)
+    assert areas, ("kratos previously had 21 unlisted knowledge areas; finding "
+                   "none means reference_only_areas() stopped working, not "
+                   "that the knowledge was promoted")
+    key = f"{areas[0]} [reference only — no generator; write the input yourself]"
+    assert "reference only" in key and "no generator" in key

--- a/tests/test_knowledge_not_contaminated.py
+++ b/tests/test_knowledge_not_contaminated.py
@@ -1,0 +1,295 @@
+"""Guard: OASiS's knowledge must describe the CODE, never the ANSWER.
+
+An audit found evaluation-specific content reachable through the very tool the
+server instructions tell every agent to call first. Confirmed by execution:
+
+  * campaign identifiers inside agent-readable pitfalls — "the E5 prototype
+    run (2026-08-01)", "(T14 campaign fix.)";
+  * MEASURED convergence orders shipped as knowledge — "L2 EOCs
+    1.984/1.996/1.999", "observed orders 1.93 / 1.99 / 1.99", "Richardson
+    orders 2.018/2.004";
+  * pre-solved coupled cases — an exact solution and a tuned relaxation answer
+    for the same geometry the evaluation uses.
+
+Knowledge like that makes the evaluation measure itself: the agent can read the
+answer to a convergence study out of the tool being assessed.
+
+THE RULE THIS TEST ENFORCES
+    Knowledge may state how the code behaves, how it fails, what a keyword
+    means in the installed version, which element locks, which default changed.
+    It may NOT state the answer to a problem: a measured convergence order we
+    produced, an exact solution, a tuned parameter for a specific setup, or any
+    reference to our own evaluation campaign.
+
+Published literature benchmarks WITH a citation are expertise, not answers, and
+are deliberately allowed.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Where knowledge an agent can reach actually lives.
+KNOWLEDGE_ROOTS = [REPO / "src" / "backends", REPO / "src" / "tools",
+                   REPO / "data"]
+
+# Identifiers of our own evaluation. None of these may appear in knowledge.
+CAMPAIGN_TOKENS = [
+    r"\bE[1-5]\s+prototype\b", r"\bT1[0-9]\s+campaign\b", r"\bT[0-9]+\s+campaign\b",
+    r"\bcampaign\s+fix\b", r"\bevaluation\s+campaign\b",
+    r"\bB2/E[1-5]\b", r"\bheld-?out\s+(?:cell|instance)\b",
+]
+# NOTE: "held-out evaluation" is deliberately NOT a token here. Unlike a
+# campaign identifier, the phrase legitimately appears in OASiS's own design
+# prose (e.g. the verification gate explaining why an ablation flag exists).
+# Flagging it would pressure a maintainer into deleting correct documentation,
+# which is a worse outcome than the residual risk: an entry that named a
+# specific held-out CELL or INSTANCE is still caught above, and the measured
+# numbers such an entry would carry are caught by MEASURED_ORDER_PATTERNS.
+
+# "we measured this order on this install" — the answer to a convergence study.
+#
+# The first four patterns were written from the contamination an audit had
+# already found, and matched only that phrasing. An adversarial re-audit then
+# found the same class of content passing straight through, in different words:
+# `prepare_simulation('ngsolve','poisson')` was returning
+# "1.669e-01 / 3.923e-02 / 8.013e-03 / 1.763e-03 (rates 2.09, 2.29, 2.18)" —
+# a complete measured convergence table, handed to the agent by the tool being
+# evaluated. It said "rates" rather than "observed orders" and that was the
+# whole of its disguise.
+#
+# So these match the SHAPE of a measurement rather than one way of introducing
+# it: a list of rates, a run of slash-separated error values, and a dated
+# provenance stamp for one of our own runs.
+MEASURED_ORDER_PATTERNS = [
+    r"observed\s+orders?\s*[:=]?\s*\d+\.\d+",
+    r"\bEOCs?\b[^.\n]{0,40}\d\.\d{2,}",
+    r"Richardson\s+orders?\s+\d+\.\d+",
+    r"verified\s+live[^.\n]{0,60}\d\.\d{2,}",
+    # "(rates 2.09, 2.29, 2.18)" — a measured sequence, whatever it is called.
+    r"\brates?\s+\d+\.\d{2,}\s*,\s*\d+\.\d{2,}",
+    # "1.669e-01 / 3.923e-02 / 8.013e-03" — a convergence table. Three or more
+    # slash-separated values in a row is our error series, not a citation.
+    r"\d\.\d{2,}e[-+]\d+\s*/\s*\d\.\d{2,}e[-+]\d+\s*/\s*\d\.\d{2,}e[-+]\d+",
+    # "gave orders 2.083 / 1.997 / 1.668" — the same measurement, slash-
+    # separated instead of comma-separated, and introduced by "gave" rather
+    # than "observed". Found still shipping after the first two patterns were
+    # added, which is why these match the shape rather than the wording.
+    r"\borders?\s+\d+\.\d{2,}\s*/\s*\d+\.\d{2,}",
+]
+
+# A PARAMETER TUNED FOR ONE SPECIFIC PROBLEM.
+#
+# This is the shape the other patterns all missed, and it is the one that gives
+# most away: not a measured result but a settled ANSWER — "for the unit square
+# split at x=0.5, use theta=0.42". An agent reading that skips the work the
+# evaluation is asking it to do, and it compromises every future draw from the
+# distribution, not just the instance it names.
+#
+# The discriminator is SPECIFIC GEOMETRY plus a CONCRETE VALUE. General guidance
+# must survive untouched, because it is the knowledge we are trying to build:
+#   * a formula is general        — "theta ~ 1/(1+rho)"
+#   * a problem CLASS is general — "theta = 0.5 for problems with source terms"
+#   * a named domain with numbers, next to a value, is not.
+_TUNED_FOR_A_GEOMETRY = re.compile(
+    r"(?:for|on)\s+(?:the\s+)?"
+    r"(?:unit\s+(?:square|cube|interval)|\(0\s*,\s*[\d/.]+\)|"
+    r"\d+\s*[x×]\s*\d+\s+(?:mesh|grid|domain)|"
+    r"(?:square|cube|rectangle|box|domain)\s+split\s+at)"
+    # The bridge must allow '.', because the geometry itself carries decimals —
+    # "split at x=0.5". A first version excluded '.' to stop the match running
+    # across a sentence boundary, and that made it miss the primary case while
+    # catching the two easier ones. Bounded length does the same job.
+    r"[^\n]{0,80}?"
+    r"(?:use|set|take|choose|with)\s+\w{1,24}\s*(?:=|\bof\b|\bto\b)\s*"
+    r"[-+]?\d*\.?\d+",
+    re.IGNORECASE)
+
+# TWO PATTERNS THAT WERE TRIED AND DELIBERATELY NOT KEPT
+#
+# A gate has to be precise or it gets switched off, and a gate that fires on
+# correct content teaches people to ignore it. Both of these were measured
+# against the purged branch before being rejected:
+#
+#   r"(?:verified empirically|live-verified|measured)\s+\d{4}-\d{2}-\d{2}"
+#     — 98 hits on the ALREADY-PURGED branch. A date stamp records when we
+#       checked something; it is untidy provenance, but an agent cannot read an
+#       answer out of it. Making the merge gate fail in 98 places for that would
+#       force a mass edit that buys no safety.
+#
+#   r"/home/[a-z][a-z0-9_-]*/"
+#     — 16,435 hits, most of them in `src/backends/_installed_api.py`, a
+#       generated manifest of where things are installed ON THIS MACHINE. That
+#       file is supposed to contain local paths; that is its job. Six genuinely
+#       misplaced paths in deal.II prose are a real finding, but they are a
+#       code-review item, not something this pattern can isolate.
+#
+# What is kept above catches measured ANSWERS, and is clean on the purged
+# branch — so a failure means new contamination, every time.
+
+ALLOWED_SUFFIXES = {".py", ".json", ".md", ".txt", ".yaml", ".yml"}
+# Tests and fixtures legitimately discuss our campaigns; knowledge does not.
+SKIP_PARTS = {"tests", "scripts", "benchmarks", "__pycache__", ".git",
+              "data/sessions", "postmortems"}
+
+
+def _knowledge_files():
+    for root in KNOWLEDGE_ROOTS:
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            if not p.is_file() or p.suffix not in ALLOWED_SUFFIXES:
+                continue
+            rel = p.relative_to(REPO).as_posix()
+            if any(part in rel.split("/") for part in SKIP_PARTS):
+                continue
+            if "data/sessions" in rel or "postmortems" in rel:
+                continue
+            yield p
+
+
+def _hits(pattern: str):
+    rx = re.compile(pattern, re.IGNORECASE)
+    found = []
+    for p in _knowledge_files():
+        try:
+            text = p.read_text(errors="ignore")
+        except OSError:
+            continue
+        for m in rx.finditer(text):
+            line = text[:m.start()].count("\n") + 1
+            snippet = text[max(0, m.start() - 60):m.end() + 60].replace("\n", " ")
+            found.append(f"{p.relative_to(REPO)}:{line}: …{snippet.strip()}…")
+    return found
+
+
+@pytest.mark.parametrize("pattern", CAMPAIGN_TOKENS)
+def test_no_campaign_identifier_in_knowledge(pattern):
+    """Knowledge must not reference our own evaluation."""
+    hits = _hits(pattern)
+    assert not hits, (
+        "Evaluation-campaign reference found in agent-reachable knowledge.\n"
+        "Knowledge describes the code, never our tests.\n  " + "\n  ".join(hits[:8]))
+
+
+@pytest.mark.parametrize("pattern", MEASURED_ORDER_PATTERNS)
+def test_no_measured_convergence_orders_in_knowledge(pattern):
+    """The worst contamination: the answer to a convergence study, shipped.
+
+    A general statement of a method's THEORETICAL order is fine — that is
+    textbook code knowledge. Our measurements are not.
+    """
+    hits = _hits(pattern)
+    assert not hits, (
+        "Measured convergence order found in agent-reachable knowledge.\n"
+        "An agent can read the answer to a convergence study out of the tool "
+        "being evaluated.\n  " + "\n  ".join(hits[:8]))
+
+
+def test_no_absolute_host_paths_in_served_knowledge_payloads():
+    """A `*_knowledge.json` is handed to the agent wholesale. Absolute paths
+    from the machine it was written on are wrong everywhere else.
+
+    An audit found SPARTA's `installed_build` block shipping four absolute host
+    paths through the live `knowledge` tool, for all ten physics — the only
+    backend doing it.
+
+    Deliberately narrow. A broader sweep over `src/backends` was measured and
+    rejected: it fires 16,435 times, overwhelmingly inside the generated install
+    manifest whose whole job is to record local paths, and on ordinary comments
+    that mention a path while explaining something. Search-path fallbacks in a
+    backend's own `backend.py` are likewise legitimate — the code has to look
+    somewhere. What is not legitimate is a path baked into the knowledge PAYLOAD
+    an agent is served as fact.
+    """
+    rx = re.compile(r"[\"'](/home/|/media/)[a-z][a-z0-9_/-]*")
+    hits = []
+    for root in KNOWLEDGE_ROOTS:
+        if not root.exists():
+            continue
+        for p in root.rglob("*_knowledge.json"):
+            text = p.read_text(errors="ignore")
+            for m in rx.finditer(text):
+                line = text[:m.start()].count("\n") + 1
+                hits.append(f"{p.relative_to(REPO)}:{line}: "
+                            f"{text[m.start():m.start() + 90]}")
+    assert not hits, (
+        "An absolute host path is served to agents as knowledge. Describe how "
+        "to locate the install; do not hard-code one machine's layout.\n  "
+        + "\n  ".join(hits[:8]))
+
+
+def test_no_parameter_tuned_for_one_specific_problem():
+    """The shape every other pattern missed, and the one that gives most away.
+
+    Not a measured result but a settled ANSWER: "for the unit square split at
+    x=0.5, use theta=0.42". An agent reading that skips the work the evaluation
+    is asking it to do — and unlike a leaked instance, it compromises every
+    future draw from the problem distribution, because the tuning is general.
+
+    Calibrated in both directions, since general guidance is the knowledge we
+    are trying to build and a guard that eats it would be worse than none:
+    formulas ("theta ~ 1/(1+rho)"), problem CLASSES ("theta = 0.5 for problems
+    with source terms"), qualitative rules ("put Dirichlet on the softer
+    subdomain") and element facts ("P1 locks at nu = 0.4999") all pass.
+    """
+    hits = _hits(_TUNED_FOR_A_GEOMETRY.pattern)
+    assert not hits, (
+        "a parameter tuned for one specific geometry is shipped in "
+        "agent-reachable knowledge. State the rule or the formula, not the "
+        "answer for one domain.\n  " + "\n  ".join(hits[:8]))
+
+
+def test_the_tuned_parameter_guard_discriminates():
+    """Proof the predicate works, because an untested guard is decoration."""
+    for planted in ("for the unit square split at x=0.5 use theta=0.42",
+                    "on the unit cube with 16 elements per side, set "
+                    "relaxation = 0.3",
+                    "for the 32x32 mesh choose dt of 0.001"):
+        assert _TUNED_FOR_A_GEOMETRY.search(planted), planted
+    for legitimate in ("theta ~ 1/(1+rho) with rho the conductance ratio",
+                       "theta = 0.5 is required for problems WITH source terms",
+                       "put Dirichlet on the softer subdomain",
+                       "for nearly incompressible materials use a mixed "
+                       "formulation",
+                       "P1 elements lock at nu = 0.4999; use P2",
+                       "the unit square is the usual test domain"):
+        assert not _TUNED_FOR_A_GEOMETRY.search(legitimate), legitimate
+
+
+# Prose ABOUT exact solutions is legitimate and must not be flagged: the
+# mesh-independence tool's docstring correctly says it is "for problems WITHOUT
+# an exact solution", and a pitfall may warn that no closed form exists. Only a
+# formula being SUPPLIED is contamination, so require a right-hand side that
+# actually defines one (an equals/colon followed by an expression in x, t or a
+# number) and exclude negating context.
+_NEGATING = re.compile(
+    r"(?:without|no|lacks?|absent|not\s+have|unavailable|if\s+an?)\s+"
+    r"(?:an?\s+)?(?:known\s+|analytical\s+|closed[- ]form\s+)?exact\s+solution",
+    re.IGNORECASE)
+
+
+def test_no_exact_solution_shipped_for_a_coupled_case():
+    """Pre-solved cases were reachable via knowledge(topic='coupling'):
+    'Exact solution: T(x) = 100*(1-x)' with a per-solver error table."""
+    rx = re.compile(r"[Ee]xact\s+solution\s*[:=]\s*([A-Za-z_]\w*\s*\([^)]*\)\s*=|"
+                    r"[-+]?\d|[A-Za-z_]\w*\s*[-+*/^])")
+    hits = []
+    for f in _knowledge_files():
+        try:
+            text = f.read_text(errors="ignore")
+        except OSError:
+            continue
+        for m in rx.finditer(text):
+            ctx = text[max(0, m.start() - 120):m.end() + 40]
+            if _NEGATING.search(ctx):
+                continue                      # "for problems WITHOUT an exact solution"
+            line = text[:m.start()].count("\n") + 1
+            hits.append(f"{f.relative_to(REPO)}:{line}: …{ctx.replace(chr(10),' ').strip()[:150]}…")
+    assert not hits, (
+        "An exact solution is shipped in knowledge; the agent can read the "
+        "answer instead of computing it.\n  " + "\n  ".join(hits[:8]))

--- a/tests/test_knowledge_payload_valid_json.py
+++ b/tests/test_knowledge_payload_valid_json.py
@@ -1,0 +1,230 @@
+"""Regression: a size-capped knowledge payload must still be VALID JSON.
+
+WHY this exists
+===============
+`prepare_simulation` renders each backend's physics knowledge into a
+```json fence. Until 2026-08-03 the size cap was applied with a raw
+string slice, ``text[:LIMIT]``, which cuts in the middle of whatever
+value happens to sit at that byte offset.
+
+A sweep of all (backend, physics) payloads on this install found 12 rows
+over the 16000-char cap, and ALL 12 came back as INVALID JSON under the
+slice — 7 SPARTA rows and 5 FEniCSx rows — failing with
+"Unterminated string starting at: ..." or "Expecting property name
+enclosed in double quotes: ...". An agent that receives an unparseable
+payload has nothing to fall back on, and a small model will not go
+hunting for a second copy: this is strictly worse than serving less.
+
+The fix is `tools.consolidated._fit_json_block`, which shrinks by
+dropping or thinning WHOLE entries instead of slicing. This test pins
+its three guarantees so they cannot silently regress as knowledge grows
+— and knowledge growing is exactly what triggered the bug:
+
+  1. the rendered block always parses as JSON,
+  2. no load-bearing entry is ever removed (the description, the
+     runnable example, the spaces / weak form / BCs / solver blocks),
+  3. anything removed is NAMED, together with the call that fetches it.
+
+The test is deliberately written against the LIVE catalog rather than a
+fixture, so a newly added physics row that blows the cap is caught here
+rather than in front of an agent.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+# The cap prepare_simulation applies to the knowledge block.
+KNOWLEDGE_LIMIT = 16000
+
+
+def _all_backends():
+    """Register every backend package and return the live instances."""
+    from core.registry import get_backend
+    out = []
+    root = _REPO / "src" / "backends"
+    for name in sorted(os.listdir(root)):
+        if not (root / name).is_dir() or name.startswith("_") or name == "__pycache__":
+            continue
+        try:
+            importlib.import_module(f"backends.{name}.backend").register()
+        except Exception:
+            continue
+        be = get_backend(name)
+        if be is not None:
+            out.append((name, be))
+    return out
+
+
+def _payloads():
+    """Yield (backend_name, physics, payload_dict) for every catalog row.
+
+    The payload is what prepare_simulation dumps: the knowledge dict minus
+    the `pitfalls` list, which is rendered separately outside the fence.
+    """
+    for name, be in _all_backends():
+        try:
+            physics = [p.name for p in be.supported_physics()]
+        except Exception:
+            continue
+        for phys in physics:
+            try:
+                k = be.get_knowledge(phys)
+            except Exception:
+                continue
+            if not isinstance(k, dict) or not k:
+                continue
+            yield name, phys, {kk: vv for kk, vv in k.items() if kk != "pitfalls"}
+
+
+class TestKnowledgePayloadValidJson(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        import tools.consolidated as consolidated
+        cls.C = consolidated
+        cls.rows = list(_payloads())
+        if not cls.rows:
+            raise unittest.SkipTest("no backend catalogs importable in this env")
+
+    def test_every_fitted_payload_parses(self) -> None:
+        """Guarantee 1 — the rendered block is always valid JSON."""
+        broken = []
+        for name, phys, payload in self.rows:
+            text, _note = self.C._fit_json_block(payload, KNOWLEDGE_LIMIT)
+            try:
+                json.loads(text)
+            except Exception as exc:
+                broken.append(f"{name}::{phys}: {exc}")
+        self.assertFalse(
+            broken,
+            "knowledge payload does not parse as JSON after fitting "
+            "(the agent receives this verbatim inside a ```json fence):\n  "
+            + "\n  ".join(broken))
+
+    def test_load_bearing_entries_survive(self) -> None:
+        """Guarantee 2 — a shrink never removes setup-critical content."""
+        lost = []
+        for name, phys, payload in self.rows:
+            text, _note = self.C._fit_json_block(payload, KNOWLEDGE_LIMIT)
+            kept = json.loads(text)
+            for key in payload:
+                if self.C._is_load_bearing(key) and key not in kept:
+                    lost.append(f"{name}::{phys} lost {key!r}")
+        self.assertFalse(
+            lost,
+            "fitting dropped a load-bearing entry — a small model cannot "
+            "reconstruct these:\n  " + "\n  ".join(lost))
+
+    def test_removals_are_announced(self) -> None:
+        """Guarantee 3 — whatever was removed is named for the caller."""
+        silent = []
+        for name, phys, payload in self.rows:
+            text, note = self.C._fit_json_block(payload, KNOWLEDGE_LIMIT)
+            kept = json.loads(text)
+            removed = [k for k in payload if k not in kept]
+            thinned = [k for k in kept
+                       if isinstance(kept[k], (dict, list))
+                       and any("_more_entries_omitted__" in str(x)
+                               for x in (kept[k] if isinstance(kept[k], list)
+                                         else kept[k].keys()))]
+            if (removed or thinned) and not note.strip():
+                silent.append(f"{name}::{phys} removed {removed + thinned} with no note")
+            for k in removed:
+                if k not in note:
+                    silent.append(f"{name}::{phys} dropped {k!r} without naming it")
+        self.assertFalse(
+            silent,
+            "content was removed without telling the caller what or how to "
+            "fetch it:\n  " + "\n  ".join(silent))
+
+    def test_under_cap_payloads_are_untouched(self) -> None:
+        """A payload that fits must be passed through byte-identically."""
+        for name, phys, payload in self.rows:
+            raw = json.dumps(payload, indent=2, default=str)
+            if len(raw) > KNOWLEDGE_LIMIT:
+                continue
+            text, note = self.C._fit_json_block(payload, KNOWLEDGE_LIMIT)
+            self.assertEqual(text, raw, f"{name}::{phys} altered while under the cap")
+            self.assertEqual(note, "", f"{name}::{phys} noted a trim it did not make")
+
+    def test_slicing_would_have_broken_real_payloads(self) -> None:
+        """The bug is real, not hypothetical — keep the evidence executable.
+
+        If this ever finds ZERO sliceable payloads it means every catalog row
+        now fits the cap; that is fine and the assertion below is skipped
+        rather than failed, so the test does not become a growth requirement.
+        """
+        would_break = []
+        for name, phys, payload in self.rows:
+            raw = json.dumps(payload, indent=2, default=str)
+            if len(raw) <= KNOWLEDGE_LIMIT:
+                continue
+            try:
+                json.loads(raw[:KNOWLEDGE_LIMIT])
+            except Exception:
+                would_break.append(f"{name}::{phys}")
+        if not would_break:
+            self.skipTest("no catalog row currently exceeds the cap")
+        # Same rows, through the real fitter — all must parse.
+        for name, phys, payload in self.rows:
+            if f"{name}::{phys}" not in would_break:
+                continue
+            text, _ = self.C._fit_json_block(payload, KNOWLEDGE_LIMIT)
+            json.loads(text)   # raises and fails the test if the fix regressed
+
+    def test_prepare_simulation_fence_parses(self) -> None:
+        """End-to-end: the ```json fence inside the real tool output parses.
+
+        This is the surface the agent actually reads, so it is checked
+        separately from the helper.
+        """
+        import asyncio
+        import re
+        from tools.consolidated import register_consolidated_tools
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("payload-test")
+        register_consolidated_tools(mcp)
+        tools = asyncio.get_event_loop().run_until_complete(mcp.list_tools())
+        if not any(t.name == "prepare_simulation" for t in tools):
+            self.skipTest("prepare_simulation not registered")
+
+        # Pick the biggest row per backend — the one most likely to be capped.
+        biggest = {}
+        for name, phys, payload in self.rows:
+            n = len(json.dumps(payload, indent=2, default=str))
+            if n > biggest.get(name, (0, None))[0]:
+                biggest[name] = (n, phys)
+
+        broken = []
+        for name, (_n, phys) in sorted(biggest.items()):
+            try:
+                out = asyncio.get_event_loop().run_until_complete(
+                    mcp.call_tool("prepare_simulation",
+                                  {"solver": name, "physics": phys}))
+            except Exception:
+                continue
+            text = "".join(getattr(c, "text", "") for c in
+                           (out[0] if isinstance(out, tuple) else out))
+            m = re.search(r"## Knowledge\n```json\n(.*?)\n```", text, re.S)
+            if not m:
+                continue
+            try:
+                json.loads(m.group(1))
+            except Exception as exc:
+                broken.append(f"{name}::{phys}: {exc}")
+        self.assertFalse(
+            broken,
+            "the ```json fence in real prepare_simulation output does not "
+            "parse:\n  " + "\n  ".join(broken))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kratos_curved_mms.py
+++ b/tests/test_kratos_curved_mms.py
@@ -11,9 +11,10 @@ Covered:
     prints the machine-readable L2_ERROR line, and passes backend.validate_input
   * module-level validate_parameters accepts good params and rejects bad ones
 
-Live convergence evidence (run outside pytest, /usr/bin/python3, 2026-08-01):
-h=0.2/0.1/0.05/0.025 gave L2 = 6.363e-2/1.674e-2/4.226e-3/1.063e-3,
-observed orders 1.93/1.99/1.99 (theoretical: 2).
+The live execution gate runs outside pytest under /usr/bin/python3: an
+h-refinement sweep whose L2 errors must approach the theoretical P1
+order of 2. The measured errors and orders are outputs of that run and
+are deliberately NOT recorded here or in the module KNOWLEDGE.
 """
 from __future__ import annotations
 

--- a/tests/test_kratos_sparta_verified_2026_08.py
+++ b/tests/test_kratos_sparta_verified_2026_08.py
@@ -1,0 +1,396 @@
+"""Regression gate for the 2026-08-03 Kratos + SPARTA verification campaign.
+
+Everything asserted here was established by EXECUTING the installed solvers
+(Kratos Multiphysics 10.4.0 under /usr/bin/python3; SPARTA "24 Sep 2025",
+spa_serial). The tier-2 fixtures under scripts/tier2_fixtures/{kratos,sparta}/
+hold the executable evidence:
+
+  kratos/cda_element_diffusion_vs_mass
+  kratos/cda_conductivity_is_nodal
+  kratos/constitutive_law_registry_names
+  kratos/parameters_unknown_key_raises
+  kratos/point_load_direction_process_rejects
+  kratos/quad4_shear_locking_vs_quad8
+  sparta/no_collide_is_free_molecular
+  sparta/docpage_names_are_not_commands
+
+This file is the CHEAP gate: it imports no solver, so it runs everywhere, and
+it fails if someone reverts a corrected claim back to the falsified wording.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+sys.path.insert(0, str(_REPO / "data"))
+
+
+def _kratos_knowledge() -> dict:
+    from backends.kratos.generators import KNOWLEDGE
+    return KNOWLEDGE
+
+
+def _all_text(block: dict) -> str:
+    import json
+    return json.dumps(block, default=str)
+
+
+class TestKratosFalsifiedClaimsStayFixed(unittest.TestCase):
+    """Wordings that EXECUTION proved wrong must not come back."""
+
+    # (physics, forbidden substring, what the execution showed instead)
+    FORBIDDEN = [
+        ("poisson",
+         "produce solutions that differ by less than 1e-12 relative norm",
+         "LaplacianElement2D3N and EulerianConvDiff2D3N differ by relative norm 1.0 "
+         "in a stationary solve; EulerianConvDiff returns TEMPERATURE == 0"),
+        ("poisson",
+         "go on Properties object, NOT on nodes",
+         "LaplacianElement2D3N reads CONDUCTIVITY nodally; the Properties value is "
+         "ignored (LHS[0][0] = 1.0 with Properties 999, = 999.0 with nodal 999)"),
+        ("structural_dynamics",
+         "Wrong key is silently ignored and the scheme runs without damping",
+         "Parameters::ValidateAndAssignDefaults raises on the unknown key and the "
+         "analysis aborts before the first time step"),
+        ("structural_dynamics",
+         "KeyError 'echo_level' from AnalysisStage.RunSolutionLoop",
+         "the real message is the C++ 'Error: Getting a value that does not exist. "
+         "entry string : echo_level'"),
+    ]
+
+    # A corrected pitfall is allowed — and encouraged — to QUOTE the falsified
+    # wording as provenance. What must never happen is the old wording standing
+    # on its own as a live claim. So: wherever a falsified phrase appears, the
+    # same pitfall string must also carry a supersession marker.
+    SUPERSESSION_MARKERS = ("was WRONG", "had it exactly backwards", "was stale",
+                            "prior catalog", "earlier catalog", "supersedes",
+                            "Re-verified", "re-verified")
+
+    def test_falsified_wordings_absent(self) -> None:
+        knowledge = _kratos_knowledge()
+        offenders = []
+        for physics, forbidden, why in self.FORBIDDEN:
+            for pitfall in knowledge[physics].get("pitfalls", []):
+                if forbidden not in pitfall:
+                    continue
+                if not any(m in pitfall for m in self.SUPERSESSION_MARKERS):
+                    offenders.append(
+                        f"{physics}: {forbidden!r} appears without a supersession "
+                        f"marker — execution showed: {why}")
+            # the phrase must not live outside the pitfalls either
+            rest = dict(knowledge[physics])
+            rest.pop("pitfalls", None)
+            if forbidden in _all_text(rest):
+                offenders.append(
+                    f"{physics}: {forbidden!r} present outside pitfalls — "
+                    f"execution showed: {why}")
+        self.assertEqual(offenders, [], "Falsified claim reintroduced:\n" + "\n".join(offenders))
+
+    def test_corrections_present(self) -> None:
+        knowledge = _kratos_knowledge()
+        required = [
+            # NOT "TEMPERATURE == 0.0 at EVERY node": that 2026-08-03 wording was
+            # itself falsified on 2026-08-03 (re-audit) (it recorded a DELTA_TIME = 0 artifact
+            # of its own fixture). The element-level statement is what survives.
+            ("poisson", "max T = 19.7392"),
+            ("poisson", "setting the RHS to zero"),
+            ("poisson", "nodal 999 + Properties 1 -> 999.0"),
+            ("structural_dynamics", "NOT silently ignored"),
+            ("structural_dynamics", "Getting a value that does not exist"),
+            ("structural_dynamics", "66.6% of the Timoshenko value"),
+            ("curved_mms", "REPRODUCED 2026-08-03"),
+        ]
+        missing = [f"{p}: {s!r}" for p, s in required
+                   if s not in _all_text(knowledge[p])]
+        self.assertEqual(missing, [], f"Verified correction missing: {missing}")
+
+    def test_structural_hyperelastic_names_are_not_mpm_only(self) -> None:
+        """HyperElasticNeoHookean* is registered by MPMApplication, not by
+        StructuralMechanicsApplication. Offering it as a structural law makes
+        Materials.json fail with 'Kratos components missing'. Proven 2026-08-03 (re-audit)
+        with only SMA + CLA imported: HasConstitutiveLaw is False and
+        KM.ReadMaterialsUtility raises."""
+        elast = _all_text(_kratos_knowledge()["linear_elasticity"]["constitutive_laws"])
+        self.assertIn("HyperElasticSimoTaylorNeoHookean3DLaw", elast)
+        self.assertIn("MPMApplication", elast,
+                      "the structural hyperelastic list must say that the "
+                      "HyperElasticNeoHookean* family comes from MPMApplication")
+        laws = _all_text(_kratos_knowledge()["constitutive_laws"]["laws"])
+        self.assertNotIn("HyperElasticQuasiIncompressibleNeoHookean3DLaw", laws,
+                         "not registered under ANY of the 26 importable "
+                         "applications on 10.4.0 (checked 2026-08-03 (re-audit))")
+
+
+class TestKratosConstitutiveLawNames(unittest.TestCase):
+    """Law names that resolve to nothing on the installed 10.4.0 must not be
+    listed as usable law names. Checked against the registry AND the Python
+    attributes by scripts/tier2_fixtures/kratos/constitutive_law_registry_names."""
+
+    # Bare tokens that do not resolve, with the registered name that does.
+    DEAD_NAMES = {
+        "LinearElasticAxisymmetric2DLaw": "LinearElasticAxisym2DLaw",
+        "HyperElasticIsotropicNeoHookean3DLaw": "HyperElasticNeoHookean3DLaw",
+        "HyperElasticIsotropicNeoHookean2D/3DLaw": "HyperElasticNeoHookean3DLaw",
+        "ThermalLinearElastic2DPlaneStrain": "ThermalLinearPlaneStrain",
+    }
+    # These appeared as standalone "laws" in KNOWLEDGE['constitutive_laws'].
+    DEAD_FAMILIES = ("Yeoh", "Arruda-Boyce", "Blatz-Ko", "Mazars", "Perzyna",
+                     "ModifiedCamClay", "CriticalStateLine", "RankineFragile",
+                     "DruckerPragerViscoplastic")
+
+    def test_dead_law_names_not_offered_as_usable(self) -> None:
+        knowledge = _kratos_knowledge()
+        offenders = []
+        for physics in ("linear_elasticity", "mpm", "constitutive_laws", "dam"):
+            laws = _all_text(knowledge[physics].get("constitutive_laws")
+                             or knowledge[physics].get("laws") or {})
+            for dead, live in self.DEAD_NAMES.items():
+                if dead in laws and live not in laws:
+                    offenders.append(f"{physics}: {dead!r} listed without {live!r}")
+        self.assertEqual(offenders, [], "\n".join(offenders))
+
+    def test_dead_families_removed_from_constitutive_laws(self) -> None:
+        laws = _all_text(_kratos_knowledge()["constitutive_laws"].get("laws", {}))
+        still = [f for f in self.DEAD_FAMILIES if f in laws]
+        self.assertEqual(
+            still, [],
+            f"KNOWLEDGE['constitutive_laws']['laws'] still offers {still} as law "
+            f"names; none of them resolves on Kratos 10.4.0 (neither as a registry "
+            f"string nor as a Python attribute).")
+
+    def test_corrected_law_names_are_offered(self) -> None:
+        knowledge = _kratos_knowledge()
+        elast = _all_text(knowledge["linear_elasticity"]["constitutive_laws"])
+        for name in ("LinearElasticAxisym2DLaw", "KirchhoffSaintVenant3DLaw",
+                     "ViscousGeneralizedMaxwell3D", "ViscousGeneralizedKelvin3D",
+                     "SmallStrainIsotropicDamageFactory"):
+            self.assertIn(name, elast)
+        mpm = _all_text(knowledge["mpm"]["constitutive_laws"])
+        for name in ("LinearElasticIsotropic3DLaw", "HenckyMCPlastic3DLaw",
+                     "JohnsonCookThermalPlastic3DLaw"):
+            self.assertIn(name, mpm)
+
+
+class TestSpartaVerifiedKnowledge(unittest.TestCase):
+    """SPARTA's knowledge was restructured from one flat JSON dump into
+    per-physics modules under src/backends/sparta/generators/, the shape every
+    FEM backend already uses. Two things must hold afterwards: the payload an
+    agent receives stays small, structured and free of host paths, and the
+    execution-verified claims keep being served."""
+
+    def _backend(self):
+        from core.registry import get_backend, load_all_backends
+        load_all_backends()
+        backend = get_backend("sparta")
+        self.assertIsNotNone(backend, "sparta backend not registered")
+        return backend
+
+    def _knowledge(self) -> dict:
+        return self._backend().get_knowledge("rarefied_flow")
+
+    def _kb_file(self) -> dict:
+        import json
+        return json.loads((_REPO / "src" / "backends" / "sparta"
+                           / "sparta_knowledge.json").read_text())
+
+    # ── payload shape ────────────────────────────────────────────────────
+    def test_knowledge_is_structured_not_a_manual_dump(self) -> None:
+        """The old payload was ~43 KB per physics, 27 KB of it a verbatim copy
+        of the SPARTA manual under 'relevant_commands'. That pushed the
+        pitfalls past the client-side truncation point, so half the knowledge
+        never reached the agent."""
+        backend = self._backend()
+        for cap in backend.supported_physics():
+            kn = backend.get_knowledge(cap.name)
+            self.assertNotIn("relevant_commands", kn,
+                             f"{cap.name}: the verbatim manual dump is back")
+            self.assertIn("key_commands", kn)
+            self.assertIn("deck_skeleton", kn)
+            self.assertIn("pitfalls", kn)
+            self.assertLess(
+                len(_all_text(kn)), 25_000,
+                f"{cap.name}: knowledge payload grew back past 25 KB")
+
+    def test_knowledge_carries_no_absolute_host_path(self) -> None:
+        """'installed_build' used to hard-code four absolute paths from the
+        machine the campaign ran on and served them for all ten physics."""
+        import re
+        host = re.compile(r"/home/[A-Za-z0-9_.-]+|/Users/[A-Za-z0-9_.-]+")
+        backend = self._backend()
+        for name in [c.name for c in backend.supported_physics()] + ["_general"]:
+            hits = host.findall(_all_text(backend.get_knowledge(name)))
+            self.assertEqual(hits, [], f"{name}: host paths leaked into knowledge")
+        build = self._kb_file()["installed_build"]
+        for key in ("distribution_root", "data_dir", "examples_dir"):
+            self.assertNotIn(key, build,
+                             f"sparta_knowledge.json['installed_build'] "
+                             f"re-added the host path key {key!r}")
+
+    def test_every_pitfall_carries_a_signal(self) -> None:
+        backend = self._backend()
+        missing = []
+        for cap in backend.supported_physics():
+            for i, pit in enumerate(backend.get_knowledge(cap.name)["pitfalls"]):
+                if "Signal:" not in str(pit):
+                    missing.append((cap.name, i))
+        self.assertEqual(missing, [], "pitfalls without an observable Signal:")
+
+    def test_every_physics_offers_an_executable_generator(self) -> None:
+        from backends.sparta.generators import GENERATORS
+        backend = self._backend()
+        for cap in backend.supported_physics():
+            self.assertTrue(cap.template_variants, f"{cap.name}: no variants")
+            for v in cap.template_variants:
+                self.assertIn(f"{cap.name}_{v}", GENERATORS)
+                deck = backend.generate_input(cap.name, v, {})
+                self.assertIn("run ", deck)
+                self.assertIn("seed ", deck)
+                self.assertIn("timestep ", deck,
+                              f"{cap.name}/{v}: no timestep line — SPARTA's "
+                              f"default dt is 1.0 s and the deck would hang")
+                self.assertEqual(backend.validate_input(deck), [],
+                                 f"{cap.name}/{v}: generated deck fails validation")
+
+    # ── the verbatim command index moved, it did not disappear ───────────
+    def test_command_surface_separates_commands_from_doc_pages(self) -> None:
+        surface = self._kb_file()["command_surface"]
+        self.assertEqual(surface["n_true_commands"], 66)
+        true_cmds = surface["true_commands"]
+        self.assertEqual(len(true_cmds), 66)
+        for real in ("create_box", "create_grid", "create_particles", "collide",
+                     "species", "mixture", "surf_collide", "surf_modify", "run",
+                     "stats", "stats_style", "dump", "fix", "compute"):
+            self.assertIn(real, true_cmds)
+        doc_only = surface["not_commands_doc_page_names_only"]
+        self.assertEqual(len(doc_only), 55)
+        for fake in ("compute_grid", "fix_ave_surf", "dump_image",
+                     "surf_react_adsorb", "suffix"):
+            self.assertIn(fake, doc_only)
+            self.assertNotIn(fake, true_cmds)
+
+    def test_command_reference_is_reachable_on_demand(self) -> None:
+        ref = self._backend().get_command_reference("compute_grid")
+        self.assertNotIn("error", ref)
+        self.assertEqual(ref["doc_page"], "compute_grid")
+        self.assertEqual(ref["command"], "compute grid")
+        self.assertIn("syntax", ref)
+
+    def test_installed_build_block_kept_its_style_inventory(self) -> None:
+        build = self._kb_file()["installed_build"]
+        self.assertEqual(build["version"], "24 Sep 2025")
+        self.assertEqual(build["compiled_styles"]["collide"], ["vss"])
+        self.assertIn("diffuse", build["compiled_styles"]["surf_collide"])
+        self.assertIn("kokkos_kk_styles", build["documented_but_absent_here"])
+        facts = self._knowledge()["build"] if "build" in self._knowledge() else {}
+        del facts  # served through knowledge(topic='overview'), see below
+        general = self._backend().get_knowledge("_general")
+        self.assertEqual(general["build"]["compiled_collide_styles"], ["vss"])
+        self.assertIn("KOKKOS", general["build"]["accelerators"])
+
+    # ── ordering / output knowledge survived the move ────────────────────
+    def test_setup_ordering_errors_are_served(self) -> None:
+        errs = self._knowledge()["hard_ordering_errors"]
+        self.assertIn("create_grid.cpp:44", errs["create_grid before create_box"])
+        self.assertIn("random_mars.cpp:91", errs["no seed command"])
+        general = self._backend().get_knowledge("_general")
+        self.assertIn("nrho = 1.0",
+                      general["silently_accepted"]["no global nrho/fnum"])
+
+    def test_output_reading_block(self) -> None:
+        out = self._knowledge()["output_idioms"]
+        self.assertIn("mode vector", out["boundary tally idiom"])
+        self.assertIn("VECTOR", out["vector vs array rule"])
+        general = self._backend().get_knowledge("_general")["reading_output"]
+        self.assertIn("reduce sum", general["per-surf tally idiom"])
+
+    # ── claims execution established, in their CORRECTED form ────────────
+    def test_verified_pitfalls_are_served_for_every_physics(self) -> None:
+        """These wordings replaced earlier ones that a critic pass falsified by
+        execution — see FORBIDDEN_SPARTA below for what they replaced."""
+        backend = self._backend()
+        markers = (
+            "silently overrides 'global nrho'",
+            "the z extent handed to create_box is ignored",
+            "no default timestep worth having",
+            "does NOT convert the species, VSS, reaction or surface files",
+        )
+        for cap in backend.supported_physics():
+            text = "\n".join(backend.get_knowledge(cap.name)["pitfalls"])
+            for marker in markers:
+                self.assertIn(marker, text,
+                              f"sparta physics {cap.name!r} lost the verified "
+                              f"pitfall {marker!r}")
+        surf = "\n".join(backend.get_knowledge("surface_interaction")["pitfalls"])
+        self.assertIn("reverses the normal velocity component", surf)
+
+    def test_falsified_sparta_wordings_stay_dead(self) -> None:
+        """Each string here was in the catalog and was disproved by running the
+        installed binary. None may come back."""
+        FORBIDDEN_SPARTA = [
+            ("rarefied_flow", "Omitting the collide command is NEVER an error",
+             "collide_modify, fix vibmode and react tce each abort with a hard "
+             "error when no collide style is defined"),
+            ("axisymmetric",
+             "Use 'global ... axisymmetric yes' and radial particle weighting",
+             "there is no such keyword: 'global axisymmetric yes' gives "
+             "'Illegal global command (../update.cpp:1805)'; axisymmetry is the "
+             "boundary letter 'a' on the lower y face"),
+            ("chemistry", "Reaction file format (tce/qk) must match the 'react' "
+             "style",
+             "'react qk <a tce file>' is accepted without error or warning and "
+             "fires reactions"),
+            ("surface_interaction",
+             "for conjugate heat transfer the wall T is updated each coupling "
+             "window",
+             "vague and untestable; replaced by the fix surf/temp ordering and "
+             "bracket rules, each with its own error string"),
+        ]
+        backend = self._backend()
+        for physics, forbidden, why in FORBIDDEN_SPARTA:
+            text = _all_text(backend.get_knowledge(physics))
+            self.assertNotIn(forbidden, text,
+                             f"sparta {physics}: falsified wording came back "
+                             f"({forbidden!r}) — execution showed: {why}")
+
+    def test_validate_input_rejects_doc_page_command_forms(self) -> None:
+        backend = self._backend()
+        preamble = ("seed 1\ndimension 2\nboundary p p p\n"
+                    "create_box 0 1 0 1 -0.5 0.5\ncreate_grid 2 2 1\n")
+        self.assertEqual(backend.validate_input(preamble + "run 10\n"), [])
+        for bad in ("compute_grid all all n", "fix_ave_surf all 1 1 1",
+                    "dump_image all 100 img.ppm", "suffix kk"):
+            errs = backend.validate_input(preamble + bad + "\nrun 10\n")
+            self.assertTrue(errs, f"validate_input accepted the doc-page form {bad!r}")
+
+    def test_validate_input_understands_line_continuations(self) -> None:
+        """SPARTA continues a command when the line ends in '&'. Without
+        joining, the continuation line's first word is read as a command and
+        every multi-line 'fix adapt' deck is falsely rejected."""
+        backend = self._backend()
+        deck = ("seed 1\ndimension 2\nboundary p p p\n"
+                "create_box 0 1 0 1 -0.5 0.5\ncreate_grid 2 2 1\n"
+                "fix ad adapt 100 all refine coarsen value c_x[2] 2.0 4.5 &\n"
+                "    combine min thresh less more cells 2 2 1\n"
+                "run 10\n")
+        self.assertEqual(backend.validate_input(deck), [])
+
+    def test_verified_running_lists_only_decks_that_exist(self) -> None:
+        """An entry belongs here only if examples/<name>/in.<name> exists.
+        'surf' and 'emit' both failed that test and were removed; the same
+        check must not silently regress."""
+        kb = self._kb_file()
+        for absent in ("surf", "emit", "adjust_temp"):
+            self.assertNotIn(
+                absent, kb["verified_running"],
+                f"examples/{absent}/ ships in.{absent}.* variants but no file "
+                f"called in.{absent}, so it could never have been executed "
+                f"as written.")
+        self.assertEqual(sorted(kb["verified_running"]),
+                         ["ambi", "axi", "chem", "circle", "collide", "free"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_instructions.py
+++ b/tests/test_mcp_instructions.py
@@ -2,11 +2,14 @@
 
 A client that truncates the server's instructions when folding them into the
 model's context dropped the mid-string MANDATORY CRITIC safety block. It now
-leads the string; these tests guard that it stays there, appears once, respects
-the ablation toggle, and only references tools that actually exist.
+leads the string; these tests guard that it stays there, appears exactly once,
+cannot be switched off, references only tools that actually exist, and tells the
+agent how to SATISFY the requirement — enforcement an agent is never told about
+would just make every run fail with nothing explaining why.
 """
 import functools
 import os
+import pathlib
 import subprocess
 import sys
 from pathlib import Path
@@ -16,8 +19,11 @@ SRC = str(Path(__file__).resolve().parent.parent / "src")
 
 @functools.lru_cache(maxsize=None)
 def _instructions(disable_critic: bool = False) -> str:
-    """Build the server's instructions in a subprocess so env toggles read at
-    import time (OFA_DISABLE_CRITIC) take effect. Cached so we import at most twice."""
+    """Build the server's instructions in a subprocess.
+
+    `disable_critic` sets the retired OFA_DISABLE_CRITIC variable, which must
+    now do nothing — see test_no_environment_toggle_removes_the_critic_block.
+    """
     env = dict(os.environ, PYTHONPATH=SRC)
     env.pop("OFA_DISABLE_CRITIC", None)
     if disable_critic:
@@ -44,10 +50,27 @@ def test_critic_block_appears_exactly_once():
     assert _instructions().count(_BLOCK) == 1
 
 
-def test_ablation_removes_critic_block():
+def test_no_environment_toggle_removes_the_critic_block():
+    """This test used to assert the opposite: that OFA_DISABLE_CRITIC stripped
+    the block. Both that toggle and the runtime bypass it paired with are gone,
+    so an evaluation cannot end up silently running without the requirement."""
     instr = _instructions(disable_critic=True)
-    assert instr.count(_BLOCK) == 0
-    assert "MANDATORY CRITIC" not in instr
+    assert instr.count(_BLOCK) == 1
+    assert "MANDATORY CRITIC" in instr
+
+
+def test_the_critic_block_tells_the_agent_how_to_satisfy_it():
+    """Enforcement the agent is not told about is just a failure mode: every
+    run would come back NOT VERIFIED and nothing would say why."""
+    instr = _instructions()
+    assert "submit_critic_review" in instr
+    assert "does NOT" in instr and "critic_approved=True" in instr
+
+
+def test_the_instructions_offer_the_residual_check_and_computed_numbers():
+    instr = _instructions()
+    assert "verify_pde" in instr          # prove the output solves the problem
+    assert "oasis_computed" in instr      # report OASiS's numbers, not your own
 
 
 def test_critic_block_references_only_real_tools():
@@ -108,3 +131,53 @@ def test_coupling_tools_expose_critic_approved():
     schemas = _registered_tools()
     for name in ("couple", "couple_precice"):
         assert "critic_approved" in schemas[name].get("properties", {})
+def test_every_critic_gated_tool_actually_RESOLVES_the_critic():
+    """A declared parameter that decides nothing is worse than no parameter.
+
+    An audit found `coupled_solve` accepting `critic_approved` and never
+    referencing it, so an unreviewed run was indistinguishable from a reviewed
+    one — while the schema test above passed, because it only checked that the
+    parameter EXISTS. Declaring the gate is not enforcing it.
+
+    Reading the flag is no longer the bar either, and this test used to check
+    exactly that. `critic_approved` is a self-report; OASiS now resolves the
+    critic from its own review record. So the requirement is that a gated tool
+    LOOKS THE REVIEW UP: either by calling `_critic_state` itself, or by handing
+    `_stamp_verification` the `solver` and `setup_text` it needs to do so. A
+    tool that does neither cannot know whether its setup was reviewed, whatever
+    it does with the flag.
+    """
+    import ast
+    src = pathlib.Path(__file__).resolve().parents[1] / "src" / "tools" / "consolidated.py"
+    tree = ast.parse(src.read_text())
+
+    def resolves_critic(node) -> bool:
+        for n in ast.walk(node):
+            if not isinstance(n, ast.Call):
+                continue
+            fn = n.func
+            name = getattr(fn, "id", None) or getattr(fn, "attr", None)
+            if name == "_critic_state":
+                return True
+            if name == "_stamp_verification":
+                kws = {k.arg for k in n.keywords}
+                if {"solver", "setup_text"} <= kws:
+                    return True
+        return False
+
+    unenforced = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name == "_stamp_verification":
+            continue                      # the gate itself, not a gated tool
+        params = [a.arg for a in (*node.args.args, *node.args.kwonlyargs)]
+        if "critic_approved" not in params:
+            continue
+        if not resolves_critic(node):
+            unenforced.append(node.name)
+
+    assert not unenforced, (
+        "these tools are critic-gated but never look up whether their setup "
+        "was reviewed, so the requirement is unenforced for them: "
+        + ", ".join(unenforced))

--- a/tests/test_mcp_stdio.py
+++ b/tests/test_mcp_stdio.py
@@ -196,10 +196,10 @@ def test_run_simulation_skfem_poisson_round_trip(tmp_path):
                 "solver": "skfem",
                 "input_content": script,
                 "job_name": "mcp_stdio_smoke_skfem_poisson",
-                # critic_approved=True bypasses the in-tool reminder
-                # that an independent critic should pre-approve real
-                # simulations — fine here because the script is a
-                # fixed smoke probe, not a research run.
+                # Passed to exercise the parameter, not to obtain a verdict:
+                # the flag no longer verifies anything on its own, and this
+                # test asserts only that the run completed and produced an
+                # artefact. A VERIFIED stamp would need submit_critic_review.
                 "critic_approved": True,
             },
         ))

--- a/tests/test_mcp_tool_docstring_dispatch.py
+++ b/tests/test_mcp_tool_docstring_dispatch.py
@@ -83,20 +83,60 @@ def _docstring_bullets(func, param_name: str) -> set[str]:
     return set(re.findall(r'-\s+"([^"]+)"', text))
 
 
-def _dispatch_string_constants(func, param_name: str) -> set[str]:
-    """Walk the function body looking for `<param> == "X"`
-    comparisons. Returns the set of X-values."""
+def _module_string_sets(tree) -> dict[str, set[str]]:
+    """Module-level names bound to a set/frozenset of string literals.
+
+    A dispatch branch may legitimately be written `topic in _SOME_ALIASES`
+    rather than `topic == "x"`, when one branch answers to several spellings.
+    Without this the drift check would report the branch as undispatched and
+    push the author to either delete the aliases or stop documenting the
+    topic — both worse than the thing the check exists to prevent."""
+    out: dict[str, set[str]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        value = node.value
+        # frozenset({...}) / set({...}) wrapper, or a bare set literal.
+        if (isinstance(value, ast.Call) and isinstance(value.func, ast.Name)
+                and value.func.id in ("frozenset", "set") and value.args):
+            value = value.args[0]
+        if isinstance(value, (ast.Set, ast.List, ast.Tuple)):
+            items = {e.value for e in value.elts
+                     if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+            if items:
+                out[target.id] = items
+    return out
+
+
+def _dispatch_string_constants(func, param_name: str,
+                               string_sets: dict[str, set[str]] | None = None
+                               ) -> set[str]:
+    """Walk the function body looking for `<param> == "X"` comparisons and
+    `<param> in <NAME>` membership tests against a module-level set of string
+    literals. Returns the set of X-values either form can select."""
+    string_sets = string_sets or {}
     out: set[str] = set()
     for inner in ast.walk(func):
-        if isinstance(inner, ast.Compare):
-            left = inner.left
-            if (isinstance(left, ast.Name) and left.id == param_name
-                    and len(inner.ops) == 1
-                    and isinstance(inner.ops[0], ast.Eq)
-                    and len(inner.comparators) == 1):
-                cmp = inner.comparators[0]
-                if isinstance(cmp, ast.Constant) and isinstance(cmp.value, str):
-                    out.add(cmp.value)
+        if not isinstance(inner, ast.Compare):
+            continue
+        left = inner.left
+        if not (isinstance(left, ast.Name) and left.id == param_name
+                and len(inner.ops) == 1 and len(inner.comparators) == 1):
+            continue
+        op, cmp = inner.ops[0], inner.comparators[0]
+        if isinstance(op, ast.Eq):
+            if isinstance(cmp, ast.Constant) and isinstance(cmp.value, str):
+                out.add(cmp.value)
+        elif isinstance(op, ast.In):
+            if isinstance(cmp, ast.Name) and cmp.id in string_sets:
+                out |= string_sets[cmp.id]
+            elif isinstance(cmp, (ast.Set, ast.List, ast.Tuple)):
+                out |= {e.value for e in cmp.elts
+                        if isinstance(e, ast.Constant)
+                        and isinstance(e.value, str)}
     return out
 
 
@@ -105,20 +145,49 @@ class TestMcpToolDocstringDispatch(unittest.TestCase):
     def setUpClass(cls) -> None:
         src = (_REPO / "src" / "tools" / "consolidated.py").read_text()
         cls.tree = ast.parse(src)
+        cls.string_sets = _module_string_sets(cls.tree)
 
     def _check(self, tool_name: str, param_name: str) -> None:
         func = _find_tool_function(self.tree, tool_name)
         documented = _docstring_bullets(func, param_name)
-        dispatched = _dispatch_string_constants(func, param_name)
-        self.assertEqual(
-            documented, dispatched,
-            f"{tool_name}({param_name}=...) docstring drifted from "
-            "dispatch chain.\n"
-            f"  documented: {sorted(documented)}\n"
-            f"  dispatched: {sorted(dispatched)}\n"
-            f"  diff:       {sorted(documented ^ dispatched)}\n"
+        dispatched = _dispatch_string_constants(func, param_name,
+                                                self.string_sets)
+        # BOTH directions still matter, but aliases are handled asymmetrically.
+        #
+        # A DOCUMENTED value with no branch is a lie to the caller — always a
+        # failure. A DISPATCHED value with no docstring bullet is normally a
+        # feature nobody can find, so it fails too; the exception is a member
+        # of an alias set, where the docstring names the canonical spelling and
+        # the synonyms exist so a caller who guesses a near-miss still lands on
+        # the right branch. Requiring every synonym its own bullet would make
+        # the docstring worse, not better.
+        aliases = set().union(*self.string_sets.values()) if self.string_sets \
+            else set()
+        undispatched = documented - dispatched
+        undocumented = dispatched - documented - aliases
+        self.assertFalse(
+            undispatched,
+            f"{tool_name}({param_name}=...) documents a value the dispatch "
+            f"chain does not handle.\n"
+            f"  documented but not dispatched: {sorted(undispatched)}\n"
             "Edit src/tools/consolidated.py docstring + dispatch "
             "in lock-step.")
+        self.assertFalse(
+            undocumented,
+            f"{tool_name}({param_name}=...) dispatches a value the docstring "
+            f"never mentions — callers cannot discover it.\n"
+            f"  dispatched but not documented: {sorted(undocumented)}\n"
+            "Edit src/tools/consolidated.py docstring + dispatch "
+            "in lock-step.")
+        # The canonical spelling of an alias group must still be documented,
+        # or the whole group is undiscoverable.
+        for name, members in self.string_sets.items():
+            if members & dispatched and not (members & documented):
+                self.fail(
+                    f"{tool_name}({param_name}=...) dispatches the alias group "
+                    f"{name} but the docstring documents none of its "
+                    f"spellings {sorted(members)} — the branch is "
+                    f"unreachable by anyone reading the docs.")
 
     def test_discover_query(self) -> None:
         self._check("discover", "query")

--- a/tests/test_mesh_independence.py
+++ b/tests/test_mesh_independence.py
@@ -1,0 +1,611 @@
+"""Tests for the automated mesh-independence study (verify_mesh_independence).
+
+MMS convergence tests require a manufactured exact solution; application
+problems have none, so the established recourse is the heuristic
+mesh-refinement study: halve the discretisation length and accept the
+solution only once global norms AND values at selected points stop
+changing materially. src/core/mesh_independence.py implements the
+comparison/verdict arithmetic; the verify_mesh_independence MCP tool
+drives the re-runs through the normal backend layer.
+
+Covered here:
+  * template instantiation (placeholder substitution, refinement ladder)
+  * the volume-weighted global L2 norm (constant-field exactness,
+    refinement invariance, cell-family coverage, RMS fallback)
+  * probe selection/interpolation and the near-zero probe floor
+  * compare_levels verdict logic — including the NOT-converged path
+  * end-to-end: the actual MCP tool runs a real scikit-fem problem at
+    two resolutions and returns a verdict (converged AND not-converged),
+    with the verification-gate stamp wired to the study outcome.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+from core import mesh_independence as mi  # noqa: E402
+
+
+def _quad_mesh(n: int):
+    """Uniform n x n quad mesh of the unit square: (points, connectivity)."""
+    xs = np.linspace(0.0, 1.0, n + 1)
+    X, Y = np.meshgrid(xs, xs, indexing="ij")
+    pts = np.column_stack([X.ravel(), Y.ravel()])
+    conn = []
+    for i in range(n):
+        for j in range(n):
+            a = i * (n + 1) + j
+            conn.append([a, a + n + 1, a + n + 2, a + 1])
+    return pts, np.array(conn)
+
+
+def _tet_mesh_unit_cube(n: int):
+    """Unit cube split into n^3 hex cells, each into 5 tets."""
+    xs = np.linspace(0.0, 1.0, n + 1)
+    X, Y, Z = np.meshgrid(xs, xs, xs, indexing="ij")
+    pts = np.column_stack([X.ravel(), Y.ravel(), Z.ravel()])
+
+    def nid(i, j, k):
+        return (i * (n + 1) + j) * (n + 1) + k
+
+    tets = []
+    for i in range(n):
+        for j in range(n):
+            for k in range(n):
+                # VTK hexahedron corner ordering
+                v = [nid(i, j, k), nid(i + 1, j, k),
+                     nid(i + 1, j + 1, k), nid(i, j + 1, k),
+                     nid(i, j, k + 1), nid(i + 1, j, k + 1),
+                     nid(i + 1, j + 1, k + 1), nid(i, j + 1, k + 1)]
+                for a, b, c, d in [(0, 1, 3, 4), (1, 2, 3, 6), (1, 3, 4, 6),
+                                   (1, 4, 5, 6), (3, 4, 6, 7)]:
+                    tets.append([v[a], v[b], v[c], v[d]])
+    return pts, np.array(tets)
+
+
+# ── template instantiation ───────────────────────────────────────────────
+
+
+class TestSubstitution(unittest.TestCase):
+
+    def test_replaces_every_occurrence(self):
+        out = mi.substitute_resolution(
+            "nx = __RESOLUTION__\nny = __RESOLUTION__\n", 16)
+        self.assertEqual(out, "nx = 16\nny = 16\n")
+
+    def test_integer_valued_floats_render_as_int(self):
+        # MCP delivers `resolution` as float; `nx = 16.0` must not appear
+        # where an element count is expected.
+        self.assertEqual(mi.format_resolution(16.0), "16")
+        self.assertEqual(mi.format_resolution(0.05), "0.05")
+
+    def test_missing_token_raises(self):
+        # Without the placeholder the study would re-run the identical
+        # script and fake a converged verdict — must refuse loudly.
+        with self.assertRaises(ValueError):
+            mi.substitute_resolution("nx = 16", 32)
+
+
+class TestRefinementLadder(unittest.TestCase):
+
+    def test_divisions_multiply(self):
+        self.assertEqual(mi.refinement_resolutions(16, 2.0, 2), [16, 32, 64])
+
+    def test_size_divides(self):
+        self.assertEqual(
+            mi.refinement_resolutions(0.1, 2.0, 1, "size"), [0.1, 0.05])
+
+    def test_at_least_one_refinement_required(self):
+        with self.assertRaises(ValueError):
+            mi.refinement_resolutions(16, 2.0, 0)
+
+    def test_factor_must_refine(self):
+        with self.assertRaises(ValueError):
+            mi.refinement_resolutions(16, 1.0, 1)
+
+    def test_zero_and_negative_base_rejected_in_both_kinds(self):
+        # Copilot review (PR #49): resolution=0 / negative silently
+        # produced an invalid ladder ([0, 0, ...]) that only failed later
+        # in solver-specific ways.
+        for kind in ("divisions", "size"):
+            for bad in (0, -8, -0.1):
+                with self.assertRaises(ValueError, msg=f"{kind}, {bad}"):
+                    mi.refinement_resolutions(bad, 2.0, 1, kind)
+
+    def test_fractional_divisions_base_rejected_but_valid_size_accepted(self):
+        # divisions must count at least one element ...
+        with self.assertRaises(ValueError):
+            mi.refinement_resolutions(0.5, 2.0, 1, "divisions")
+        # ... while the same value is a perfectly good element SIZE.
+        self.assertEqual(
+            mi.refinement_resolutions(0.5, 2.0, 1, "size"), [0.5, 0.25])
+
+    def test_non_numeric_base_rejected(self):
+        with self.assertRaises(ValueError):
+            mi.refinement_resolutions("coarse", 2.0, 1)
+
+
+# ── global norm ──────────────────────────────────────────────────────────
+
+
+class TestGlobalL2(unittest.TestCase):
+
+    def test_constant_field_on_unit_square_is_exact(self):
+        pts, conn = _quad_mesh(8)
+        u = np.full(len(pts), 3.0)
+        norm, kind = mi.compute_global_l2(pts, [("quad", conn)], u)
+        self.assertEqual(kind, "volume_weighted_l2")
+        self.assertAlmostEqual(norm, 3.0, places=12)
+
+    def test_norm_is_unnormalised_l2_scaling_with_domain_measure(self):
+        # Documented semantics (Copilot review, PR #49): the value is the
+        # UNNORMALISED ||u||_L2 = sqrt(int |u|^2 dOmega), so a constant
+        # field c on a domain of measure V gives c*sqrt(V) — not a
+        # volume-normalised RMS. On a 2x2 square (V=4): 3*sqrt(4)=6.
+        pts, conn = _quad_mesh(8)
+        norm, _ = mi.compute_global_l2(
+            2.0 * pts, [("quad", conn)], np.full(len(pts), 3.0))
+        self.assertAlmostEqual(norm, 6.0, places=12)
+
+    def test_refinement_invariance_smooth_field(self):
+        # The SAME smooth field sampled on two refinements must give nearly
+        # the same norm — that is the property the comparison relies on.
+        norms = []
+        for n in (8, 16):
+            pts, conn = _quad_mesh(n)
+            u = np.sin(np.pi * pts[:, 0]) * np.sin(np.pi * pts[:, 1])
+            norm, _ = mi.compute_global_l2(pts, [("quad", conn)], u)
+            norms.append(norm)
+        self.assertLess(abs(norms[1] - norms[0]) / norms[1], 5e-3)
+
+    def test_constant_field_on_unit_cube_tets(self):
+        pts, tets = _tet_mesh_unit_cube(2)
+        u = np.full(len(pts), 2.0)
+        norm, kind = mi.compute_global_l2(pts, [("tetra", tets)], u)
+        self.assertEqual(kind, "volume_weighted_l2")
+        self.assertAlmostEqual(norm, 2.0, places=10)
+
+    def test_vector_field_uses_magnitude(self):
+        pts, conn = _quad_mesh(4)
+        u = np.tile([3.0, 4.0], (len(pts), 1))  # |u| = 5 everywhere
+        norm, _ = mi.compute_global_l2(pts, [("quad", conn)], u)
+        self.assertAlmostEqual(norm, 5.0, places=12)
+
+    def test_rms_fallback_without_supported_cells(self):
+        pts = np.random.default_rng(0).random((10, 3))
+        u = np.full(10, 4.0)
+        norm, kind = mi.compute_global_l2(pts, [], u)
+        self.assertEqual(kind, "rms_point")
+        self.assertAlmostEqual(norm, 4.0, places=12)
+
+    def test_surface_blocks_in_volume_mesh_are_ignored(self):
+        # A 3-D result that also carries boundary triangles must integrate
+        # over the volume only.
+        pts, tets = _tet_mesh_unit_cube(2)
+        bogus_tris = tets[:4, :3]
+        u = np.full(len(pts), 2.0)
+        norm, _ = mi.compute_global_l2(
+            pts, [("triangle", bogus_tris), ("tetra", tets)], u)
+        self.assertAlmostEqual(norm, 2.0, places=10)
+
+
+# ── probes ───────────────────────────────────────────────────────────────
+
+
+class TestProbes(unittest.TestCase):
+
+    def test_default_probes_lie_in_bbox_and_include_hotspot(self):
+        pts, _ = _quad_mesh(8)
+        u = np.exp(-((pts[:, 0] - 0.75) ** 2 + (pts[:, 1] - 0.25) ** 2) / 0.01)
+        probes = mi.default_probe_points(pts, u)
+        self.assertGreaterEqual(len(probes), 3)
+        hot = pts[int(np.argmax(u))]
+        self.assertTrue(np.allclose(probes[0][:2], hot, atol=1e-12))
+        for p in probes:
+            self.assertTrue(0.0 <= p[0] <= 1.0 and 0.0 <= p[1] <= 1.0)
+
+    def test_probe_interpolation_reproduces_linear_field(self):
+        pts, _ = _quad_mesh(8)
+        u = 2.0 * pts[:, 0] + 3.0 * pts[:, 1]
+        vals = mi.probe_field(pts, u, [[0.5, 0.5], [0.25, 0.75]])
+        self.assertAlmostEqual(vals[0], 2.5, places=10)
+        self.assertAlmostEqual(vals[1], 2.75, places=10)
+
+    def test_n_extra_beyond_two_is_honored(self):
+        # Copilot review (PR #49): n_extra > 2 used to be silently capped
+        # at the fixed (0.35, 0.65) pair.
+        pts, _ = _quad_mesh(8)
+        probes = mi.default_probe_points(pts, values=None, n_extra=4)
+        # centre + 4 distinct interior points, all inside the bbox
+        self.assertEqual(len(probes), 5)
+        for p in probes:
+            self.assertTrue(0.0 <= p[0] <= 1.0 and 0.0 <= p[1] <= 1.0)
+        keys = {tuple(np.round(p, 9)) for p in probes}
+        self.assertEqual(len(keys), 5)
+        # the historical first two interior positions are preserved
+        self.assertEqual(mi._interior_fractions(4)[:2], [0.35, 0.65])
+        # default behaviour (n_extra=2) unchanged
+        self.assertEqual(mi._interior_fractions(2), [0.35, 0.65])
+
+
+# ── comparison + verdict ─────────────────────────────────────────────────
+
+
+def _level(res, l2, gmax, probes, qoi=None):
+    d = {"resolution": res, "global_l2": l2, "global_max": gmax,
+         "probe_values": probes}
+    if qoi is not None:
+        d["qoi"] = qoi
+    return d
+
+
+class TestCompareLevels(unittest.TestCase):
+
+    def test_converged_when_all_changes_below_threshold(self):
+        c = mi.compare_levels(
+            [_level(8, 1.000, 2.000, [0.500, 1.900]),
+             _level(16, 1.005, 2.004, [0.502, 1.905])], rel_tol=0.01)
+        self.assertTrue(c["converged"])
+        self.assertIn("CONVERGED", c["verdict"])
+        self.assertEqual(c["failures"], [])
+        self.assertEqual(len(c["steps"]), 1)
+
+    def test_not_converged_names_the_failing_probe(self):
+        c = mi.compare_levels(
+            [_level(8, 1.000, 2.000, [0.50, 1.90]),
+             _level(16, 1.002, 2.002, [0.60, 1.905])], rel_tol=0.01)
+        self.assertFalse(c["converged"])
+        self.assertIn("NOT CONVERGED", c["verdict"])
+        self.assertTrue(any("probe 0" in f for f in c["failures"]))
+
+    def test_not_converged_on_global_norm_alone(self):
+        # Probes agreeing while the global norm drifts must still fail —
+        # BOTH criteria are required.
+        c = mi.compare_levels(
+            [_level(8, 1.00, 2.000, [0.500]),
+             _level(16, 1.10, 2.001, [0.5001])], rel_tol=0.01)
+        self.assertFalse(c["converged"])
+        self.assertTrue(any("L2" in f for f in c["failures"]))
+
+    def test_verdict_uses_finest_step_only(self):
+        # Large early change, small final change → the customary rule
+        # accepts on the LAST halving.
+        c = mi.compare_levels(
+            [_level(8, 1.00, 2.00, [0.5]),
+             _level(16, 1.20, 2.30, [0.6]),
+             _level(32, 1.201, 2.301, [0.6005])], rel_tol=0.01)
+        self.assertTrue(c["converged"])
+        self.assertEqual(len(c["steps"]), 2)
+
+    def test_near_zero_probe_does_not_produce_spurious_failure(self):
+        # A probe in a dead region of the field: 1e-9 → 3e-9 is a 200%
+        # naive relative change, but physically nothing moved (field scale
+        # is 2.0). The floor = 1% of global max must absorb it.
+        c = mi.compare_levels(
+            [_level(8, 1.000, 2.000, [1e-9]),
+             _level(16, 1.001, 2.001, [3e-9])], rel_tol=0.01)
+        self.assertTrue(c["converged"])
+
+    def test_qoi_from_summary_is_monitored(self):
+        c = mi.compare_levels(
+            [_level(8, 1.000, 2.000, [0.5], qoi={"tip_deflection": 1.00}),
+             _level(16, 1.001, 2.001, [0.5], qoi={"tip_deflection": 1.10})],
+            rel_tol=0.01)
+        self.assertFalse(c["converged"])
+        self.assertTrue(any("tip_deflection" in f for f in c["failures"]))
+
+    def test_two_levels_required(self):
+        with self.assertRaises(ValueError):
+            mi.compare_levels([_level(8, 1.0, 2.0, [0.5])])
+
+
+class TestCollectQoi(unittest.TestCase):
+
+    def test_flattens_scalars_and_skips_nonfinite(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "results_summary.json").write_text(json.dumps({
+                "max_temperature": 400.0,
+                "nested": {"flux": 1.5},
+                "label": "steel",           # non-numeric: skipped
+                "bad": float("nan"),        # non-finite: skipped
+                "per_node": [1, 2, 3],      # array: skipped
+            }))
+            qoi = mi.collect_qoi_scalars(td)
+        self.assertEqual(qoi, {"max_temperature": 400.0, "nested.flux": 1.5})
+
+    def test_missing_summary_gives_empty(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(mi.collect_qoi_scalars(td), {})
+
+    def test_discretisation_descriptors_are_not_qois(self):
+        # Live agent-validation finding (qwen campaign, scenario S1): a
+        # summary carrying resolution/ndofs made the verdict fail on
+        # "QoI 'ndofs' changed 74.61%" although every physical quantity
+        # had settled. Descriptors that change under refinement BY
+        # CONSTRUCTION must never be monitored.
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "results_summary.json").write_text(json.dumps({
+                "max_T": 2.69, "l2_norm": 2.15,          # physical QoIs
+                "resolution": 32, "ndofs": 4225,          # descriptors
+                "n_elements": 2048, "wall_time": 0.56,
+                "mesh": {"n_cells": 2048, "nx": 32},
+            }))
+            qoi = mi.collect_qoi_scalars(td)
+        self.assertEqual(set(qoi), {"max_T", "l2_norm"})
+
+    def test_descriptor_qois_do_not_flip_the_verdict(self):
+        # End-to-end on the comparison: physical quantities settled while
+        # the descriptor entries differ wildly between the levels' summary
+        # files -> still CONVERGED, because collect_qoi_scalars filtered
+        # the descriptors out.
+        import tempfile
+        levels = []
+        for res, ndofs in ((32, 4225), (64, 16641)):
+            with tempfile.TemporaryDirectory() as td:
+                (Path(td) / "results_summary.json").write_text(json.dumps({
+                    "max_T": 2.6944, "resolution": res, "ndofs": ndofs}))
+                qoi = mi.collect_qoi_scalars(td)
+            levels.append(_level(res, 2.1518, 2.6944, [2.4135], qoi=qoi))
+        c = mi.compare_levels(levels, rel_tol=0.01)
+        self.assertTrue(c["converged"], c)
+
+
+class TestExtractLevelMetrics(unittest.TestCase):
+
+    def _write_vtu(self, td: Path, field="u", values=None):
+        import meshio
+        pts, conn = _quad_mesh(4)
+        u = values if values is not None else pts[:, 0] * pts[:, 1]
+        path = td / "result.vtu"
+        meshio.Mesh(np.column_stack([pts, np.zeros(len(pts))]),
+                    [("quad", conn)], point_data={field: u}).write(str(path))
+        return path
+
+    def test_reads_field_and_probes(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_vtu(Path(td))
+            m = mi.extract_level_metrics(path, field="u")
+        self.assertEqual(m["field"], "u")
+        self.assertEqual(m["norm_type"], "volume_weighted_l2")
+        self.assertEqual(len(m["probe_points"]), len(m["probe_values"]))
+        self.assertTrue(np.isfinite(m["global_l2"]))
+
+    def test_missing_field_raises_with_available_names(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_vtu(Path(td))
+            with self.assertRaises(ValueError) as cm:
+                mi.extract_level_metrics(path, field="temperature")
+        self.assertIn("u", str(cm.exception))
+
+    def test_auto_selection_skips_vtk_metadata_arrays(self):
+        # dolfinx VTKFile writes vtkOriginalPointIds/vtkGhostType alongside
+        # the field; auto-selection must never monitor those.
+        import meshio
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            pts, conn = _quad_mesh(4)
+            path = Path(td) / "result.vtu"
+            meshio.Mesh(
+                np.column_stack([pts, np.zeros(len(pts))]), [("quad", conn)],
+                point_data={
+                    "vtkGhostType": np.zeros(len(pts)),
+                    "z_temperature": pts[:, 0],
+                }).write(str(path))
+            m = mi.extract_level_metrics(path)
+        self.assertEqual(m["field"], "z_temperature")
+
+    def test_pyvista_fallback_reader_matches_meshio(self):
+        # dolfinx's VTKFile emits VTU 2.2 with Lagrange cells, which meshio
+        # rejects; the pyvista fallback must deliver the same geometry and
+        # data for a file BOTH can read.
+        try:
+            import pyvista  # noqa: F401
+        except ImportError:
+            self.skipTest("pyvista not installed")
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_vtu(Path(td))
+            pts_a, cells_a, pdata_a = mi.read_nodal_mesh(path)
+            pts_b, cells_b, pdata_b = mi._read_with_pyvista(path)
+        self.assertEqual(pts_a.shape[0], pts_b.shape[0])
+        self.assertIn("u", pdata_b)
+        np.testing.assert_allclose(np.sort(pdata_a["u"]),
+                                   np.sort(pdata_b["u"]), rtol=1e-12)
+        fam_b, conn_b = cells_b[0]
+        self.assertEqual(fam_b, "quad")
+        self.assertEqual(conn_b.shape[1], 4)
+        norm_a, _ = mi.compute_global_l2(pts_a, cells_a, pdata_a["u"])
+        norm_b, _ = mi.compute_global_l2(pts_b, cells_b, pdata_b["u"])
+        self.assertAlmostEqual(norm_a, norm_b, places=12)
+
+    def test_nonfinite_field_is_rejected(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            pts, _ = _quad_mesh(4)
+            bad = np.full(len(pts), np.nan)
+            path = self._write_vtu(Path(td), values=bad)
+            with self.assertRaises(ValueError):
+                mi.extract_level_metrics(path, field="u")
+
+
+# ── end-to-end through the real MCP tool on a real backend ───────────────
+
+
+class _StubMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self, *args, **kwargs):
+        def deco(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+        return deco
+
+    def resource(self, *args, **kwargs):
+        def deco(fn):
+            return fn
+        return deco
+
+    def prompt(self, *args, **kwargs):
+        def deco(fn):
+            return fn
+        return deco
+
+
+# Test-problem template: Poisson with a peaked interior source on the unit
+# square — no closed-form solution, the mesh-independence use case. The
+# discretisation parameter is the __RESOLUTION__ placeholder (repo rule:
+# templates carry placeholders, never hard-coded discretisations).
+_SKFEM_TEMPLATE = '''"""Poisson, peaked interior source, homogeneous Dirichlet."""
+import numpy as np
+import meshio
+from skfem import MeshTri, ElementTriP1, Basis, asm, solve, condense, LinearForm
+from skfem.models.poisson import laplace
+
+n = __RESOLUTION__
+m = MeshTri.init_tensor(np.linspace(0.0, 1.0, n + 1),
+                        np.linspace(0.0, 1.0, n + 1))
+basis = Basis(m, ElementTriP1())
+
+
+@LinearForm
+def load(v, w):
+    x, y = w.x
+    return np.exp(-((x - 0.6) ** 2 + (y - 0.4) ** 2) / 0.02) * v
+
+
+K = asm(laplace, basis)
+f = asm(load, basis)
+D = basis.get_dofs().flatten()
+u = solve(*condense(K, f, D=D))
+meshio.Mesh(np.column_stack([m.p.T, np.zeros(m.p.shape[1])]),
+            [("triangle", m.t.T)], point_data={"u": u}).write("result.vtu")
+'''
+
+
+class TestVerifyMeshIndependenceE2E(unittest.TestCase):
+    """Drive the ACTUAL tool against the scikit-fem backend."""
+
+    @classmethod
+    def setUpClass(cls):
+        from core.registry import load_all_backends, get_backend
+        from tools.consolidated import register_consolidated_tools
+        load_all_backends()
+        backend = get_backend("skfem")
+        status, msg = backend.check_availability()
+        if status.value != "available":
+            raise unittest.SkipTest(f"skfem not available: {msg}")
+        stub = _StubMCP()
+        register_consolidated_tools(stub)
+        cls.tool = staticmethod(stub.tools["verify_mesh_independence"])
+        cls.submit_review = staticmethod(stub.tools["submit_critic_review"])
+
+    def _run(self, **kw):
+        out = asyncio.run(self.tool(**kw))
+        return json.loads(out)
+
+    def _review(self, solver, template):
+        """Put a critic review of this template on record.
+
+        `critic_approved=True` alone no longer verifies anything: OASiS looks
+        the review up on the server rather than trusting the flag, so a test
+        that wants a VERIFIED verdict has to do what a real agent does.
+        """
+        out = json.loads(asyncio.run(self.submit_review(
+            solver=solver, setup=template,
+            findings="Checked the manufactured problem, the boundary "
+                     "conditions, the element choice and the refinement "
+                     "sequence; the discretisation is adequate and the "
+                     "units are consistent.")))
+        self.assertTrue(out["accepted"], out)
+
+    def test_registered_with_critic_approved(self):
+        import inspect
+        params = inspect.signature(self.tool).parameters
+        self.assertIn("critic_approved", params)
+        self.assertIn("rel_tol", params)
+
+    def test_resolved_problem_converges(self):
+        self._review("skfem", _SKFEM_TEMPLATE)
+        d = self._run(solver="skfem", input_template=_SKFEM_TEMPLATE,
+                      resolution=32, job_name="test_meshcheck_converged",
+                      critic_approved=True)
+        self.assertEqual(d["status"], "completed")
+        self.assertTrue(d["converged"], d)
+        self.assertIn("CONVERGED", d["verdict"])
+        self.assertEqual(len(d["levels"]), 2)
+        self.assertEqual([lv["resolution"] for lv in d["levels"]], [32, 64])
+        step = d["refinement_steps"][0]
+        self.assertLess(step["global_l2_rel_change"], 0.01)
+        self.assertLess(max(step["probe_rel_changes"]), 0.01)
+        # the study passed AND the critic approved → verified result
+        self.assertTrue(d["trustworthy_result"])
+
+    def test_underresolved_problem_is_not_converged(self):
+        d = self._run(solver="skfem", input_template=_SKFEM_TEMPLATE,
+                      resolution=3, job_name="test_meshcheck_notconverged",
+                      critic_approved=True)
+        self.assertEqual(d["status"], "completed")
+        self.assertFalse(d["converged"], d)
+        self.assertIn("NOT CONVERGED", d["verdict"])
+        self.assertTrue(d["failures"])
+        # gate: a mesh-dependent solution is never a trustworthy result
+        self.assertFalse(d["trustworthy_result"])
+        self.assertIn("NOT VERIFIED", d["verification"])
+
+    def test_directory_named_like_result_file_is_ignored(self):
+        # Live agent-validation finding (qwen campaign, scenario S1):
+        # dolfinx VTXWriter emits a DIRECTORY named *.vtu; the level's
+        # result-file pick must skip directories or the study dies on
+        # "unreadable by meshio: Is a directory". The decoy's stem ends in
+        # a digit so sorted_by_step would rank it LAST (i.e. pick it)
+        # if directories were not filtered out.
+        template = _SKFEM_TEMPLATE.replace(
+            'point_data={"u": u}).write("result.vtu")',
+            'point_data={"u": u}).write("result.vtu")\n'
+            'import os\nos.makedirs("zzz9.vtu", exist_ok=True)')
+        d = self._run(solver="skfem", input_template=template,
+                      resolution=8, job_name="test_meshcheck_decoy_dir",
+                      critic_approved=True)
+        self.assertEqual(d["status"], "completed", d)
+        for lv in d["levels"]:
+            self.assertEqual(lv["result_file"], "result.vtu")
+
+    def test_unknown_solver_returns_structured_failure(self):
+        # Copilot review (PR #49): the unknown-solver early exit used to
+        # return a plain string, skipping the JSON shape, the verification
+        # stamp and the tool_error journal record every other failure
+        # path carries.
+        d = self._run(solver="no_such_solver",
+                      input_template=_SKFEM_TEMPLATE, resolution=8,
+                      job_name="test_meshcheck_unknown_solver")
+        self.assertEqual(d["status"], "failed")
+        self.assertIn("Unknown solver", d["error"])
+        self.assertFalse(d["trustworthy_result"])
+        self.assertIn("NOT VERIFIED", d["verification"])
+
+    def test_template_without_placeholder_is_refused(self):
+        d = self._run(solver="skfem",
+                      input_template=_SKFEM_TEMPLATE.replace(
+                          "__RESOLUTION__", "16"),
+                      resolution=16, job_name="test_meshcheck_noplaceholder")
+        self.assertEqual(d["status"], "failed")
+        self.assertIn("__RESOLUTION__", d["error"])
+        self.assertFalse(d["trustworthy_result"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_named_input_keys_exist.py
+++ b/tests/test_named_input_keys_exist.py
@@ -1,0 +1,116 @@
+"""Every input key OASiS names must exist in the backend that would consume it.
+
+A wrong warning misleads a user. A wrong KEY produces a deck the solver refuses
+to parse, for every user, every time — and the user has no way to tell whether
+the key is wrong or their problem is. Two of these were live in the corpus when
+this gate was written:
+
+  * `SOUNDSPEED` and `SMOOTHING_LENGTH`, served as required 4C SPH material
+    parameters beside the real `DYN_VISCOSITY` and `BULK_MODULUS`, one of them
+    carrying the numeric tuning rule "c >= 10 * v_max". Neither appears in any
+    file of 4C's source or in any of its 2171 input decks.
+  * `AREA0`, in the arterial-network DECK TEMPLATE — the YAML actually written
+    into the input file. 4C's `MAT_CNST_ART` has no such parameter; the
+    reference geometry comes from `DIAM`. The same generator already carried a
+    warning saying exactly that, and the template was never updated.
+
+WHY THIS IS A BASELINE AND NOT A HARD FAIL
+------------------------------------------
+The corpus has candidates under active triage, and a hard fail would block every
+unrelated change until the last one is resolved. So the gate ratchets: it fails
+on any key NOT in the recorded baseline, which catches a newly invented key the
+moment it is written, while the known set is worked down.
+
+The baseline is deliberately a readable JSON file listing every key by name, not
+a count and not a hash. An allowlist you cannot read is a place for things to
+hide. It is expected to shrink to empty; entries leave it as they are fixed or
+reclassified as correct negatives.
+
+WHAT THIS GATE REFUSES TO ASSERT
+--------------------------------
+It renders no verdict at all for a backend whose corpus it cannot see. Kratos
+does not import on this host, and only 3 of its ~40 applications are installed,
+so a key from the DEM or Poromechanics application is invisible here no matter
+how real it is — reported UNVERIFIABLE, never "invented". An audit that judged
+Kratos against scipy once reported 121 of 139 keys as fabricated; every one was
+an artefact of not being able to see the software.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+BASELINE_PATH = REPO / "scripts" / "scan_results" / "named_key_baseline.json"
+BACKENDS = ["fourc", "fenics", "dealii", "ngsolve", "skfem", "kratos", "dune",
+            "febio", "sparta"]
+
+
+def _baseline() -> dict:
+    if not BASELINE_PATH.is_file():
+        return {}
+    return json.loads(BASELINE_PATH.read_text()).get("baseline", {})
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_named_keys_resolve_in_the_backend(backend: str) -> None:
+    from audit_named_input_keys import audit
+
+    res = audit(backend)
+
+    if res["status"] in ("UNKNOWN", "NO_ENTRIES"):
+        pytest.skip(f"no verdict possible: {res['reason']}")
+    if res["status"] == "PARTIAL_CORPUS":
+        pytest.skip(
+            f"{backend}: corpus is a known subset, so a key that does not "
+            f"resolve is not thereby shown to be invented — "
+            f"{res['corpus_partial']}. "
+            f"{len(res.get('unverifiable', []))} keys unverifiable here.")
+
+    known = set(_baseline().get(backend, []))
+    found = {u["key"] for u in res["unresolved"]}
+    new = sorted(found - known)
+
+    assert not new, (
+        f"{backend}: {len(new)} input key(s) named by the knowledge do not "
+        f"exist anywhere in the backend's corpus, and are not in the triage "
+        f"baseline:\n"
+        + "\n".join(
+            f"    {k}  <- {next(u['signal'] for u in res['unresolved'] if u['key'] == k)}"
+            for k in new)
+        + f"\n\nEach is either an invented key — a user following it writes a "
+          f"deck the solver rejects — or a correct negative whose phrasing the "
+          f"absence matcher did not recognise. Check it against the backend's "
+          f"source AND its example inputs (grep -r -a -F; the -a matters, "
+          f"without it grep silently skips the compiled libraries where many "
+          f"backends register their variables). Fix real ones; add correct "
+          f"negatives to {BASELINE_PATH.name} with a note saying why."
+    )
+
+
+def test_baseline_only_shrinks() -> None:
+    """Keys resolved since the baseline was taken must be removed from it.
+
+    Without this the baseline becomes a graveyard: a key gets fixed, its entry
+    stays, and the entry silently re-permits the same fabrication if it is
+    reintroduced later. The list has to track reality in both directions.
+    """
+    from audit_named_input_keys import audit
+
+    stale: list[str] = []
+    for backend, keys in _baseline().items():
+        res = audit(backend)
+        if res["status"] not in ("OK", "CANDIDATES"):
+            continue
+        still = {u["key"] for u in res["unresolved"]}
+        for k in keys:
+            if k not in still:
+                stale.append(f"{backend}:{k}")
+    assert not stale, (
+        "these keys now resolve and must be dropped from the baseline, so it "
+        "cannot re-permit them later:\n    " + "\n    ".join(stale))

--- a/tests/test_no_foreign_solver_diagnostics.py
+++ b/tests/test_no_foreign_solver_diagnostics.py
@@ -1,0 +1,132 @@
+"""A backend must not quote diagnostics from a solver stack it does not use.
+
+THE CASE FOR A GATE RATHER THAN A SWEEP
+---------------------------------------
+On 2026-08-03 someone ran a PETSc-vocabulary sweep over the NGSolve knowledge
+and corrected two entries. Both now say so explicitly:
+
+    mixed_poisson#2  "NOTE: `KSPSolve: DIVERGED_INDEFINITE_PC` is a PETSc
+                      message and is NOT emitted by NGSolve..."
+    surface_pde#2    "NOTE: `KSPSolve: DIVERGED_BREAKDOWN` is a PETSc string
+                      and is never emitted by..."
+
+The same sweep missed `time_dependent_ns#4`, which still reads "Signal: PETSc
+reports `KSPSolve: DIVERGED_BREAKDOWN`". NGSolve does not route through PETSc;
+umfpack emits nothing and returns a finite vector.
+
+That is the whole argument for gating this class of defect. The pattern was
+known, someone went looking for exactly it, and a third instance survived
+because a manual sweep depends on the sweeper's diligence at that moment.
+Measured now across every backend that does not use PETSc: **six uncorrected
+entries** — three NGSolve, three FEBio, which uses NOX.
+
+WHY IT MATTERS TO AN AGENT
+--------------------------
+This is the project's recurring shape: the caution is sound, the mechanism is
+sound, the observable is not produced. An agent told to watch for
+`DIVERGED_BREAKDOWN` from a solver that cannot emit it watches forever, sees
+nothing, and reads the silence as success. The guard does not fail to help — it
+manufactures confidence, which is worse than no entry at all.
+
+WHAT IS ALLOWED
+---------------
+Naming a foreign string in order to say it is NOT emitted is exactly the right
+correction, and the two entries above are the model. So an entry that carries a
+retraction cue near the string passes. So does a backend that genuinely uses the
+stack: FEniCSx really does route through PETSc and its KSP/SNES strings are
+real, so it is not checked here.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+BACKENDS_DIR = REPO / "src" / "backends"
+
+# Which foreign solver stacks to look for, and which backends legitimately use
+# them. Deliberately conservative: only stacks whose diagnostic strings are
+# distinctive enough that a false positive is implausible.
+FOREIGN_STACKS = {
+    "PETSc": {
+        "pattern": re.compile(
+            r"KSPSolve|SNESSolve|KSP_DIVERGED|SNES_DIVERGED"
+            r"|DIVERGED_(?:BREAKDOWN|INDEFINITE_PC|FNORM_NAN|LINE_SEARCH|ITS"
+            r"|MAX_IT|LINEAR_SOLVE|PC_FAILED)"
+            r"|PETSc reports"),
+        # Backends that really do route through PETSc, so these strings are
+        # theirs to quote.
+        "legitimate": {"fenics", "dealii"},
+    },
+}
+
+# Naming a foreign string to say it is NOT emitted is the correct fix, not a
+# violation. Same idea as the retraction exemption in the quoted-diagnostics
+# screen: a checker that punishes the correction deletes the correction.
+_RETRACTION = re.compile(
+    r"is (?:a )?(?:PETSc|foreign|another library.s)|never emitted|not emitted"
+    r"|does not (?:use|route|emit)|do not (?:use|route|emit)"
+    r"|is NOT emitted|no such (?:string|message)|comes from PETSc"
+    r"|signal-text correction",
+    re.IGNORECASE)
+
+
+def _entries(backend: str) -> list[tuple[Path, str]]:
+    be_dir = BACKENDS_DIR / backend
+    out: list[tuple[Path, str]] = []
+    if not be_dir.is_dir():
+        return out
+    seen: set[str] = set()
+    for py in sorted(be_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(py.read_text(errors="ignore"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and "Signal:" in node.value
+                    and node.value not in seen):
+                seen.add(node.value)
+                out.append((py, node.value))
+    return out
+
+
+BACKENDS = sorted(p.name for p in BACKENDS_DIR.iterdir()
+                  if p.is_dir() and not p.name.startswith("_")) \
+    if BACKENDS_DIR.is_dir() else []
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_no_diagnostics_from_a_solver_stack_this_backend_lacks(backend):
+    """Quoting a message the backend cannot emit builds a guard that never fires."""
+    offenders = []
+    for stack, spec in FOREIGN_STACKS.items():
+        if backend in spec["legitimate"]:
+            continue
+        for path, entry in _entries(backend):
+            m = spec["pattern"].search(entry)
+            if not m:
+                continue
+            if _RETRACTION.search(entry):
+                continue  # correctly says the string is NOT emitted
+            offenders.append(
+                f"{path.relative_to(REPO)}\n      [{stack}] "
+                f"...{entry[max(0, m.start() - 55):m.start() + 70].strip()}...")
+
+    assert not offenders, (
+        f"{backend}: {len(offenders)} entries quote diagnostics from a solver "
+        f"stack this backend does not use, so an agent following them watches "
+        f"for a message that can never appear:\n  " + "\n  ".join(offenders[:10])
+        + "\n\nReplace the quoted string with what this backend ACTUALLY prints "
+          "— or, if the point is that the foreign string is a common "
+          "misconception, say so explicitly the way ngsolve/mixed_poisson#2 "
+          "does: 'NOTE: `KSPSolve: DIVERGED_INDEFINITE_PC` is a PETSc message "
+          "and is NOT emitted by NGSolve'. That phrasing is exempt from this "
+          "gate and is the right correction.\n\n"
+          "This gate exists because a manual sweep on 2026-08-03 corrected two "
+          "NGSolve entries for exactly this and missed a third.")

--- a/tests/test_no_undisclosed_surrogates.py
+++ b/tests/test_no_undisclosed_surrogates.py
@@ -1,0 +1,201 @@
+"""A template must not claim to be a backend it does not use.
+
+OASiS is going to be read and picked apart by the computational-mechanics
+community. The single most damaging thing it could contain is a template that
+names a solver and quietly solves with something else — a reviewer who finds one
+is entitled to distrust everything around it.
+
+There were real instances. DUNE's `linear_elasticity_2d` was literally
+`return _poisson_2d(params)` and printed "DUNE-fem Poisson solve complete."
+under an elasticity name; its `stokes_2d` was a self-described Poisson "proxy".
+Both were repaired on their branch. This guard is what stops the next one.
+
+WHAT IS AND IS NOT A SURROGATE, because the distinction decides whether a thing
+is dishonest or merely limited:
+
+  * A template that solves the physics with a DIFFERENT library, while SAYING SO
+    in its docstring, is legitimate. Eight Kratos templates assemble with
+    numpy/scipy and seven of them say "Kratos (manual assembly)" or
+    "(standalone)" on the first line; the server instructions route them to
+    `run_simulation` accordingly. The physics is right and the reader is told.
+  * The same template with an unqualified "— Kratos Multiphysics" docstring is
+    NOT legitimate, and exactly one was in that state. A weak model reads the
+    first line and stops; telling it "Kratos Multiphysics" when the code is
+    scipy is the opposite of the truth.
+  * A reference stub that says "Not a runnable input — the user must supply the
+    case-specific mesh" and lists the requirements is legitimate. Twenty 4C
+    entries are of that kind. Declining to fabricate a mesh you cannot know is
+    honesty, not a gap.
+
+So the rule enforced here is narrow and defensible: if a template does not use
+its own backend, its docstring must say so.
+"""
+from __future__ import annotations
+
+import ast
+import functools
+import re
+
+import pytest
+
+# How to tell a template really drives its own backend.
+_BACKEND_MARKERS = {
+    "fenics": ("dolfinx", "ufl"),
+    "dune": ("dune",),
+    "ngsolve": ("ngsolve", "netgen"),
+    "skfem": ("skfem",),
+    "kratos": ("KratosMultiphysics",),
+    "febio": ("febio_spec",),
+    "fourc": ("PROBLEM TYPE", "PROBLEMTYPE"),
+    "sparta": ("create_box", "species", "global "),
+}
+
+# Wording that tells a reader the template does not use the backend itself.
+_DISCLOSES = re.compile(
+    r"manual assembly|standalone|without Kratos|does not use|no Kratos"
+    # "NOT a runnable 4C input" — allow words between, since the first version
+    # required the phrase verbatim and so accused five honest 4C entries whose
+    # header says exactly that with the solver name in the middle.
+    r"|not\s+(?:a\s+)?(?:\w+\s+){0,3}runnable"
+    r"|reference stub|meta-reference|umbrella"
+    r"|scipy|numpy-only|proxy|placeholder|surrogate|stub", re.I)
+
+
+@functools.lru_cache(maxsize=1)
+def _templates():
+    from core.registry import get_backend, list_backends, load_all_backends
+
+    load_all_backends()
+    out = []
+    for entry in list_backends():
+        be = get_backend(entry["name"])
+        if not be:
+            continue
+        for p in be.supported_physics():
+            for v in list(p.template_variants):
+                try:
+                    out.append((entry["name"], f"{p.name}/{v}",
+                                be.generate_input(p.name, v, {})))
+                except Exception:
+                    continue                      # generator failures: other tests
+    return tuple(out)
+
+
+def _header(text: str) -> str:
+    """The docstring, or the leading comment block — what a reader sees first."""
+    try:
+        doc = ast.get_docstring(ast.parse(text))
+        if doc:
+            return doc
+    except (SyntaxError, ValueError):
+        pass
+    lines = []
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("#") or not s:
+            # Skip pure divider rules. A first version returned `# =====` as the
+            # header and then accused five honest 4C entries whose very next line
+            # reads "This is NOT a runnable 4C input" — a guard that misreads the
+            # text it judges is worse than none.
+            if s.strip("#= \t-*_"):
+                lines.append(s)
+            if len(lines) > 25:
+                break
+        elif lines:
+            break
+    return "\n".join(lines) or text[:400]
+
+
+def test_a_template_that_does_not_use_its_backend_says_so():
+    """The narrow, defensible rule. Exactly one template failed it: a Kratos
+    Poisson script whose docstring read "— Kratos Multiphysics" while the code
+    assembled with scipy."""
+    offenders = []
+    for backend, name, text in _templates():
+        markers = _BACKEND_MARKERS.get(backend)
+        if not markers or any(m in text for m in markers):
+            continue
+        if _DISCLOSES.search(_header(text)):
+            continue
+        offenders.append(f"{backend}/{name}: {_header(text).splitlines()[0][:90]!r}")
+    assert not offenders, (
+        "these templates do not use their own backend and do not say so, so a "
+        "reader is told the opposite of the truth:\n  " + "\n  ".join(offenders)
+        + "\n\nEither drive the backend, or state plainly in the first line that "
+          "the script assembles the problem itself.")
+
+
+def test_the_guard_catches_the_shape_it_was_written_for():
+    """Calibration on both the real defect and the legitimate cases it must not
+    accuse — a guard that flagged all 8 manual-assembly Kratos templates, or the
+    20 honest 4C stubs, would be deleted within a week."""
+    misleading = '"""Poisson on the unit square — Kratos Multiphysics"""\nimport scipy\n'
+    assert not _DISCLOSES.search(_header(misleading))
+
+    for honest in (
+        '"""Heat conduction — Kratos (manual assembly)"""\nimport numpy\n',
+        '"""MPM — large-deformation solid — Kratos (standalone)"""\n',
+        "# 4C reference stub: ssi / monolithic_elch_3d\n"
+        "# Not a runnable input — the user must supply the mesh\n",
+    ):
+        assert _DISCLOSES.search(_header(honest)), honest
+
+
+def test_no_template_delegates_to_a_different_physics():
+    """DUNE's `linear_elasticity_2d` was `return _poisson_2d(params)`. A template
+    whose body hands off to another physics' generator is a surrogate however it
+    is worded, so this reads the source rather than the output."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "src" / "backends"
+    offenders = []
+    for path in sorted(root.glob("*/generators/*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:
+            continue
+        all_fns = [n for n in ast.walk(tree)
+                   if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+        def _template_shaped(nm: str) -> bool:
+            return nm.startswith("_") and (
+                "template" in nm or "_2d" in nm or "_3d" in nm or "_1d" in nm)
+
+        # Locally defined AND IMPORTED template functions. The first version
+        # collected only local definitions and so missed the one real surrogate
+        # in the repo: DUNE's `_elasticity_2d` returns `_poisson_2d(params)`,
+        # and `_poisson_2d` is imported `from .poisson`. The test passed and I
+        # only noticed because I checked the file by hand instead of trusting it.
+        template_fns = {n.name for n in all_fns if _template_shaped(n.name)}
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for a in node.names:
+                    nm = a.asname or a.name
+                    if _template_shaped(nm):
+                        template_fns.add(nm)
+        for fn in all_fns:
+            body = [s for s in fn.body if not isinstance(s, ast.Expr)]
+            if len(body) != 1 or not isinstance(body[0], ast.Return):
+                continue
+            call = body[0].value
+            if not isinstance(call, ast.Call):
+                continue
+            callee = str(getattr(call.func, "id", None)
+                         or getattr(call.func, "attr", ""))
+            # Only a call to ANOTHER TEMPLATE FUNCTION counts. A first version
+            # compared name prefixes and flagged `sorted`, `dedent`, `format` and
+            # `get` — ordinary one-line helpers, 20-odd false accusations against
+            # one real finding. A delegation target must itself be a private
+            # template-shaped function defined in this file.
+            if not callee.startswith("_"):
+                continue
+            if callee not in template_fns or callee == fn.name:
+                continue
+            mine = fn.name.strip("_").split("_")[0]
+            theirs = callee.strip("_").split("_")[0]
+            if theirs != mine:
+                offenders.append(
+                    f"{path.parent.parent.name}/{path.name}:{fn.lineno} "
+                    f"{fn.name} -> {callee}")
+    assert not offenders, (
+        "a template generator delegates straight to a different physics:\n  "
+        + "\n  ".join(offenders))

--- a/tests/test_payload_stays_parseable.py
+++ b/tests/test_payload_stays_parseable.py
@@ -1,0 +1,166 @@
+"""What the agent receives must always be parseable, however big the knowledge gets.
+
+`prepare_simulation` serialised its knowledge dict and sliced the string at a
+character count. Measured across every backend and physics, three SPARTA
+payloads came back with the `## Knowledge` block cut mid-string, so `json.loads`
+failed on exactly what an agent is handed. Not merely losing content — handing a
+weak model something it cannot parse at all.
+
+The failure mode also grows with the thing we are trying to improve. Every
+expansion that adds knowledge pushes more payloads past the cap, so enriching a
+backend was quietly making it less usable. That is the opposite of the point,
+and it is why this is a test rather than a fix-and-move-on.
+
+Whole keys are dropped now, load-bearing ones last, with the payload told to the
+agent as incomplete and the missing sections named.
+"""
+from __future__ import annotations
+
+import functools
+import json
+import re
+
+import pytest
+
+from tools.consolidated import _fit_json_payload
+
+
+@functools.lru_cache(maxsize=1)
+def _served():
+    """Every (backend, physics) payload, generated ONCE.
+
+    `prepare_simulation` builds templates and reads reference files, so driving
+    it per assertion turns a guard into a ten-minute suite and the guard gets
+    deleted. Two hundred payloads, collected once, shared by both checks.
+    """
+    from core.registry import get_backend, list_backends, load_all_backends
+    from tools import consolidated as C
+
+    load_all_backends()
+    captured = {}
+
+    class _Recorder:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    C.register_consolidated_tools(_Recorder())
+    prepare = captured["prepare_simulation"]
+
+    # Only oversized payloads can truncate, and `prepare_simulation` is
+    # expensive — it generates a template and reads reference files per call.
+    # Driving all 206 took 10.6 minutes, which is how a guard becomes a thing
+    # people delete. The raw knowledge dict is free to measure, so it decides
+    # which ones are worth serving. The margin is generous because pitfalls are
+    # carved out before the fit, so raw size overestimates what must fit.
+    from tools.consolidated import _fit_json_payload  # noqa: F401  (same module)
+    LIMIT = 16_000
+    MARGIN = 0.5
+
+    out = []
+    for entry in list_backends():
+        be = get_backend(entry["name"])
+        if not be:
+            continue
+        for p in be.supported_physics():
+            try:
+                raw = be.get_knowledge(p.name) or {}
+                size = len(json.dumps(raw, default=str))
+            except Exception:
+                size = LIMIT                     # unmeasurable: check it
+            if size < LIMIT * MARGIN:
+                continue
+            try:
+                text = prepare(entry["name"], p.name)
+            except Exception as exc:             # a broken physics row
+                text = f"__ERROR__ {exc}"
+            out.append((entry["name"], p.name, text))
+    return tuple(out)
+
+
+# ── the unit that does the work ───────────────────────────────────────────
+def test_a_payload_that_fits_is_returned_whole():
+    payload = {"description": "short", "solver": "cg"}
+    text, dropped = _fit_json_payload(payload, 10_000)
+    assert not dropped
+    assert json.loads(text) == payload
+
+
+def test_an_oversized_payload_is_still_valid_json():
+    payload = {"description": "keep me", "bulk": "x" * 50_000}
+    text, dropped = _fit_json_payload(payload, 1_000)
+    json.loads(text)                      # must not raise
+    assert "bulk" in dropped
+
+
+def test_load_bearing_keys_survive_and_bulk_goes_first():
+    """A payload that keeps the manual and drops the element names would be
+    worse than useless."""
+    payload = {
+        "relevant_commands": {"c%d" % i: "x" * 400 for i in range(50)},
+        "description": "what this physics is",
+        "required_sections": ["A", "B"],
+        "element": "hex8",
+    }
+    text, dropped = _fit_json_payload(payload, 2_000)
+    kept = json.loads(text)
+    assert "description" in kept and "required_sections" in kept
+    assert "element" in kept
+    assert dropped == ["relevant_commands"]
+
+
+def test_surviving_keys_keep_the_authors_order():
+    payload = {"description": "d", "element": "e", "bulk": "x" * 40_000}
+    text, _ = _fit_json_payload(payload, 500)
+    assert list(json.loads(text)) == ["description", "element"]
+
+
+def test_nothing_droppable_still_returns_valid_json():
+    """A single key larger than the limit cannot be trimmed; the result must
+    still parse rather than being a sliced fragment."""
+    text, dropped = _fit_json_payload({"huge": "x" * 40_000}, 100)
+    json.loads(text)
+    assert dropped == ["huge"]
+
+
+# ── through the real tool, across everything ──────────────────────────────
+_BLOCK = re.compile(r"## Knowledge\n```json\n(.*?)\n```", re.S)
+
+
+def test_every_served_payload_parses():
+    """The one that matters: three SPARTA payloads used to fail this."""
+    broken = []
+    for backend, physics, text in _served():
+        m = _BLOCK.search(text)
+        if not m:
+            continue
+        try:
+            json.loads(m.group(1))
+        except json.JSONDecodeError as exc:
+            broken.append(f"{backend}/{physics}: {exc}")
+    assert not broken, (
+        "the knowledge block an agent receives is not valid JSON — a weak "
+        "model cannot parse this at all:\n  " + "\n  ".join(broken))
+
+
+def test_an_incomplete_payload_says_so():
+    """A silent hole reads as 'this backend has nothing to say'."""
+    from core.registry import get_backend
+
+    silent = []
+    for backend, physics, text in _served():
+        m = _BLOCK.search(text)
+        if not m:
+            continue
+        be = get_backend(backend)
+        full = be.get_knowledge(physics) or {}
+        if not isinstance(full, dict):
+            continue
+        missing = {k for k in full if k != "pitfalls"} - set(json.loads(m.group(1)))
+        if missing and "too large to serve whole" not in text:
+            silent.append(f"{backend}/{physics} omits {sorted(missing)}")
+    assert not silent, (
+        "sections were dropped with no note to the agent:\n  "
+        + "\n  ".join(silent))

--- a/tests/test_pitfall_format_contract.py
+++ b/tests/test_pitfall_format_contract.py
@@ -1,0 +1,203 @@
+"""The two fields retrieval depends on must be present on every entry.
+
+WHY A CONTRACT AND NOT A STYLE GUIDE
+------------------------------------
+Knowledge is being added continuously and by many hands at once. A convention
+that lives in a reviewer's memory decays under that load — not through
+carelessness but because each writer sees only their own entries and the format
+is invisible until something tries to retrieve across all of them.
+
+Measured over the 1122 entries present when this was written, the convention was
+already near-universal, which is why it is worth locking rather than redesigning:
+
+    [Category] <the fact, and what to do about it, in prose>.
+    Signal: <what you observe when it bites>. (Verified <date>, <version>)
+
+    Signal: clause present   1122/1122  (100%)
+    [Category] tag present   1121/1122  (100%)
+    exact duplicate entries  0
+    median entry length      398 chars
+
+Retrieval is built on exactly those two fields — `signal=` matches the Signal
+clause, `category=` filters the tag. An entry missing either is not a smaller
+contribution; it is invisible to the query that would have surfaced it. So this
+gate protects retrieval, not tidiness.
+
+WHAT IS DELIBERATELY NOT ENFORCED
+---------------------------------
+No `Fix:` marker. The advice lives in prose on purpose: an explanation a weak
+model can reason from is worth more than a terse field it can only copy, and
+prose is what 1120 of the entries already are. Cutting them into fields would
+be a large mechanical edit across files that concurrent work is actively
+changing, for no retrieval gain.
+
+Length is not capped either. The longest entries earn it — Kratos contact
+integration needs every one of its 817 characters — and a cap would push
+authors to drop the reasoning rather than tighten it.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+from core.pitfall_index import CANONICAL_CATEGORIES, parse_entry  # noqa: E402
+
+BACKENDS_DIR = REPO / "src" / "backends"
+# Compound tags are legitimate: `_cross.py` writes [Cross-Backend][Units] and
+# the axis is the LAST tag. The gate must read the convention the same way the
+# retrieval layer does, or it fails entries that retrieval handles correctly.
+_CATEGORY_RE = re.compile(r"^\s*(?:\[[^\]]{1,40}\])+")
+
+
+def _entries() -> list[tuple[Path, str]]:
+    """Every pitfall entry in the tree, with the file it came from.
+
+    Deduplicated by (file, value): a sub-dict attached by reference to several
+    physics keys is one entry to maintain, and counting it repeatedly once
+    inflated a DUNE audit's total from 111 to 127.
+
+    DOCSTRINGS ARE NOT ENTRIES. A pitfall entry is a data value — an item in a
+    `pitfalls` list, a value in a knowledge dict. A module/class/function
+    docstring is documentation, and several of them legitimately explain the
+    convention using the literal token `Signal:` while describing it. Collecting
+    those made the gate demand a [Category] tag on prose that must not carry
+    one, and the only way to satisfy it was to reword correct documentation.
+    Measured when this exclusion was added during the branch consolidation:
+    1299 strings under src/backends contain `Signal:`, exactly 4 are docstrings,
+    and none of the 4 is a pitfall — so this drops false positives and nothing
+    else. (Found three separate times: _setup.py, dune/generators/__init__.py,
+    and four SPARTA modules.)
+    """
+    seen: set[tuple[str, str]] = set()
+    out: list[tuple[Path, str]] = []
+    for py in sorted(BACKENDS_DIR.rglob("*.py")):
+        try:
+            tree = ast.parse(py.read_text(errors="ignore"))
+        except SyntaxError:
+            continue
+        docstrings = set()
+        for holder in ast.walk(tree):
+            if isinstance(holder, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                   ast.AsyncFunctionDef)):
+                body = getattr(holder, "body", None)
+                if (body and isinstance(body[0], ast.Expr)
+                        and isinstance(body[0].value, ast.Constant)
+                        and isinstance(body[0].value.value, str)):
+                    docstrings.add(id(body[0].value))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and "Signal:" in node.value
+                    and id(node) not in docstrings):
+                k = (str(py), node.value)
+                if k not in seen:
+                    seen.add(k)
+                    out.append((py, node.value))
+    return out
+
+
+ENTRIES = _entries()
+
+
+def test_there_are_entries_to_check():
+    """Guard against the collector silently finding nothing.
+
+    A format gate that examines zero entries passes perfectly and means
+    nothing. This project has already shipped one green suite that was
+    asserting against an empty set.
+    """
+    assert len(ENTRIES) > 900, (
+        f"expected the full pitfall corpus, collected {len(ENTRIES)}. Either "
+        f"the collector broke or the corpus shrank — both need looking at "
+        f"before any format claim below can be believed.")
+
+
+def test_every_entry_has_a_signal_clause():
+    """Without it the entry cannot be found by the error the agent is holding."""
+    bad = [(p.relative_to(REPO), t[:90]) for p, t in ENTRIES
+           if not parse_entry(t)["signal"]]
+    assert not bad, (
+        f"{len(bad)} entries have no usable Signal: clause, so "
+        f"knowledge(topic='pitfalls', signal=...) can never surface them:\n  "
+        + "\n  ".join(f"{p}: {t}" for p, t in bad[:12]))
+
+
+def test_every_entry_has_a_category_tag():
+    """Without it the entry is invisible to category filtering."""
+    bad = [(p.relative_to(REPO), t[:90]) for p, t in ENTRIES
+           if not _CATEGORY_RE.match(t)]
+    assert not bad, (
+        f"{len(bad)} entries do not open with a [Category] tag:\n  "
+        + "\n  ".join(f"{p}: {t}" for p, t in bad[:12])
+        + "\n\nStart the entry with one of: "
+        + ", ".join(sorted(set(CANONICAL_CATEGORIES.values()))))
+
+
+def test_categories_come_from_the_known_vocabulary():
+    """A new category name silently partitions the corpus.
+
+    An agent filtering on `Numerical` will not see an entry tagged with a
+    freshly-invented synonym, and nothing reports the miss. Spelling variants
+    are folded on read (`Numerics` -> `Numerical`); this catches genuinely new
+    values, which need a deliberate decision rather than arriving by accident.
+    """
+    unknown: dict[str, list[str]] = {}
+    for p, t in ENTRIES:
+        if not _CATEGORY_RE.match(t):
+            continue
+        raw = parse_entry(t)["category_as_written"]
+        if raw.lower() not in CANONICAL_CATEGORIES:
+            unknown.setdefault(raw, []).append(
+                f"{p.relative_to(REPO)}: {t[:70]}")
+    assert not unknown, (
+        "category tags outside the known vocabulary:\n  "
+        + "\n  ".join(f"[{k}] x{len(v)} — e.g. {v[0]}"
+                      for k, v in sorted(unknown.items()))
+        + "\n\nEither use an existing category or add the new one to "
+          "CANONICAL_CATEGORIES in src/core/pitfall_index.py, mapping it to "
+          "the axis it belongs on so filtering stays complete.")
+
+
+def test_signal_clause_is_not_empty_boilerplate():
+    """`Signal:` followed by nothing useful is the same as no Signal at all.
+
+    Caught in review more than once: an entry whose Signal read only "see
+    above" or "error message" — present, therefore passing a presence check,
+    and matching nothing an agent could ever paste.
+    """
+    vague = {"", "see above", "error", "error message", "n/a", "none",
+             "as described", "tbd", "unknown", "varies", "see description"}
+    bad = []
+    for p, t in ENTRIES:
+        sig = parse_entry(t)["signal"].strip().rstrip(".").lower()
+        if sig in vague or len(sig) < 15:
+            bad.append(f"{p.relative_to(REPO)}: Signal: {sig!r}")
+    assert not bad, (
+        f"{len(bad)} entries have a Signal: clause too vague to match against:"
+        f"\n  " + "\n  ".join(bad[:12])
+        + "\n\nQuote what the software actually prints, or describe the "
+          "observable numerically. A placeholder passes a presence check while "
+          "making the entry unfindable.")
+
+
+def test_entries_do_not_duplicate_each_other_verbatim():
+    """Two identical entries mean one of them is unmaintained.
+
+    Zero at the time of writing. Worth keeping there: when the same text sits in
+    two places, a correction lands on one and the other keeps being served.
+    """
+    from collections import Counter
+    c = Counter(t for _, t in ENTRIES)
+    dupes = {t: n for t, n in c.items() if n > 1}
+    assert not dupes, (
+        f"{len(dupes)} entries appear verbatim in more than one place:\n  "
+        + "\n  ".join(f"x{n}: {t[:80]}" for t, n in list(dupes.items())[:8])
+        + "\n\nKeep one copy and reference it, so a fix cannot land on only "
+          "one of them.")

--- a/tests/test_pitfall_signal_coverage.py
+++ b/tests/test_pitfall_signal_coverage.py
@@ -487,12 +487,73 @@ SIGNAL_COVERAGE_MIN = {
                        #                 FEM backend at 100% Signal: coverage.
                        #                 Trajectory: 0.0% -> 100.0% in
                        #                 a SINGLE pass.)
-    "sparta":   0.0,   # SPARTA (DSMC particle code, the 9th backend) carries one
-                       #   curated rarefied-gas pitfall per physics (10 total) that
-                       #   predate the Signal: convention. Baseline locked at 0.0
-                       #   so it can't REGRESS; enriching them with Signal:
-                       #   observable-symptom markers is follow-up work (it is a
-                       #   fundamentally different, non-FEM code).
+    "sparta":  99.0,   # measured 100.0 — SPARTA (the 9th backend, a DSMC
+                       #                  particle code) reached FULL Signal
+                       #                  coverage when its flat
+                       #                  sparta_knowledge.json dump was
+                       #                  restructured into per-physics modules
+                       #                  under backends/sparta/generators/,
+                       #                  the shape every FEM backend already
+                       #                  uses. RECOUNTED 2026-08-03 (audit):
+                       #                  165 Signal-tagged pitfalls counted
+                       #                  across 10 physics = 65 physics-
+                       #                  specific (rarefied_flow 9,
+                       #                  surface_interaction 10,
+                       #                  conjugate_heat_transfer 7,
+                       #                  adaptive_grid 6, axisymmetric 6,
+                       #                  collision_relaxation 6,
+                       #                  hypersonic_flow 6, particle_emission
+                       #                  6, chemistry 4, ambipolar_plasma 5)
+                       #                  plus 10 cross-cutting deck-level
+                       #                  entries attached to every row.
+                       #                  The earlier "155 / collision_relaxation
+                       #                  5" arithmetic was wrong.
+                       #                  COUNT WHAT YOU NAME. Three different
+                       #                  numbers live here and they are NOT
+                       #                  interchangeable:
+                       #                    165 = pitfall entries counted
+                       #                     75 = distinct pitfall entries
+                       #                          (65 physics-specific + 10
+                       #                          cross-cutting; confirmed both
+                       #                          by value and by id())
+                       #                     74 = distinct Signal TEXTS
+                       #                  75 -> 74 because hypersonic_flow[0]
+                       #                  and particle_emission[0] are two
+                       #                  differently-worded pitfalls carrying
+                       #                  the SAME Signal literal verbatim (the
+                       #                  fix emit/face periodic-boundary
+                       #                  abort), so the 65 physics-specific
+                       #                  entries yield only 64 distinct
+                       #                  physics-specific Signal texts. That
+                       #                  64 is the only real "n=64" here; it is
+                       #                  a Signal-level duplicate, NOT an
+                       #                  entry-level miscount, and "75 unique
+                       #                  entries" was correct as written.
+                       #                  Checked for the reference-sharing trap
+                       #                  that inflated a peer backend's count:
+                       #                  exactly one sub-container is attached
+                       #                  by reference to all ten rows
+                       #                  ('deck_skeleton'), and it is not a
+                       #                  pitfall, so no counted number here is
+                       #                  inflated by it.
+                       #                  Message literals quoted inside those
+                       #                  Signals: 71 distinct, 71/71 present in
+                       #                  the installed binary (49 ERROR/WARNING
+                       #                  strings + 22 other console lines).
+                       #                  strings -n 6 canNOT check the
+                       #                  '(../file.cpp:NN)' suffix — the error
+                       #                  handler appends it at runtime — and a
+                       #                  FLERR-line audit against the SPARTA
+                       #                  sources found 1 of 48 such locations
+                       #                  wrong (compute_reduce.cpp:280, the
+                       #                  per-grid twin, quoted for the per-surf
+                       #                  message, which is at :293).
+                       #                  The old floor was 0.0 with 0 Signal
+                       #                  clauses in src/backends/sparta/.
+                       #                  NOTE the floor is not tight: at 165
+                       #                  counted rows, losing exactly ONE
+                       #                  physics-specific Signal leaves 99.394%
+                       #                  and still passes; two or more fail.
 }
 
 

--- a/tests/test_quoted_diagnostics_are_real.py
+++ b/tests/test_quoted_diagnostics_are_real.py
@@ -1,0 +1,163 @@
+"""A quoted error message must be one the software actually prints.
+
+WHY THIS IS THE MOST IMPORTANT GATE IN THE SUITE
+------------------------------------------------
+Every verification pass that EXECUTED knowledge rather than reading it came back
+with the same largest category of defect, on every backend:
+
+    FEBio    25 invented error messages, 11 non-existent material names
+    4C       a majority of quoted diagnostics not found in the source tree
+             (see ON PRECISION below before quoting any rate — the first
+             version of this screen reported 91% and the figure was wrong)
+    NGSolve  "Newton did not converge after N iterations" — nowhere in
+             ngsolve/netgen; the real text is "Warning: Newton might not
+             converge! Error = "
+    skfem    meshio "Cannot write complex array" — never emitted; the real
+             failure is KeyError: dtype('complex128')
+    Kratos   FREESTREAM_VELOCITY / MACH_INFINITY — neither name exists
+    scipy    cg "raises RuntimeError: matrix not positive definite" — scipy
+             raises nothing; it returns info=1000 and a garbage vector
+
+A fabricated diagnostic is worse than a missing entry, because an agent uses the
+quoted string to BUILD ITS GUARD. Told that cg raises, it writes an exception
+handler and reads the absence of an exception as success — the guard passes and
+the wrong answer flows through, wearing a checkmark. The knowledge does not
+merely fail to help; it manufactures false confidence, which is the exact
+failure this project exists to prevent.
+
+`audit_phantom_apis.py` checks API ATTRIBUTES via hasattr. It says nothing about
+message text, which is where the damage has actually been.
+
+HOW THIS AVOIDS CRYING WOLF
+---------------------------
+Two earlier guards here were too eager and had to be retracted — a delegation
+guard flagged `sorted`, `dedent` and `format` (about 20 false accusations), and
+a disclosure guard failed five honest 4C entries over a phrasing difference. An
+ignored gate protects nothing, so this one is deliberately conservative, and
+each rule below exists because the naive version produced a false accusation on
+the real corpus:
+
+  * dependency trees are searched too, since genuine messages come from
+    Trilinos, PETSc, UMFPACK, meshio and scipy as well as from the backend;
+  * matching is on the longest STATIC fragment, because real messages
+    interpolate at runtime;
+  * quotes are paired left to right — an alternation regex straddled from one
+    fragment's closing quote to the next one's opening quote and "found" prose;
+  * RETRACTIONS ARE EXEMPT. When a pass falsifies a string, the honest fix
+    records what the entry used to claim. Flagging that would punish exactly
+    the behaviour we want;
+  * a backend whose source cannot be found reports UNKNOWN, never ABSENT —
+    "could not verify" and "verified absent" are different claims and only one
+    is an accusation.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+import audit_quoted_diagnostics as audit  # noqa: E402
+
+# Backends whose implementation this machine can actually search. Others are
+# reported by the script as UNKNOWN and are not asserted on here.
+CHECKABLE = ["fourc", "ngsolve", "skfem", "fenics", "kratos"]
+
+
+@pytest.mark.parametrize("backend", CHECKABLE)
+def test_quoted_diagnostics_exist_in_the_software(backend):
+    """No entry may quote a diagnostic the software cannot emit."""
+    result = audit.audit_backend(backend)
+
+    if result["verdict"].startswith("UNKNOWN"):
+        pytest.skip(
+            f"{backend}: no searchable source on this machine "
+            f"({', '.join(result['roots_missing']) or 'no roots configured'}). "
+            f"That is 'not checked', NOT 'clean' — this backend needs the audit "
+            f"run where its source is available.")
+
+    absent = result["fragments_absent"]
+    assert not absent, (
+        f"{backend}: {len(absent)} quoted diagnostics could not be found in the "
+        f"software that is supposed to emit them, out of "
+        f"{result['fragments_present'] + len(absent)} checked. These are "
+        f"CANDIDATES TO ADJUDICATE, not proven fabrications — see the note on "
+        f"precision below.\n\n"
+        + "\n".join(f"  {a['file']}\n      {a['fragment']}"
+                    for a in absent[:25])
+        + (f"\n  ... and {len(absent) - 25} more" if len(absent) > 25 else "")
+        + "\n\nRun the software, capture what it ACTUALLY prints, and quote "
+          "that. If the message turns out not to exist, say so in the entry — "
+          "a documented retraction is exempt from this gate and is the right "
+          "way to record a falsified claim.\n\n"
+          "ON PRECISION, because this list must not be pasted into a report as "
+          "a fabrication count. A hand adjudication of 57 NGSolve and skfem "
+          "strings — grepping the sources AND the vendored .so files, then "
+          "triggering the ones in doubt live — found 36 present, 13 already "
+          "documented as absent, 5 genuinely fabricated, 2 paraphrases and 1 "
+          "uncheckable. This screen flagged far more than 5. It catches real "
+          "fabrications (the ProxyFunction 'neighbour' message was one), but it "
+          "also flags messages from dependencies it cannot see, constants like "
+          "PETSc's DIVERGED_* that live outside the searched trees, and text "
+          "the extractor mangled. Treat every entry here as a lead to check by "
+          "running the software, never as a verdict.")
+
+
+def test_the_auditor_pairs_quotes_correctly():
+    """Regression: the extractor must not straddle adjacent quoted fragments.
+
+    The first version used an alternation regex with a minimum length inside
+    the match. On the real entry
+
+        writing 'SOLID QUAD4' for an ALE mesh raises
+        'expected ALE element type' from 4C_ale_factory.cpp
+
+    `SOLID QUAD4` is 11 characters, one below the minimum, so the regex skipped
+    it and matched from that fragment's CLOSING quote to the next one's OPENING
+    quote — yielding the prose "for an ALE mesh raises". Two failures in one:
+    a fabricated accusation against prose, and the real assertion never checked.
+    """
+    text = ("writing 'SOLID QUAD4' for an ALE mesh raises "
+            "'expected ALE element type' from 4C_ale_factory.cpp")
+    assert audit.quoted_fragments(text) == ["expected ALE element type"]
+
+
+def test_retractions_are_not_reported_as_fabrications():
+    """A documented falsification must not be punished as a fabrication.
+
+    Both directions matter, and both were wrong in the first implementation:
+    a plain backward window also excused the REAL message that followed the
+    retraction (the one string that must be checked), and a backward-only
+    window missed cues that follow the quote.
+    """
+    both = ("older quote 'beam element type not supported in Exodus' is in no "
+            "4C source file; the real message is "
+            "'The cell data does not contain the key'")
+    assert audit.quoted_fragments(both) == [
+        "The cell data does not contain the key"]
+
+    assert audit.quoted_fragments(
+        "'zero pivot in Schur complement' does not exist in the source") == []
+    assert audit.quoted_fragments(
+        "the claimed 'no design nodes found' never appears") == []
+
+    # And a plain assertion is still caught.
+    assert audit.quoted_fragments(
+        "Signal: the solver prints 'expected ALE element type' and aborts"
+    ) == ["expected ALE element type"]
+
+
+def test_auditor_reports_unknown_rather_than_clean_without_a_source():
+    """Absence of evidence must not be reported as evidence of absence.
+
+    If a backend's source cannot be found, every quoted string would trivially
+    "not be found" in it. Reporting that as ABSENT would flood the gate with
+    false accusations on any machine lacking a source tree, and the predictable
+    response is to switch the gate off.
+    """
+    result = audit.audit_backend("a-backend-that-does-not-exist")
+    assert result["verdict"].startswith("UNKNOWN")
+    assert not result["fragments_absent"]

--- a/tests/test_residual_gate.py
+++ b/tests/test_residual_gate.py
@@ -1,0 +1,366 @@
+"""The residual gate over the operator families the evaluation actually uses.
+
+`residual_check` separates a solve from a forgery. `residual_gate` is what makes
+it reachable from a run, and what turns a JSON problem declaration into the
+operator OASiS assembles. These tests cover the shapes that appear in the blind
+problem set — 2D and 3D, constant, spatially varying and anisotropic tensor
+coefficients — because a check that only works on the one case its author tried
+is how `residual_check` came to raise TypeError on every real artefact while its
+own tests stayed green.
+
+Each family is tested twice: an honest solve must pass, and the analytic field
+sampled at the nodes must fail. The second is the discriminating half. A gate
+that only ever sees correct input cannot be shown to reject anything.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+skfem = pytest.importorskip("skfem")
+meshio = pytest.importorskip("meshio")
+sympy = pytest.importorskip("sympy")
+
+from core.residual_gate import ResidualSpecError, check_run_residual, parse_spec
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+def _solve(mesh, elem, source, coeff=None, dim=2):
+    from skfem import (Basis, BilinearForm, LinearForm, asm, condense, solve)
+    from skfem.helpers import dot, grad
+
+    basis = Basis(mesh, elem)
+
+    @BilinearForm
+    def a(u, v, w):
+        gu, gv = grad(u), grad(v)
+        if coeff is None:
+            return dot(gu, gv)
+        if isinstance(coeff, np.ndarray) and coeff.ndim == 2:
+            return sum(coeff[i, j] * gu[j] * gv[i]
+                       for i in range(dim) for j in range(dim))
+        return coeff(w.x) * dot(gu, gv)
+
+    @LinearForm
+    def L(v, w):
+        return source(w.x) * v
+
+    return solve(*condense(asm(a, basis), asm(L, basis), D=basis.get_dofs()))
+
+
+def _artefact(mesh, values, dim):
+    """Write a real meshio artefact — the form the gate meets in production.
+
+    Hand-built tuples are what hid the CellBlock bug, so these tests go through
+    a written file every time.
+    """
+    d = Path(tempfile.mkdtemp())
+    path = d / "solution.vtu"
+    p = mesh.p.T
+    pts = np.column_stack([p, np.zeros(len(p))]) if dim == 2 else p
+    cells = [("triangle" if dim == 2 else "tetra", mesh.t.T)]
+    meshio.write_points_cells(str(path), pts, cells,
+                              point_data={"u": np.asarray(values, float)})
+    return [path]
+
+
+def _verdict(spec, files):
+    return check_run_residual(spec, files)["verdict"]
+
+
+# ── constant coefficient, 2D and 3D ───────────────────────────────────────
+def test_2d_constant_coefficient():
+    m = skfem.MeshTri().refined(5)
+    src = lambda X: 2 * np.pi ** 2 * np.sin(np.pi * X[0]) * np.sin(np.pi * X[1])
+    u = _solve(m, skfem.ElementTriP1(), src)
+    p = m.p.T
+    exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])
+    spec = json.dumps({"operator": "diffusion", "dim": 2, "domain_measure": 1.0,
+                       "source": "2*pi**2*sin(pi*x)*sin(pi*y)"})
+    assert _verdict(spec, _artefact(m, u, 2)) == "SOLVES"
+    assert _verdict(spec, _artefact(m, exact, 2)) == "DOES_NOT_SOLVE"
+
+
+def test_3d_constant_coefficient():
+    m = skfem.MeshTet().refined(3)
+    src = (lambda X: 3 * np.pi ** 2 * np.sin(np.pi * X[0])
+           * np.sin(np.pi * X[1]) * np.sin(np.pi * X[2]))
+    u = _solve(m, skfem.ElementTetP1(), src, dim=3)
+    p = m.p.T
+    exact = (np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])
+             * np.sin(np.pi * p[:, 2]))
+    spec = json.dumps({"operator": "diffusion", "dim": 3, "domain_measure": 1.0,
+                       "source": "3*pi**2*sin(pi*x)*sin(pi*y)*sin(pi*z)"})
+    assert _verdict(spec, _artefact(m, u, 3)) == "SOLVES"
+    assert _verdict(spec, _artefact(m, exact, 3)) == "DOES_NOT_SOLVE"
+
+
+# ── spatially varying scalar coefficient ──────────────────────────────────
+def test_variable_coefficient():
+    import sympy as sp
+    X, Y = sp.symbols("x y")
+    ue, kk = sp.sin(sp.pi * X) * sp.sin(sp.pi * Y), 1 + X ** 2
+    fe = sp.expand(sp.simplify(-(sp.diff(kk * sp.diff(ue, X), X)
+                                 + sp.diff(kk * sp.diff(ue, Y), Y))))
+    fnum = sp.lambdify((X, Y), fe, "numpy")
+
+    m = skfem.MeshTri().refined(5)
+    u = _solve(m, skfem.ElementTriP1(), lambda A: fnum(A[0], A[1]),
+               coeff=lambda A: 1 + A[0] ** 2)
+    p = m.p.T
+    exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])
+    spec = json.dumps({"operator": "diffusion", "dim": 2, "domain_measure": 1.0,
+                       "coefficient": "1 + x**2", "source": str(fe)})
+    assert _verdict(spec, _artefact(m, u, 2)) == "SOLVES"
+    assert _verdict(spec, _artefact(m, exact, 2)) == "DOES_NOT_SOLVE"
+
+
+# ── anisotropic tensor coefficient ────────────────────────────────────────
+def _anisotropic_case():
+    import sympy as sp
+    K = np.array([[2.0, 0.5], [0.5, 1.0]])
+    X, Y = sp.symbols("x y")
+    ue = sp.sin(sp.pi * X) * sp.sin(sp.pi * Y)
+    q = [K[0, 0] * sp.diff(ue, X) + K[0, 1] * sp.diff(ue, Y),
+         K[1, 0] * sp.diff(ue, X) + K[1, 1] * sp.diff(ue, Y)]
+    fe = sp.expand(sp.simplify(-(sp.diff(q[0], X) + sp.diff(q[1], Y))))
+    fnum = sp.lambdify((X, Y), fe, "numpy")
+    m = skfem.MeshTri().refined(5)
+    u = _solve(m, skfem.ElementTriP1(), lambda A: fnum(A[0], A[1]), coeff=K)
+    return m, u, fe, K
+
+
+def test_anisotropic_tensor_coefficient():
+    m, u, fe, K = _anisotropic_case()
+    spec = json.dumps({"operator": "diffusion", "dim": 2, "domain_measure": 1.0,
+                       "coefficient": [["2.0", "0.5"], ["0.5", "1.0"]],
+                       "source": str(fe)})
+    p = m.p.T
+    exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])
+    assert _verdict(spec, _artefact(m, u, 2)) == "SOLVES"
+    assert _verdict(spec, _artefact(m, exact, 2)) == "DOES_NOT_SOLVE"
+
+
+def test_declaring_a_scalar_for_an_anisotropic_problem_does_not_pass():
+    """Otherwise the declaration becomes the loophole: state a simpler operator
+    than the one you solved and the residual is measured against the wrong
+    system."""
+    m, u, fe, _ = _anisotropic_case()
+    spec = json.dumps({"operator": "diffusion", "dim": 2, "domain_measure": 1.0,
+                       "coefficient": "2.0", "source": str(fe)})
+    assert _verdict(spec, _artefact(m, u, 2)) == "DOES_NOT_SOLVE"
+
+
+# ── the whole second-order linear scalar family, in one assembly ──────────
+# Poisson, steady heat, convection-diffusion, reaction-diffusion and Helmholtz
+# are the same operator with different terms present. Before this they were
+# UNSUPPORTED, which is honest and is no protection: a fabricated result on any
+# of them passed every other check in the gate.
+_SCALAR_FAMILY = [
+    ("poisson",              "1",        None,        None),
+    ("diffusion",            "1 + x**2", None,        None),   # variable K
+    ("convection_diffusion", "1",        ["1", "2"],  None),
+    ("reaction_diffusion",   "1",        None,        "5"),
+    # Helmholtz is c = -k^2: indefinite, and the sign must be allowed.
+    ("helmholtz",            "1",        None,        "-16*pi**2"),
+]
+
+
+def _scalar_family_case(coeff, advection, reaction):
+    """Manufacture u = sin(pi x) sin(pi y), derive f for the stated operator,
+    and solve it honestly."""
+    import sympy as sp
+    from skfem import (Basis, BilinearForm, ElementTriP1, LinearForm, asm,
+                       condense, solve)
+    from skfem.helpers import dot, grad
+
+    X, Y = sp.symbols("x y")
+    ue = sp.sin(sp.pi * X) * sp.sin(sp.pi * Y)
+    K = sp.sympify(coeff)
+    b = [sp.sympify(e) for e in (advection or ["0", "0"])]
+    c = sp.sympify(reaction) if reaction is not None else sp.Integer(0)
+    f = sp.simplify(-(sp.diff(K * sp.diff(ue, X), X)
+                      + sp.diff(K * sp.diff(ue, Y), Y))
+                    + b[0] * sp.diff(ue, X) + b[1] * sp.diff(ue, Y) + c * ue)
+
+    fl = sp.lambdify((X, Y), f, "numpy")
+    Kl = sp.lambdify((X, Y), K, "numpy")
+    bl = [sp.lambdify((X, Y), e, "numpy") for e in b]
+    cl = sp.lambdify((X, Y), c, "numpy")
+
+    m = skfem.MeshTri().refined(5)
+    basis = Basis(m, ElementTriP1())
+
+    @BilinearForm
+    def a(u, v, w):
+        out = Kl(w.x[0], w.x[1]) * dot(grad(u), grad(v))
+        g = grad(u)
+        out = out + (bl[0](w.x[0], w.x[1]) * g[0]
+                     + bl[1](w.x[0], w.x[1]) * g[1]) * v
+        return out + cl(w.x[0], w.x[1]) * np.ones_like(w.x[0]) * u * v
+
+    @LinearForm
+    def L(v, w):
+        return fl(w.x[0], w.x[1]) * np.ones_like(w.x[0]) * v
+
+    uh = solve(*condense(asm(a, basis), asm(L, basis), D=basis.get_dofs()))
+    p = m.p.T
+    exact = np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])
+    return m, uh, exact, str(f)
+
+
+@pytest.mark.parametrize("operator, coeff, advection, reaction", _SCALAR_FAMILY,
+                         ids=[c[0] for c in _SCALAR_FAMILY])
+def test_scalar_family_certifies_a_solve_and_rejects_a_forgery(
+        operator, coeff, advection, reaction):
+    m, uh, exact, source = _scalar_family_case(coeff, advection, reaction)
+    spec = {"operator": operator, "dim": 2, "domain_measure": 1.0,
+            "source": source, "coefficient": coeff}
+    if advection:
+        spec["advection"] = advection
+    if reaction is not None:
+        spec["reaction"] = reaction
+    spec = json.dumps(spec)
+    assert _verdict(spec, _artefact(m, uh, 2)) == "SOLVES"
+    assert _verdict(spec, _artefact(m, exact, 2)) == "DOES_NOT_SOLVE"
+
+
+def test_helmholtz_must_declare_its_wave_number():
+    """Silently treating Helmholtz as Poisson would assemble a definite
+    operator for an indefinite problem and certify the wrong thing."""
+    with pytest.raises(ResidualSpecError) as exc:
+        parse_spec({"operator": "helmholtz", "dim": 2, "source": "1"})
+    assert "reaction" in str(exc.value)
+
+
+def test_a_malformed_advection_is_refused():
+    with pytest.raises(ResidualSpecError) as exc:
+        parse_spec({"operator": "convection_diffusion", "dim": 2,
+                    "source": "1", "advection": ["1"]})
+    assert "2-component" in str(exc.value)
+
+
+# ── vector elasticity: the case that used to be UNSUPPORTED ───────────────
+def _elasticity_case():
+    """Manufactured displacement vanishing on the whole boundary, with the body
+    force derived from it symbolically."""
+    import sympy as sp
+    from skfem import (Basis, ElementTriP1, ElementVector, LinearForm, asm,
+                       condense, solve)
+    from skfem.models.elasticity import lame_parameters, linear_elasticity
+
+    E, nu = 1000.0, 0.3
+    lam, mu = lame_parameters(E, nu)
+    X, Y = sp.symbols("x y")
+    ux = sp.sin(sp.pi * X) * sp.sin(sp.pi * Y)
+    uy = sp.Rational(1, 2) * ux
+    eps = [[sp.diff(ux, X), (sp.diff(ux, Y) + sp.diff(uy, X)) / 2],
+           [(sp.diff(ux, Y) + sp.diff(uy, X)) / 2, sp.diff(uy, Y)]]
+    tr = eps[0][0] + eps[1][1]
+    sig = [[2 * mu * eps[0][0] + lam * tr, 2 * mu * eps[0][1]],
+           [2 * mu * eps[1][0], 2 * mu * eps[1][1] + lam * tr]]
+    f1 = sp.simplify(-(sp.diff(sig[0][0], X) + sp.diff(sig[0][1], Y)))
+    f2 = sp.simplify(-(sp.diff(sig[1][0], X) + sp.diff(sig[1][1], Y)))
+    fn = [sp.lambdify((X, Y), f, "numpy") for f in (f1, f2)]
+
+    def src(A):
+        return np.array([fn[0](A[0], A[1]) * np.ones_like(A[0]),
+                         fn[1](A[0], A[1]) * np.ones_like(A[0])])
+
+    m = skfem.MeshTri().refined(5)
+    basis = Basis(m, ElementVector(ElementTriP1()))
+
+    @LinearForm
+    def L(v, w):
+        f = src(w.x)
+        return f[0] * v[0] + f[1] * v[1]
+
+    uh = solve(*condense(asm(linear_elasticity(lam, mu), basis), asm(L, basis),
+                         D=basis.get_dofs()))
+    nd = basis.nodal_dofs
+    p = m.p.T
+    genuine = np.column_stack([uh[nd[0]], uh[nd[1]]])
+    exact = np.column_stack([np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1]),
+                             0.5 * np.sin(np.pi * p[:, 0]) * np.sin(np.pi * p[:, 1])])
+    spec = json.dumps({"operator": "elasticity", "dim": 2, "young": E,
+                       "poisson": nu, "domain_measure": 1.0,
+                       "source": [str(f1), str(f2)]})
+    return m, p, genuine, exact, spec
+
+
+def _vector_artefact(m, p, values):
+    d = Path(tempfile.mkdtemp())
+    path = d / "solution.vtu"
+    meshio.write_points_cells(
+        str(path), np.column_stack([p, np.zeros(len(p))]),
+        [("triangle", m.t.T)],
+        point_data={"u": np.column_stack([values, np.zeros(len(p))])})
+    return [path]
+
+
+def test_elasticity_genuine_solve_and_forgery():
+    m, p, genuine, exact, spec = _elasticity_case()
+    assert _verdict(spec, _vector_artefact(m, p, genuine)) == "SOLVES"
+    assert _verdict(spec, _vector_artefact(m, p, exact)) == "DOES_NOT_SOLVE"
+
+
+def test_elasticity_discriminates_on_the_equations_not_on_accuracy():
+    """The genuine solve differs from the exact field by the discretisation
+    error, so this cannot be passing merely because one equals the other."""
+    m, p, genuine, exact, _ = _elasticity_case()
+    assert np.abs(genuine - exact).max() > 1e-4
+
+
+def test_elasticity_zero_field_is_refused():
+    m, p, genuine, _, spec = _elasticity_case()
+    zeros = np.zeros_like(genuine)
+    assert _verdict(spec, _vector_artefact(m, p, zeros)) == "DOES_NOT_SOLVE"
+
+
+@pytest.mark.parametrize("spec, why", [
+    ({"operator": "elasticity", "dim": 2, "source": ["0", "0"]}, "young"),
+    ({"operator": "elasticity", "dim": 2, "source": ["0", "0"], "young": 1.0},
+     "poisson"),
+    ({"operator": "elasticity", "dim": 2, "source": "0", "young": 1.0,
+      "poisson": 0.3}, "2-component body force"),
+    ({"operator": "elasticity", "dim": 3, "source": ["0", "0"], "young": 1.0,
+      "poisson": 0.3}, "3-component body force"),
+])
+def test_elasticity_declarations_must_be_complete(spec, why):
+    with pytest.raises(ResidualSpecError) as exc:
+        parse_spec(spec)
+    assert why in str(exc.value)
+
+
+# ── declarations that must be refused, never quietly accepted ─────────────
+@pytest.mark.parametrize("spec, why", [
+    ({"operator": "navier_stokes", "source": "0", "dim": 2}, "assemble"),
+    ({"operator": "diffusion", "dim": 2}, "source term"),
+    ({"operator": "diffusion", "dim": 5, "source": "1"}, "dim must be"),
+    ({"operator": "diffusion", "dim": 2, "source": "__import__('os')"}, "not an available function"),
+    ({"operator": "diffusion", "dim": 2, "source": "x.__class__"}, "not allowed"),
+    ({"operator": "diffusion", "dim": 2, "source": "open('/etc/passwd')"}, "not an available function"),
+    ({"operator": "diffusion", "dim": 2, "source": "1", "coefficient": [["1", "0"]]}, "2x2"),
+    ({"operator": "diffusion", "dim": 2, "source": "q + 1"}, "unknown name"),
+    ({"operator": "diffusion", "dim": 2, "source": "[i for i in range(3)]"}, "not allowed"),
+])
+def test_malformed_declarations_are_refused(spec, why):
+    with pytest.raises(ResidualSpecError) as exc:
+        parse_spec(spec)
+    assert why in str(exc.value)
+
+
+def test_a_refused_declaration_never_reads_as_a_pass():
+    """'Not checked' must not be reachable as 'checked and fine'."""
+    m = skfem.MeshTri().refined(3)
+    files = _artefact(m, np.zeros(m.p.shape[1]), 2)
+    for bad in ('{"operator": "elasticity", "source": "0", "dim": 2}',
+                "not json at all",
+                '{"operator": "diffusion", "dim": 2}'):
+        out = check_run_residual(bad, files)
+        assert out["verdict"] == "REFUSED", out
+        assert out["verdict"] != "SOLVES"

--- a/tests/test_results_file_is_not_stale.py
+++ b/tests/test_results_file_is_not_stale.py
@@ -1,0 +1,129 @@
+"""The recorded pass record must describe the fixtures that exist.
+
+WHAT WENT WRONG
+---------------
+`scripts/scan_results/tier2_results.json` is the record of which fixtures ran
+and passed. `tests/test_signal_verification.py` gates on it, and
+`scripts/verify_signal_clauses.py` reads it.
+
+Measured on one branch: **303 fixture directories on disk, 108 rows recorded.**
+The file had not been rewritten as fixtures were added, so two thirds of the
+suite had no entry — and a gate reading it was certifying a pass count that
+described a tree from weeks earlier. Nothing failed; the number was simply about
+a different suite than the one in the repository.
+
+That is the same shape as every other defect this project keeps finding: not a
+wrong answer, but a right-looking answer about the wrong thing. It is worse here
+than most, because this file is what "the fixtures pass" MEANS when someone
+asks for evidence.
+
+A SECOND DEFECT IN THE SAME FILE
+--------------------------------
+Three keys are recorded more than once — `elasticity_mms_convergence` four
+times, `poisson_mms_convergence` four, `stokes_mms_convergence` three. Different
+BACKENDS reuse the same fixture NAME, and the results are keyed by name, so each
+new backend's result overwrites the previous one's. Ten distinct runs collapse
+to three rows, and whichever backend ran last is the one the record describes.
+
+WHAT THIS GATE DOES
+-------------------
+It does not require the file to be regenerated on every commit — running 300
+fixtures takes hours and several need solvers that are not on every machine. It
+requires the file to be HONEST about what it covers: if it claims fewer fixtures
+than exist, that must be visible rather than silently read as full coverage, and
+its keys must distinguish fixtures that are genuinely different.
+
+The tolerance is deliberately generous. The point is to catch a record that has
+drifted far from the tree, not to demand it be perfectly current.
+"""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+RESULTS = REPO / "scripts" / "scan_results" / "tier2_results.json"
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+
+# How far the record may lag the tree before it stops meaning anything. A record
+# covering under half the suite is not "slightly stale", it is about a different
+# suite.
+MIN_COVERAGE_OF_TREE = 0.50
+
+
+def _rows(payload) -> list:
+    if isinstance(payload, dict):
+        for key in ("results", "fixtures", "rows"):
+            v = payload.get(key)
+            if isinstance(v, list):
+                return v
+            if isinstance(v, dict):
+                return list(v.values())
+        return [v for v in payload.values() if isinstance(v, dict)]
+    return payload if isinstance(payload, list) else []
+
+
+def _fixture_dirs() -> list[Path]:
+    if not FIXTURES.is_dir():
+        return []
+    return [d for be in FIXTURES.iterdir() if be.is_dir()
+            for d in be.iterdir() if (d / "fixture.json").is_file()]
+
+
+def test_results_file_covers_most_of_the_tree():
+    """A record about a third of the suite must not read as a full pass."""
+    if not RESULTS.is_file():
+        pytest.skip("no tier2_results.json — nothing claims to be a record")
+    on_disk = _fixture_dirs()
+    if not on_disk:
+        pytest.skip("no fixtures in this tree")
+
+    rows = _rows(json.loads(RESULTS.read_text()))
+    ratio = len(rows) / len(on_disk)
+
+    assert ratio >= MIN_COVERAGE_OF_TREE, (
+        f"tier2_results.json records {len(rows)} results but {len(on_disk)} "
+        f"fixtures exist ({ratio:.0%} of the tree). A gate reads this file as "
+        f"the pass record, so it is currently certifying a suite that no longer "
+        f"matches the repository.\n\n"
+        f"Regenerate it — `scripts/run_tier2_fixtures.py --write-results` — or, "
+        f"if the fixtures cannot all run on this machine, record that explicitly "
+        f"so nobody mistakes a partial record for a complete one. Note the "
+        f"`--write-results` flag was itself parsed and never read for a while, "
+        f"so confirm the file's timestamp actually changes.")
+
+
+def test_results_keys_distinguish_different_fixtures():
+    """Two different fixtures must not share one row.
+
+    Measured: `elasticity_mms_convergence` appears four times, once per backend
+    that happens to use that name. Keyed by name alone, each backend's result
+    overwrites the last, so ten runs become three rows and the record describes
+    whichever backend ran most recently.
+    """
+    if not RESULTS.is_file():
+        pytest.skip("no tier2_results.json")
+    rows = _rows(json.loads(RESULTS.read_text()))
+    if not rows:
+        pytest.skip("results file records nothing")
+
+    keys = Counter()
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        key = r.get("fixture_id") or r.get("id") or r.get("name")
+        if key is None:
+            key = f"{r.get('backend')}::{r.get('physics')}::{r.get('pitfall_index')}"
+        keys[str(key)] += 1
+
+    collisions = {k: n for k, n in keys.items() if n > 1}
+    assert not collisions, (
+        f"{len(collisions)} result keys appear more than once, so results "
+        f"overwrite each other and the record describes only the last writer:\n"
+        + "\n".join(f"  {k} x{n}" for k, n in list(collisions.items())[:10])
+        + "\n\nDifferent backends legitimately reuse fixture NAMES — "
+          "elasticity_mms_convergence exists under several. Key the record by "
+          "backend AND name so each run keeps its own row.")

--- a/tests/test_setup_knowledge.py
+++ b/tests/test_setup_knowledge.py
@@ -1,0 +1,543 @@
+"""Guards for the install / setup / build-configuration surface.
+
+WHAT THIS PROTECTS
+    `src/backends/_setup.py` is the first thing a new user needs and the last
+    thing anyone re-checks. It is also the surface most exposed to drift,
+    because it describes the machine it was written on: an install route stays
+    in the file long after the package it names has moved, and a claim keeps
+    its confident tone long after the build option it depended on changed.
+
+    So the tests here enforce SHAPE rather than content, with one exception.
+    The exception is the important one:
+
+        A claim that depends on build configuration MUST tell the reader how
+        to find out which configuration they have.
+
+    That is the whole point of the surface. "deal.II raises ExcDivideByZero on
+    CG breakdown" is a true sentence and a useless one, because it is true on
+    a Debug build and impossible on a Release build, and the reader has no
+    idea which they are running. The fix is not to delete the claim — it is to
+    ship the check alongside it. `test_build_config_claims_carry_a_check`
+    makes that mechanical instead of aspirational.
+
+WHAT THIS DELIBERATELY DOES NOT DO
+    It does not assert that any measured quantity has a particular value, and
+    it does not re-verify the quoted error strings by running solvers. A test
+    that shells out to nine backends would be skipped on almost every machine
+    that runs the suite, and a skipped test guards nothing. The strings were
+    verified by execution when they were written; what a merge gate can
+    usefully add is that nobody adds an entry in the WRONG SHAPE afterwards.
+
+    Where a test does touch a real install, it SKIPS when the install is
+    absent rather than passing — same rule as
+    tests/test_fixtures_cannot_pass_vacuously.py. A pass on a machine that
+    could not run the check is worse than no test, because it is indistinguish-
+    able from a pass on a machine that could.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+from backends._setup import (  # noqa: E402
+    CONFIG_PROBES, PORTABILITY_EVIDENCE, SETUP_KNOWLEDGE, get_setup_knowledge,
+    get_setup_pitfalls,
+)
+
+# The sub-kinds an entry may declare. Every pitfall starts with one of these.
+_SUBKINDS = ("[Integration][Install]", "[Integration][Discovery]",
+             "[Integration][FirstRun]", "[Integration][BuildConfig]",
+             "[Integration][Portability]")
+
+
+class TestCoverage(unittest.TestCase):
+
+    def test_every_registered_backend_has_setup_knowledge(self):
+        """A backend OASiS advertises but cannot tell you how to install is a
+        backend a stranger cannot use. Derived from the registry, not from a
+        hardcoded list, so adding a backend fails here until it is covered."""
+        from core.registry import all_backends, load_all_backends
+
+        load_all_backends()
+        registered = {b.name() for b in all_backends()}
+        self.assertTrue(registered, "no backends registered at all")
+        missing = sorted(registered - set(SETUP_KNOWLEDGE))
+        self.assertFalse(
+            missing,
+            f"registered backend(s) with no setup knowledge: {missing}. "
+            f"Add an entry to src/backends/_setup.py.")
+
+    def test_each_entry_is_complete(self):
+        for name, entry in SETUP_KNOWLEDGE.items():
+            with self.subTest(backend=name):
+                for key in ("verified_on", "install_route", "pitfalls"):
+                    self.assertIn(key, entry, f"{name} is missing {key!r}")
+                    self.assertTrue(str(entry[key]).strip(),
+                                    f"{name}'s {key} is empty")
+                self.assertGreaterEqual(
+                    len(entry["pitfalls"]), 2,
+                    f"{name} has fewer than two setup pitfalls — install and "
+                    f"discovery are separate failure modes and both bite")
+
+    def test_install_route_gives_runnable_commands(self):
+        """An install instruction a reader cannot copy is a description, not
+        an instruction. Every route must contain at least one recognisable
+        command, not just prose about one."""
+        verbs = ("pip install", "conda create", "conda install", "apt install",
+                 "git clone", "cmake", "make ", "brew install")
+        for name, entry in SETUP_KNOWLEDGE.items():
+            with self.subTest(backend=name):
+                route = entry["install_route"]
+                self.assertTrue(
+                    any(v in route for v in verbs),
+                    f"{name}'s install_route contains no runnable command "
+                    f"(looked for {verbs})")
+
+
+class TestShape(unittest.TestCase):
+
+    def test_every_pitfall_is_categorised(self):
+        """Same [Category] discipline as the rest of the pitfall DB, plus a
+        sub-kind — the sub-kind is what lets a caller pick out the
+        build-conditional ones."""
+        for name, entry in SETUP_KNOWLEDGE.items():
+            for i, p in enumerate(entry["pitfalls"]):
+                with self.subTest(backend=name, index=i):
+                    self.assertTrue(
+                        p.startswith(_SUBKINDS),
+                        f"{name}[{i}] does not start with one of "
+                        f"{_SUBKINDS}: {p[:70]!r}")
+
+    def test_pitfalls_are_prose_not_stubs(self):
+        """A one-line pitfall is a headline. The value is in what the reader
+        sees and what to do about it."""
+        for name, entry in SETUP_KNOWLEDGE.items():
+            for i, p in enumerate(entry["pitfalls"]):
+                with self.subTest(backend=name, index=i):
+                    self.assertGreater(
+                        len(p), 180,
+                        f"{name}[{i}] is too short to carry a symptom and a "
+                        f"defense: {p!r}")
+
+    def test_failure_claims_quote_a_signal(self):
+        """Install, discovery and first-run entries describe something going
+        wrong, so each must say what the user actually SEES. Portability and
+        build-config entries are exempt: they are about scope, and their
+        useful content is a version range or a probe."""
+        needs_signal = ("[Integration][Install]", "[Integration][Discovery]",
+                        "[Integration][FirstRun]")
+        for name, entry in SETUP_KNOWLEDGE.items():
+            for i, p in enumerate(entry["pitfalls"]):
+                if not p.startswith(needs_signal):
+                    continue
+                with self.subTest(backend=name, index=i):
+                    self.assertIn(
+                        "Signal", p,
+                        f"{name}[{i}] claims a failure without saying what "
+                        f"the user sees. Quote the real message.")
+
+
+class TestBuildConfigScoping(unittest.TestCase):
+    """The load-bearing rule of this module."""
+
+    # Words whose presence means the claim is conditional on how the backend
+    # was compiled. A claim mentioning any of these has to be scoped.
+    _CONFIG_WORDS = re.compile(
+        r"\b(Debug|Release|CMAKE_BUILD_TYPE|MKL|PETSc|Trilinos|p4est|MPI|"
+        r"KOKKOS|complex|UMFPACK|SLEPc|glibc|GLIBC)\b")
+
+    # Ways an entry can discharge the obligation: point at a probe, give a
+    # command, or name the file that answers the question.
+    _CHECK_MARKERS = ("CONFIG_PROBES[", "Check with", "Check which",
+                      "Defense:", "check `", "grep", "ldd ", "objdump",
+                      "readelf", "make ps", "-info", "config.h")
+
+    def test_build_config_claims_carry_a_check(self):
+        """A build-conditional claim must ship the way to check the build.
+
+        This is the rule the whole module exists for. A reader on a different
+        build than ours needs to know (a) that the claim is conditional and
+        (b) how to find out which side of it they are on. An entry that
+        states the behaviour flat leaves them worse off than silence, because
+        they will act on a claim that is false for them."""
+        for name, entry in SETUP_KNOWLEDGE.items():
+            for i, p in enumerate(entry["pitfalls"]):
+                if not p.startswith("[Integration][BuildConfig]"):
+                    continue
+                with self.subTest(backend=name, index=i):
+                    self.assertTrue(
+                        any(m in p for m in self._CHECK_MARKERS),
+                        f"{name}[{i}] is a build-configuration claim with no "
+                        f"way for the reader to check their own build. Add a "
+                        f"CONFIG_PROBES reference or an explicit command.\n"
+                        f"  {p[:200]}")
+
+    def test_config_words_outside_build_config_entries_are_scoped(self):
+        """A configuration-dependent word in a NON-BuildConfig entry is how
+        an unscoped claim sneaks in. Allow it only where the entry also says
+        what it was checked against, or tells the reader how to check."""
+        allowed = self._CHECK_MARKERS + (
+            "verified", "Verified", "checked here", "was not possible",
+            "unverified", "only", "scoped", "Version range")
+        for name, entry in SETUP_KNOWLEDGE.items():
+            for i, p in enumerate(entry["pitfalls"]):
+                if p.startswith("[Integration][BuildConfig]"):
+                    continue
+                if not self._CONFIG_WORDS.search(p):
+                    continue
+                with self.subTest(backend=name, index=i):
+                    self.assertTrue(
+                        any(m in p for m in allowed),
+                        f"{name}[{i}] mentions a build-dependent feature "
+                        f"without scoping it or offering a check.\n"
+                        f"  {p[:200]}")
+
+    def test_every_probe_is_usable(self):
+        for key, probe in CONFIG_PROBES.items():
+            with self.subTest(probe=key):
+                for field in ("what", "command", "reading"):
+                    self.assertIn(field, probe)
+                    self.assertTrue(str(probe[field]).strip())
+                self.assertTrue(
+                    probe["reading"].strip(),
+                    f"{key} gives a command but not how to read its output — "
+                    f"a weak reader needs both")
+
+    def test_probes_referenced_by_pitfalls_exist(self):
+        """A dangling probe reference is worse than none: the reader goes
+        looking for something that is not there."""
+        rx = re.compile(r"CONFIG_PROBES\['([a-z_]+)'\]")
+        for name, entry in SETUP_KNOWLEDGE.items():
+            for i, p in enumerate(entry["pitfalls"]):
+                for key in rx.findall(p):
+                    with self.subTest(backend=name, index=i, probe=key):
+                        self.assertIn(
+                            key, CONFIG_PROBES,
+                            f"{name}[{i}] references CONFIG_PROBES[{key!r}], "
+                            f"which does not exist")
+
+
+class TestNoHostPaths(unittest.TestCase):
+
+    def test_no_absolute_host_paths_in_the_payload(self):
+        """Install knowledge legitimately talks about locations, so it is the
+        surface most likely to bake in one machine's layout. Describe how to
+        FIND a path; never ship the path.
+
+        Exempt: /usr, /opt and /lib prefixes that name a genuine system-wide
+        convention (a distribution deal.II really is at /usr), and the loader
+        path inside a quoted error message, which is what the user will
+        actually see on their own machine."""
+        bad = re.compile(r"(/home/[a-z][a-z0-9_-]*|/media/[a-z][a-z0-9_-]*|"
+                         r"/Users/[a-z][a-z0-9_-]*)", re.IGNORECASE)
+        hits = []
+        for name, entry in SETUP_KNOWLEDGE.items():
+            blob = json.dumps(entry)
+            for m in bad.finditer(blob):
+                hits.append(f"{name}: …{blob[max(0, m.start() - 60):m.end() + 40]}…")
+        self.assertFalse(
+            hits,
+            "An absolute host path is shipped as install knowledge. Give the "
+            "command that finds it instead.\n  " + "\n  ".join(hits[:6]))
+
+    def test_probe_commands_use_placeholders(self):
+        for key, probe in CONFIG_PROBES.items():
+            with self.subTest(probe=key):
+                self.assertNotRegex(
+                    probe["command"], r"/home/|/media/|/Users/",
+                    f"probe {key} hard-codes a host path")
+
+
+class TestReachability(unittest.TestCase):
+    """A surface a caller cannot find is a surface that does not exist."""
+
+    def test_alias_lookup_resolves_every_spelling(self):
+        for spelling, canonical in (
+                ("deal.ii", "dealii"), ("deal_ii", "dealii"),
+                ("fenicsx", "fenics"), ("dolfinx", "fenics"),
+                ("4c", "fourc"), ("dune-fem", "dune"),
+                ("scikit-fem", "skfem"), ("DEALII", "dealii"),
+                ("  Fenics  ", "fenics")):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(
+                    get_setup_knowledge(spelling).get("backend"), canonical)
+
+    def test_unknown_backend_lists_the_known_ones(self):
+        out = get_setup_knowledge("nosuchsolver")
+        self.assertIn("error", out)
+        self.assertIn("known", out)
+        self.assertIn("dealii", out["known"])
+
+    def test_no_argument_returns_everything_plus_probes(self):
+        out = get_setup_knowledge()
+        self.assertEqual(set(out["backends"]), set(SETUP_KNOWLEDGE))
+        self.assertEqual(set(out["config_probes"]), set(CONFIG_PROBES))
+        self.assertIn("_how_to_use", out)
+
+    def test_setup_pitfalls_are_merged_into_the_pitfalls_topic(self):
+        """An agent debugging a failed run asks for 'pitfalls'. If the setup
+        entries were only reachable under a topic string it has to guess, the
+        one class of pitfall it most needs would be the one it never sees."""
+        import tools.consolidated as consolidated
+
+        src = Path(consolidated.__file__).read_text()
+        self.assertIn("get_setup_pitfalls", src,
+                      "the pitfalls topic no longer merges setup pitfalls")
+        self.assertIn("install_and_build_config", src)
+
+    def test_topic_aliases_cover_the_obvious_words(self):
+        import tools.consolidated as consolidated
+
+        for word in ("install", "setup", "dependencies", "build_config",
+                     "portability"):
+            self.assertIn(word, consolidated._SETUP_TOPIC_ALIASES,
+                          f"topic={word!r} should reach the setup surface")
+
+    def test_get_setup_pitfalls_matches_the_entry(self):
+        for name in SETUP_KNOWLEDGE:
+            with self.subTest(backend=name):
+                self.assertEqual(get_setup_pitfalls(name),
+                                 SETUP_KNOWLEDGE[name]["pitfalls"])
+
+
+class TestPortabilityEvidence(unittest.TestCase):
+    """The record of what was actually re-checked, and what was not.
+
+    The failure this guards against is a file that quietly becomes confident:
+    someone adds claims, nobody adds evidence, and a year later every entry
+    reads as though it were verified everywhere. Requiring the gaps to be
+    written down makes the confident entries mean something."""
+
+    def test_every_evidence_entry_says_what_happened(self):
+        for key, ev in PORTABILITY_EVIDENCE.items():
+            if key == "not_tested":
+                continue
+            with self.subTest(env=key):
+                for field in ("what", "installed", "result"):
+                    self.assertIn(field, ev, f"{key} lacks {field!r}")
+                    self.assertTrue(str(ev[field]).strip())
+
+    def test_the_untested_list_is_not_empty(self):
+        """An honest record of a single machine ALWAYS has gaps. An empty
+        not_tested section means either the section rotted or somebody
+        stopped being careful; neither is a state to merge."""
+        not_tested = PORTABILITY_EVIDENCE.get("not_tested", {})
+        self.assertTrue(
+            not_tested,
+            "not_tested is empty. Everything here was checked on one machine; "
+            "if nothing is listed as untested, the record is wrong.")
+        for key, reason in not_tested.items():
+            with self.subTest(gap=key):
+                self.assertGreater(
+                    len(str(reason)), 60,
+                    f"{key} is listed as untested without saying why or what "
+                    f"that costs the reader")
+
+    # Words that hedge a claim. Case-insensitive on purpose: the text writes
+    # "was NOT observed" for emphasis, and a case-sensitive membership test
+    # silently missed it.
+    _HEDGES = ("was not possible", "unverified", "not observed", "not checked",
+               "limited to", "checked here", "checked on", "sourced", "scoped",
+               "nothing here claims", "rather than confirmed", "only the")
+
+    def test_untested_configurations_are_reflected_in_the_pitfalls(self):
+        """A gap recorded here but not visible in the pitfall text helps
+        nobody: the agent reads pitfalls, not this dict.
+
+        The hedge must sit in the SAME pitfall as the gap's own subject. An
+        earlier version of this test joined all of a backend's pitfalls and
+        asked whether any hedge word appeared anywhere in the result, which is
+        not the same question. An audit falsified it by mutation: strip every
+        hedge from FEBio's MKL entry, state flat that "the pardiso solver is
+        faster and is the one to use", leave the words "checked here" in the
+        unrelated Discovery entry — and the test still passed. A gate that a
+        fabricated claim walks through is worse than no gate, because it is
+        cited as evidence the claim was checked.
+
+        Each gap therefore declares the tokens that identify the pitfall it
+        belongs to; the hedge is required in a pitfall that mentions one.
+        """
+        # gap -> (backend, tokens that identify the pitfall carrying the claim)
+        gaps = {
+            "dealii_debug": ("dealii", ("Debug", "Release")),
+            "dealii_optional_deps": ("dealii", ("PETSc", "Trilinos", "MPI")),
+            "febio_with_mkl": ("febio", ("MKL", "pardiso")),
+            "sparta_with_kokkos": ("sparta", ("KOKKOS",)),
+            "macos_and_windows": (None, ()),   # cross-cutting; see below
+        }
+        not_tested = PORTABILITY_EVIDENCE.get("not_tested", {})
+
+        # Every recorded gap must be listed here, or a new gap can be added
+        # with no enforcement at all — which is how macos_and_windows went
+        # unchecked until an audit noticed.
+        self.assertEqual(
+            set(not_tested) - set(gaps), set(),
+            "a gap is recorded in not_tested with no enforcement mapping in "
+            "this test. Add it to `gaps` (with the tokens that identify the "
+            "pitfall it belongs to) so removing its hedge fails the suite.")
+
+        for gap, (backend, tokens) in gaps.items():
+            if gap not in not_tested or backend is None:
+                continue
+            with self.subTest(gap=gap):
+                carriers = [p for p in SETUP_KNOWLEDGE[backend]["pitfalls"]
+                            if any(t in p for t in tokens)]
+                self.assertTrue(
+                    carriers,
+                    f"{gap} is recorded as untested but no {backend} pitfall "
+                    f"even mentions {tokens} — the gap is invisible to the "
+                    f"agent.")
+                hedged = [p for p in carriers
+                          if any(h in p.lower() for h in self._HEDGES)]
+                self.assertTrue(
+                    hedged,
+                    f"{gap} is recorded as untested, and the {len(carriers)} "
+                    f"{backend} pitfall(s) that carry the claim state it FLAT. "
+                    f"A hedge elsewhere in the backend's text does not count: "
+                    f"scope the claim in the entry the agent will read.")
+
+    def test_the_hedging_gate_rejects_the_mutation_that_defeated_it(self):
+        """Proof the predicate discriminates, rather than trusting that a green
+        run means anything. Same rule as
+        tests/test_fixtures_cannot_pass_vacuously.py."""
+        flat = ("[Integration][BuildConfig] MKL PRESENCE CHANGES THE DEFAULT "
+                "LINEAR SOLVER. Signal of an MKL build: `Default linear "
+                "solver: pardiso`. The pardiso solver is faster and is the "
+                "one to use.")
+        decoy = ("[Integration][Discovery] FEBIO_BINARY is optional. "
+                 "Discovery order was checked here.")
+        hedges = self._HEDGES
+        carriers = [p for p in (flat, decoy) if "MKL" in p or "pardiso" in p]
+        self.assertEqual(carriers, [flat], "token match picked the wrong entry")
+        self.assertFalse(
+            [p for p in carriers if any(h in p.lower() for h in hedges)],
+            "the gate still accepts a flat MKL claim when an unrelated entry "
+            "carries the hedge word — the mutation that defeated the previous "
+            "version of this test")
+
+
+class TestAgainstRealInstalls(unittest.TestCase):
+    """Checks that touch a real install — and SKIP, never pass, without one.
+
+    These are the only tests here that can catch the knowledge going stale
+    against the software rather than against itself. They are few on purpose:
+    each one is a claim that can be settled with a single cheap command.
+    """
+
+    def _skip_without(self, path: Path | None, what: str):
+        if path is None or not Path(path).exists():
+            self.skipTest(
+                f"{what} not present on this machine — SKIPPED, not passed. "
+                f"A pass here would be indistinguishable from a pass on a "
+                f"machine that has it.")
+
+    def test_dealii_build_type_probe_reads_a_real_config(self):
+        """The deal.II feature probe must actually work on a real install:
+        config.h must exist and its DEAL_II_WITH_ lines must be parseable in
+        the two forms the knowledge says to look for."""
+        try:
+            from backends.dealii.backend import _find_dealii
+        except ImportError:
+            self.skipTest("dealii backend not importable")
+        root = _find_dealii()
+        self._skip_without(root, "a deal.II install")
+        cfgs = list(Path(root).rglob("deal.II/base/config.h"))
+        self.assertTrue(
+            cfgs,
+            f"no deal.II/base/config.h under the discovered root — the "
+            f"feature probe in _setup.py would find nothing")
+        text = cfgs[0].read_text(errors="ignore")
+        self.assertRegex(
+            text, r"#define DEAL_II_WITH_\w+|/\* #undef DEAL_II_WITH_\w+ \*/",
+            "config.h has neither form of DEAL_II_WITH_ line, so the "
+            "documented reading of it is wrong")
+
+    def test_dealii_header_presence_really_is_a_false_positive(self):
+        """The claim: on a source build, feature headers exist whether or not
+        the feature is on, so only config.h is authoritative. If a header is
+        present while config.h says the feature is OFF, the claim holds."""
+        try:
+            from backends.dealii.backend import _find_dealii
+        except ImportError:
+            self.skipTest("dealii backend not importable")
+        root = _find_dealii()
+        self._skip_without(root, "a deal.II install")
+        cfgs = list(Path(root).rglob("deal.II/base/config.h"))
+        if not cfgs:
+            self.skipTest("no config.h to read features from")
+        text = cfgs[0].read_text(errors="ignore")
+        off = {m for m in re.findall(
+            r"/\* #undef DEAL_II_WITH_(\w+) \*/", text)}
+        if not off:
+            self.skipTest("this deal.II has every feature on — the false "
+                          "positive cannot be demonstrated here")
+        probes = {"PETSC": "lac/petsc_vector.h",
+                  "TRILINOS": "lac/trilinos_vector.h",
+                  "SLEPC": "lac/slepc_solver.h",
+                  "MPI": "base/mpi.h",
+                  "P4EST": "distributed/tria.h"}
+        for feature, rel in probes.items():
+            if feature not in off:
+                continue
+            hits = list(Path(root).rglob(f"include/deal.II/{rel}"))
+            if hits:
+                # Claim demonstrated: header present, feature off.
+                return
+        self.skipTest("no feature is both OFF and header-probeable on this "
+                      "install — cannot demonstrate the false positive here")
+
+    def test_sparta_kokkos_refusals_are_real_strings(self):
+        """The three KOKKOS messages are quoted verbatim in the knowledge.
+        Check them against the binary's own string table."""
+        try:
+            from backends.sparta.backend import _find_sparta_binary
+        except ImportError:
+            self.skipTest("sparta backend not importable")
+        binary = _find_sparta_binary()
+        self._skip_without(binary and Path(binary), "a SPARTA binary")
+        if not shutil.which("strings"):
+            self.skipTest("`strings` not available to read the binary")
+        out = subprocess.run(["strings", str(binary)], capture_output=True,
+                             text=True, timeout=120).stdout
+        entry = " ".join(SETUP_KNOWLEDGE["sparta"]["pitfalls"])
+        for quoted in ("Cannot use -kokkos on without KOKKOS installed",
+                       "Package kokkos command without KOKKOS package "
+                       "enabled"):
+            with self.subTest(message=quoted[:40]):
+                self.assertIn(quoted, entry,
+                              "knowledge no longer quotes this message")
+                self.assertIn(
+                    quoted, out,
+                    f"the knowledge quotes a SPARTA message that this binary "
+                    f"does not contain: {quoted!r}. Either the message "
+                    f"changed upstream or it was never real.")
+
+    def test_febio_version_flag_claim_holds(self):
+        """The knowledge says `-v` is not a valid FEBio flag and `-info` is.
+        Cheap to settle; expensive to get wrong, because it is the command we
+        tell people to use to check they have the right binary."""
+        try:
+            from backends.febio.backend import _find_febio_binary
+        except ImportError:
+            self.skipTest("febio backend not importable")
+        binary = _find_febio_binary()
+        self._skip_without(binary, "an FEBio binary")
+        r = subprocess.run([str(binary), "-v"], capture_output=True,
+                           text=True, timeout=60)
+        combined = (r.stdout or "") + (r.stderr or "")
+        self.assertIn(
+            "Invalid command line option", combined,
+            "the knowledge says `febio4 -v` is rejected as an invalid "
+            "option; this binary answered otherwise")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shared_helpers_are_stageable.py
+++ b/tests/test_shared_helpers_are_stageable.py
@@ -1,0 +1,94 @@
+"""A shared helper must survive being copied into the mutation scratch tree.
+
+WHY, and this has now bitten three times
+----------------------------------------
+The mutation harness copies a fixture into a temporary directory and runs it
+there, so a fixture that reaches outside its own directory only works if the
+harness brings that thing along. It stages siblings whose name begins with `_`:
+
+    scripts/mutate_tier2_fixtures.py:83
+        if sib.is_dir() and sib.name.startswith("_"):
+
+**Directories only.** A shared helper written as a bare `_helper.py` is never
+copied, the staged fixture cannot import it, and the run dies before the
+mutation is even applied. The harness then reports VACUOUS_BASELINE — "I could
+not evaluate this" — which is easy to skim past as "not red".
+
+That is the whole danger. The mutation verdict is the ONLY evidence that a
+fixture detects its pathology rather than passing for some unrelated reason, so
+a harness that cannot evaluate is indistinguishable from a fixture that has no
+evidence, and both look calm in a summary.
+
+Three separate instances, all found by execution rather than review:
+
+  * 4C — 174 fixtures sourced `../_lib/preamble.sh`, which the harness did not
+    stage at all. Sampled 12 and 9 were vacuous: the UNMUTATED copy already
+    failed, so every mutation "KILLED" for the wrong reason. Fixed by staging
+    the parent layout, plus a baseline precheck that emits VACUOUS_BASELINE
+    instead of a verdict.
+  * coupling — the flagship's 18 fixtures shared a bare `_couplinglib.py`. All
+    18 would have been vacuous. Fixed by making it `_lib/`.
+  * febio (70 fixtures) and sparta (27) still share `_febio_lib.py` and
+    `_spahelp.py` as bare files. 97 fixtures whose mutation evidence would mean
+    nothing.
+
+The fix is trivial — make the helper a package directory — which is exactly why
+it should be enforced rather than remembered.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "scripts" / "tier2_fixtures"
+
+BACKENDS = sorted(p.name for p in FIXTURES.iterdir() if p.is_dir()) \
+    if FIXTURES.is_dir() else []
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_shared_helpers_are_directories(backend):
+    """A `_`-prefixed sibling must be a directory, or it is never staged."""
+    be = FIXTURES / backend
+    if not be.is_dir():
+        pytest.skip(f"{backend} has no fixtures")
+
+    bare = []
+    for item in sorted(be.iterdir()):
+        name = item.name
+        if not name.startswith("_") or name.startswith("__"):
+            continue  # __pycache__ and friends are not helpers
+        if item.is_file():
+            # Count how many fixtures would be affected, so the message says
+            # how much evidence is at stake rather than just naming a file.
+            stem = item.stem
+            users = 0
+            for d in be.iterdir():
+                if not d.is_dir():
+                    continue
+                for f in d.iterdir():
+                    if f.is_file() and f.suffix in (".py", ".sh"):
+                        try:
+                            if stem in f.read_text(errors="ignore"):
+                                users += 1
+                                break
+                        except OSError:
+                            pass
+            bare.append(f"{name} — imported by ~{users} fixtures")
+
+    assert not bare, (
+        f"{backend}: shared helpers are bare FILES, which the mutation harness "
+        f"never stages (it copies `_`-prefixed DIRECTORIES only, "
+        f"mutate_tier2_fixtures.py:83):\n  " + "\n  ".join(bare)
+        + "\n\nEvery fixture importing one of these dies in the scratch tree "
+          "before its mutation is applied, and the harness reports "
+          "VACUOUS_BASELINE — which reads as 'not red' rather than 'no "
+          "evidence'. Since the mutation verdict is the only proof a fixture "
+          "detects its pathology, that silently voids the evidence for all of "
+          "them.\n\n"
+          "Fix: make the helper a package directory — `_lib/__init__.py` plus "
+          "the module — as coupling, fourc and dealii already do. Then re-run "
+          "the mutation harness for that backend and confirm the verdicts are "
+          "KILLED rather than VACUOUS_BASELINE.")

--- a/tests/test_signal_allowlist_is_not_self_certifying.py
+++ b/tests/test_signal_allowlist_is_not_self_certifying.py
@@ -1,0 +1,217 @@
+"""The Signal gate must not declare a foreign library's diagnostics real.
+
+`verify_signal_clauses.py` tier 0 checks that a Signal names a "real" entity,
+where real means "present in a hand-maintained per-backend allowlist". That
+makes the gate circular: a Signal cites a name, the name gets added so the gate
+goes green, and the entry then validates the Signal. Nothing ever consults the
+software.
+
+Measured consequences, both found by adversarial audit rather than by the gate:
+
+  * FEBio's allowlist declared `NOX`, `DIVERGED_LINE_SEARCH` and
+    `DIVERGED_FNORM_NAN` real, annotated as "tokens that real FEBio logs emit".
+    They are Trilinos and PETSc names. FEBio links NEITHER — confirmed against
+    febio4 and all twelve of its shared libraries. An audit found 25 fabricated
+    FEBio Signals; this entry is why they passed tier 0.
+  * NGSolve's allowlist declared `KSPSolve`, `DIVERGED_BREAKDOWN` and
+    `DIVERGED_INDEFINITE_PC` real, annotated as tokens "NGSolve also surfaces
+    via krylovspace bindings". Its shared library contains no PETSc KSP strings
+    at all.
+
+A pitfall whose Signal cannot occur is worse than no pitfall: it tells an agent
+that never seeing a message it could never have seen means the problem is
+absent. So this guard refuses the specific move that produced both — allowlisting
+another project's diagnostic vocabulary for a backend that does not link it.
+
+It is deliberately narrow. It does not try to verify the whole allowlist against
+every install, because most entries are ordinary API names and the corpora are
+not always available. `scripts/verify_signal_literals.py` does that check where a
+binary can be inspected. What this stops is the one pattern that has actually
+caused fabrications twice.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+GATE = REPO / "scripts" / "verify_signal_clauses.py"
+
+# Diagnostic vocabularies that belong to a specific external library. A backend
+# may legitimately allowlist these ONLY if it links that library.
+_FOREIGN = {
+    "PETSc": re.compile(r'^(KSP\w*|SNES\w*|DIVERGED_\w+|CONVERGED_[AR]TOL)$'),
+    "Trilinos": re.compile(r'^(NOX\w*|Epetra\w*|Teuchos\w*|Tpetra\w*)$'),
+}
+
+# WHICH BACKENDS LINK WHICH LIBRARY — and why this is a fallback, not an oracle.
+#
+# A first version of this guard hard-coded the answer. That reproduces the exact
+# defect it was written to catch: a hand-maintained table asserting what is real,
+# never checked against the software. A peer audit made the point concrete by
+# reporting that DUNE genuinely links PETSc on this box — which, if a DUNE Signal
+# ever quoted a PETSc diagnostic, this guard would have called a fabrication.
+#
+# So the table below is only consulted when the installed artefacts cannot be
+# inspected. Where they can, the evidence decides. `_evidence_links()` looks for
+# the library's own marker strings in what the backend actually loads.
+#
+# On the DUNE claim specifically: `libpetsc_real.so.3.12` exists system-wide but
+# NOT inside `dune-fem-env`, and the peer's `ldd` evidence could not be
+# reproduced here. So DUNE is deliberately absent from the table — an unconfirmed
+# peer assertion is not evidence, and the evidence path will admit it
+# automatically if the linkage is real.
+_LINKS = {
+    "fenics": {"PETSc"},        # dolfinx is built on petsc4py
+    # deal.II names PETSc and Trilinos in its own wrapper namespaces
+    # (`PETScWrappers`, `TrilinosWrappers`), so those are genuinely deal.II
+    # symbols whether or not a given build enables the feature. A Signal that
+    # relies on the FEATURE still needs build scoping — a separate concern from
+    # whether the NAME exists.
+    "dealii": {"PETSc", "Trilinos"},
+    "fourc": {"Trilinos"},      # 4C is a Trilinos application
+    "kratos": {"Trilinos"},     # TrilinosApplication is a real Kratos module
+}
+
+# How to recognise a library: its own shared objects, or failing that, marker
+# strings inside the backend's. Filenames come first because they are direct and
+# cheap — a first version scanned only the alphabetically-first 40 libraries for
+# markers and so never reached `libpetsc*`, reporting that dolfinx does not link
+# PETSc. It passed anyway because the table covered it, which is precisely the
+# kind of "works by accident" this file exists to refuse.
+_LIB_GLOBS = {"PETSc": ("libpetsc*.so*",),
+              "Trilinos": ("libteuchos*.so*", "libnox*.so*", "libepetra*.so*",
+                           "libtrilinos*.so*")}
+_MARKERS = {"PETSc": ("PETSC ERROR", "KSPSolve"),
+            "Trilinos": ("Teuchos::", "NOX::")}
+
+
+def _evidence_links(backend: str) -> set[str] | None:
+    """Which libraries this backend demonstrably loads, or None if unknowable.
+
+    Returning None rather than an empty set matters: "we could not look" must
+    not read as "it links nothing", or the guard starts accusing backends whose
+    corpus happens to be unavailable.
+    """
+    import subprocess
+
+    # DUNE is the instructive case. Searching its env finds no `libpetsc*`, and
+    # an earlier version of this concluded it does not link PETSc. An audit
+    # settled it: DUNE links PETSc from OUTSIDE the env —
+    # `/usr/lib/petscdir/petsc3.12/.../libpetsc_real.so.3.12` — and 375 of 400
+    # JIT-compiled modules link it. The evidence is in the generated objects,
+    # not the package directory, so that is where to look. A DUNE process
+    # printing `[0]PETSC ERROR: Caught signal number 15` settled it beyond
+    # linkage: PETSc is initialised at runtime.
+    roots = {
+        "fenics": ["/home/alexander/miniconda3/envs/fenics/lib"],
+        "dune": ["/home/alexander/miniconda3/envs/dune-fem-env/lib",
+                 "/home/alexander/miniconda3/envs/dune-fem-env/.cache/"
+                 "dune-py/python/dune/generated"],
+        "febio": ["/home/alexander/Schreibtisch/febio-src/cbuild/lib"],
+        "fourc": ["/home/alexander/4C/build"],
+    }.get(backend)
+    if not roots:
+        return None
+    found: set[str] = set()
+    looked = False
+    for root in roots:
+        p = pathlib.Path(root)
+        if not p.is_dir():
+            continue
+        all_libs = sorted(p.glob("*.so*"))
+        if not all_libs:
+            continue
+        looked = True
+        # Direct evidence: the library's own shared object sits here.
+        for library, globs in _LIB_GLOBS.items():
+            if any(next(p.glob(g), None) for g in globs):
+                found.add(library)
+
+        # Linked from elsewhere: ask the loader. This is the case that defeated
+        # two earlier versions of this function — DUNE's JIT-compiled modules
+        # link `/usr/lib/petscdir/.../libpetsc_real.so.3.12`, which is neither in
+        # the env nor a string inside the module, so both a filename glob and a
+        # `strings` scan report "no PETSc" for a backend that initialises PETSc
+        # at runtime. Only a handful of objects are checked; linkage is uniform
+        # across a build, so a sample settles it.
+        for lib in all_libs[:6]:
+            missing = {k for k in _MARKERS if k not in found}
+            if not missing:
+                break
+            try:
+                deps = subprocess.run(["ldd", str(lib)], capture_output=True,
+                                      text=True, timeout=60).stdout.lower()
+            except (OSError, subprocess.SubprocessError):
+                break
+            for library in missing:
+                if library.lower() in deps:
+                    found.add(library)
+        # Indirect: the backend's own binaries carry the library's strings. Only
+        # worth the scan for libraries not already established.
+        todo = {lib: mk for lib, mk in _MARKERS.items() if lib not in found}
+        if not todo:
+            continue
+        try:
+            blob = subprocess.run(["strings", "-n", "6",
+                                   *map(str, all_libs[:60])],
+                                  capture_output=True, text=True,
+                                  timeout=300).stdout
+        except (OSError, subprocess.SubprocessError):
+            continue
+        for library, markers in todo.items():
+            if any(m in blob for m in markers):
+                found.add(library)
+    return found if looked else None
+
+
+def _blocks() -> dict[str, str]:
+    """Per-backend allowlist bodies, keyed by backend name."""
+    src = GATE.read_text()
+    parts = re.split(r'(?:if|elif)\s+backend\s*==\s*"(\w+)"', src)
+    return {parts[i]: parts[i + 1] for i in range(1, len(parts) - 1, 2)}
+
+
+@pytest.mark.parametrize("backend", sorted(_blocks()))
+def test_no_backend_allowlists_a_library_it_does_not_link(backend):
+    body = _blocks()[backend]
+    quoted = set(re.findall(r'"([A-Za-z_]\w*)"', body))
+    # Evidence first, table only where the artefacts cannot be inspected.
+    measured = _evidence_links(backend)
+    links = _LINKS.get(backend, set()) if measured is None else (
+        measured | _LINKS.get(backend, set()))
+    offenders = []
+    for library, pattern in _FOREIGN.items():
+        if library in links:
+            continue
+        offenders += [f"{name} ({library})" for name in sorted(quoted)
+                      if pattern.match(name)]
+    assert not offenders, (
+        f"the Signal gate's allowlist for '{backend}' declares another "
+        f"library's diagnostics to be real symbols, so any Signal quoting them "
+        f"passes tier 0 without the software being consulted. {backend} does "
+        f"not link that library.\n  " + "\n  ".join(offenders)
+        + "\n\nThis is how 25 fabricated FEBio Signals reached agents. If the "
+          "install genuinely links it, add the backend to _LINKS with the "
+          "evidence; do not add the names.")
+
+
+def test_the_guard_would_have_caught_the_known_cases():
+    """Calibration: the predicate must fire on the exact entries that shipped.
+
+    A guard whose discrimination is untested is a guard nobody should trust,
+    and both real cases came with a confident comment asserting the opposite.
+    """
+    for library, pattern in _FOREIGN.items():
+        pass
+    febio_shipped = {"NOX", "DIVERGED_LINE_SEARCH", "DIVERGED_FNORM_NAN"}
+    ngsolve_shipped = {"KSPSolve", "DIVERGED_BREAKDOWN", "DIVERGED_INDEFINITE_PC"}
+    for name in febio_shipped | ngsolve_shipped:
+        assert any(p.match(name) for p in _FOREIGN.values()), (
+            f"the guard does not recognise {name}, which really shipped")
+    # …and it must not fire on ordinary API names.
+    for name in ("FullNewton", "BFGS", "SolverCG", "dirichletbc", "MeshTri"):
+        assert not any(p.match(name) for p in _FOREIGN.values()), (
+            f"the guard would falsely accuse {name}")

--- a/tests/test_signal_verification.py
+++ b/tests/test_signal_verification.py
@@ -65,7 +65,47 @@ class TestDealiiSignalFloor(unittest.TestCase):
     MIN_TIER2_PASSED = 11  # deal.II pitfalls with named (catalog-indexed)
                            # Tier-2 fixtures (cheap bucket closed
                            # 2026-05-31 + 1 medium already done).
-    MIN_TIER2_RUNNER_PASSED = 108  # cross-cutting (incl. synthetic indices).
+    MIN_TIER2_RUNNER_PASSED = 183  # cross-cutting (incl. synthetic indices).
+    # CONSOLIDATION: the dune and febio campaigns each raised this floor from a
+    # DIFFERENT baseline (108 -> 112 and 113 -> 183), so neither number
+    # describes the merged tree. Held at 183 — the highest count any single
+    # branch actually recorded in one run — and deliberately NOT raised to the
+    # 187 rows the merged snapshot now carries, because those 187 were never
+    # all green at one time on one host. The fingerprint check in the test
+    # below is what makes that safe: it fails the snapshot as unverifiable
+    # until run_tier2_fixtures.py --write-results is run against this tree.
+    #
+    # Both campaigns' provenance, kept:
+    # 2026-08-03 dune knowledge-extraction pass: +4 dune fixtures, all
+    # executed against the installed dune-fem 2.12.0.2 and merged into
+    # tier2_results.json without disturbing the other backends' rows.
+    #   +1 dune::poisson::7   (DirichletBC omitted from the scheme list
+    #                          -> singular pure-Neumann system that CG
+    #                          still reports as converged; measured L2
+    #                          error 7.5e+14 after 23935 iterations)
+    #   +1 dune::poisson::9   (solver= string is not validated in
+    #                          Python; the C++ parameter reader
+    #                          enumerates gmres/cg/bicgstab)
+    #   +1 dune::poisson::11  (space UFL cell reports a simplex on a
+    #                          cube grid)
+    #   +1 dune::poisson::99  (MMS numerical-correctness gate: L2/H1
+    #                          orders for Lagrange k=1,2 on
+    #                          structuredGrid)
+    # dune::mixed_methods::0 was already counted; its fixture was made
+    # machine-independent in the same pass (it previously hard-coded
+    # one developer's absolute paths and failed everywhere else).
+    #
+    # 2026-08-06 (113 -> ... -> 183): seventy new FEBio fixtures, every one of
+    # them run here against febio4 4.12.0.86045466d, plus two re-keys
+    # that fixed mis-attributed evidence. Only the febio rows of the
+    # snapshot were rewritten; the other backends' rows are as
+    # recorded, because with the interpreter-resolution fix in place
+    # this host reproduces 52 of the 113 and that reconciliation is
+    # open work elsewhere, not a number to quietly lower here.
+    #
+    # 2026-08-06 sparta knowledge restructure: +10 SPARTA fixtures (that
+    # branch read the floor as 108 -> 118; the same +10 is inside the 197
+    # rows the merged snapshot now holds).
     # 2026-06-01 fixture additions:
     #   +1 ngsolve::helmholtz::0 (complex coef on real FESpace)
     #   +1 kratos::linear_elasticity::2 (SubModelPart case-sensitive)
@@ -114,6 +154,52 @@ class TestDealiiSignalFloor(unittest.TestCase):
     #      submodule, NOT top-level ngsolve — catalog drift)
     #   +1 fenics::biharmonic::0 (fem.functionspace factory vs FunctionSpace
     #      class — LLM-trap from legacy dolfin)
+    # 2026-08-03 fixture additions (108 -> 113): the first FEBio
+    # fixtures that RUN the solver, now that febio4 4.12.0 is built
+    # and installed. All five were executed on this machine before
+    # the floor was raised.
+    #   +1 febio::linear_elasticity::98 (hex8 patch test — FEBio's
+    #      first executed numerical-correctness gate: exact linear
+    #      field at the free interior node to 1.4e-17 and Cauchy
+    #      stress against the St.Venant-Kirchhoff closed form to
+    #      3.5e-11)
+    #   +1 febio::linear_elasticity::5 (a deck with no <Control>
+    #      reads SUCCESS, writes .xplt + CSVs, and solves nothing)
+    #   +1 febio::linear_elasticity::7 (a degenerate hex8 runs to
+    #      normal termination with 25% wrong stress)
+    #   +1 febio::heat::0 (an unregistered <Module type> SEGFAULTS
+    #      with no diagnostic — catalog falsification: FEBio 4.12
+    #      has no `heat` and no `biphasic-FSI` module)
+    #   +1 febio::biphasic::5 (<linear_solver type="test"/> is a
+    #      null solver that zeroes the solution vector and reports
+    #      success — the one case where the normal-termination
+    #      banner, exit 0 AND a non-zero completed-step count are
+    #      all satisfied by a run that solved nothing; found by
+    #      the critic pass over the first four fixtures)
+    #
+    # 2026-08-03, SAME DAY, SECOND PASS — the 108 -> 113 raise above
+    # was UNENFORCEABLE as written and has been repaired rather than
+    # rolled back. All five new fixtures printed
+    # "<key>=skipped_no_binary" and returned 0 when febio4 was
+    # absent, and each fixture.json expected only the bare "<key>="
+    # prefix, which that skip string satisfies. On any host without
+    # FEBio the five rows were therefore green while verifying
+    # nothing: the floor certified five checks that had not run. A
+    # floor that certifies nothing is worse than no floor, because it
+    # is read as evidence.
+    #
+    # Repair, applied to all five fixture directories:
+    #   * a missing binary now prints "FAIL: ..." and returns 1
+    #     ("FAIL:" is already in every fixture's forbid_in_output, so
+    #     the failure is recorded even if the exit status is ignored),
+    #   * expect_in_output pins the success TOKEN, not the key prefix
+    #     (e.g. "febio_patch_test=passed",
+    #     "unknown_module_segfault_count=4"), so no skip string can
+    #     satisfy it,
+    #   * "skipped_no_binary" was added to forbid_in_output.
+    # Verified both ways on this host: all five pass with febio4
+    # present and all five fail with FEBIO_BINARY pointing at a
+    # non-existent path.
 
     # Cost-bucket floors (round-3 critic finding E: report per-cost
     # coverage, not a fake /96 fraction). data/postmortems/
@@ -580,6 +666,23 @@ class TestHarnessSelfChecks(unittest.TestCase):
         by scripts/run_tier2_fixtures.py) and fails if the
         passed count drops below TestDealiiSignalFloor.
         MIN_TIER2_RUNNER_PASSED.
+
+        WHAT THIS DOES AND DOES NOT ESTABLISH. It reads a
+        COMMITTED snapshot; it does not run a fixture. So a green
+        result means "the recorded number has not regressed", NOT
+        "the fixtures pass on this machine" — and the file travels
+        with the repo, so without a currency check every user gets
+        our result reported as theirs. An audit found exactly that:
+        the snapshot was 18 commits stale, recording `passed: 113`
+        on a host where 7 passed and 10 failed, and this test was
+        green even with the backend's binary hidden.
+
+        The fingerprint below is the currency check. It identifies
+        the fixture SET the snapshot describes, so a fixture added,
+        deleted or edited since makes the summary detectably stale
+        instead of silently wrong. A missing fingerprint is treated
+        as stale rather than waved through, because "we cannot tell"
+        must never read as "fine".
         """
         import json
         from pathlib import Path
@@ -591,6 +694,26 @@ class TestHarnessSelfChecks(unittest.TestCase):
                 "present — run scripts/run_tier2_fixtures.py "
                 "first")
         data = json.loads(path.read_text(encoding="utf-8"))
+
+        # Currency first: a number describing a different fixture set says
+        # nothing about this one.
+        sys.path.insert(0, str(repo / "scripts"))
+        from run_tier2_fixtures import fixture_inventory_fingerprint
+        live = fixture_inventory_fingerprint()
+        recorded = data.get("fixture_fingerprint")
+        self.assertIsNotNone(
+            recorded,
+            "tier2_results.json carries no fixture_fingerprint, so there is no "
+            "way to tell whether its counts describe the fixtures now in the "
+            "tree. Re-run scripts/run_tier2_fixtures.py --write-results. An "
+            "unverifiable floor must not report as green.")
+        self.assertEqual(
+            recorded, live,
+            "tier2_results.json summarises a DIFFERENT fixture set than the one "
+            "in the tree — a fixture was added, deleted or edited since it was "
+            "written, so its passed count does not describe these fixtures. "
+            "Re-run scripts/run_tier2_fixtures.py --write-results.")
+
         passed = data.get("summary", {}).get("passed", 0)
         self.assertGreaterEqual(
             passed,

--- a/tests/test_signals_are_not_boilerplate.py
+++ b/tests/test_signals_are_not_boilerplate.py
@@ -1,0 +1,118 @@
+"""A Signal shared by many entries distinguishes none of them.
+
+WHAT THIS PREVENTS
+------------------
+The `Signal:` clause is what `knowledge(topic='pitfalls', signal=...)` matches
+against, so it is the entry's index entry: the thing that separates this pitfall
+from its neighbours when an agent pastes an error. When several entries carry
+the same Signal, a symptom query returns all of them and ranks none — the
+entries are present and unfindable at once, which is the same end state as an
+entry nobody can reach, arrived at from a different direction.
+
+Measured when this was first looked at: Kratos had **63 entries sharing one
+string**, a generic "solver reports 'Convergence is not achieved' / 'iteration
+count exceeded' / oscillating residual", plus three more groups of 12, 9 and 7.
+91 of its 204 entries — 45% — carried boilerplate. Every other backend was at
+zero, which is what made it a defect rather than a convention.
+
+Fixing it was not a rewrite of the Signals alone. Of the 94 boilerplate entries,
+41 had a real observable nobody had written down (a registry rejection, an
+AttributeError at attribute access, a ModuleNotFoundError on an inner import
+line, a silently wrong value) and 53 were genuine design advice with no failure
+mode at all — those moved to a `guidance` list rather than keeping a Signal they
+could not deliver. That is the honest fix: an entry must not promise an
+observable it does not have.
+
+WHERE THE THRESHOLD COMES FROM
+------------------------------
+Not zero. Some sharing is correct: two entries can genuinely produce the same
+message, and a container-type error that fires for two different mistakes is one
+string honestly reused. Measured across all ten surfaces after the Kratos work,
+the worst reuse anywhere is 2 and no group reaches 4. So 4 is comfortably above
+what legitimate sharing produces and far below the 63 that made the corpus
+unsearchable.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+BACKENDS_DIR = REPO / "src" / "backends"
+
+# A Signal may be shared by up to this many entries. See the module docstring:
+# measured legitimate reuse peaks at 2; the defect that motivated this was 63.
+MAX_SHARING = 3
+
+_SIGNAL_RE = re.compile(r"Signal:\s*(.*)", re.IGNORECASE | re.DOTALL)
+_PROVENANCE_RE = re.compile(
+    r"\((?:verified|audit|checked|measured|confirmed)\b[^()]*\)\s*$",
+    re.IGNORECASE)
+
+
+def _signal_of(entry: str) -> str:
+    m = _SIGNAL_RE.search(entry)
+    if not m:
+        return ""
+    return _PROVENANCE_RE.sub("", m.group(1)).strip()
+
+
+def _entries(backend: str) -> set[str]:
+    """Distinct pitfall texts. Deduplicated by value: a sub-dict attached by
+    reference to several physics is one entry, and counting it repeatedly once
+    inflated a DUNE total from 111 to 127."""
+    be_dir = BACKENDS_DIR / backend
+    found: set[str] = set()
+    if not be_dir.is_dir():
+        return found
+    for py in sorted(be_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(py.read_text(errors="ignore"))
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and "Signal:" in node.value):
+                found.add(node.value)
+    return found
+
+
+BACKENDS = sorted(p.name for p in BACKENDS_DIR.iterdir()
+                  if p.is_dir() and not p.name.startswith("_")) \
+    if BACKENDS_DIR.is_dir() else []
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_no_signal_is_shared_by_too_many_entries(backend):
+    """Boilerplate makes an entry present and unfindable at the same time."""
+    texts = _entries(backend)
+    if not texts:
+        pytest.skip(f"{backend} has no pitfall entries in this tree")
+
+    owners: dict[str, list[str]] = defaultdict(list)
+    for text in texts:
+        sig = _signal_of(text)
+        if sig:
+            owners[sig].append(text[:70])
+
+    counts = Counter({sig: len(v) for sig, v in owners.items()})
+    over = {sig: n for sig, n in counts.items() if n > MAX_SHARING}
+
+    assert not over, (
+        f"{backend}: {len(over)} Signal clauses are shared by more than "
+        f"{MAX_SHARING} entries, so a symptom query returns all of them and "
+        f"ranks none:\n  "
+        + "\n  ".join(f"x{n}: {sig[:100]}" for sig, n in
+                      sorted(over.items(), key=lambda kv: -kv[1])[:5])
+        + "\n\nGive each entry the observable that distinguishes IT. If the "
+          "entry has no failure mode — if it is design advice like a "
+          "recommended parameter range — it should not carry a Signal clause "
+          "at all; move it to a guidance list rather than stapling on a "
+          "symptom it cannot deliver. That is how 53 Kratos entries were "
+          "resolved; the other 41 turned out to have a real observable nobody "
+          "had written down.")

--- a/tests/test_sparta_tier2_claim_coverage.py
+++ b/tests/test_sparta_tier2_claim_coverage.py
@@ -1,0 +1,246 @@
+"""How much of the SPARTA pitfall catalog has an executed fixture.
+
+MEASURING THE DENOMINATOR HONESTLY IS THE HARD PART HERE, harder than for any
+other backend, because SPARTA's ten cross-cutting pitfalls are attached to EVERY
+physics row by ``generators/__init__.py``::
+
+    for _phys in KNOWLEDGE.values():
+        _phys["pitfalls"] = list(_phys.get("pitfalls", [])) + list(UNIVERSAL_PITFALLS)
+
+Walk the knowledge dict and those ten strings are counted ten times each: a plain
+walk returns 165 Signal-bearing strings where there are 75 distinct claims. The
+same shape inflated a DUNE count from 111 to 127, and there it was one shared
+sub-dict; here it is a factor of 2.2 on the whole denominator, and it inflates in
+the direction that makes coverage look WORSE, so it would not have been caught by
+the number looking too good.
+
+So claims are keyed by IDENTITY, not by position:
+
+  * ``<physics>:<index>`` for a pitfall that belongs to one physics row;
+  * ``universal:<n>`` for the n-th entry of UNIVERSAL_PITFALLS, once.
+
+A separate count worth recording because it is the number an earlier pass
+published: ``grep -c "Signal:"`` over ``src/backends/sparta/**/*.py`` returns 79.
+Four of those are PROSE — docstrings in ``_common.py``, ``__init__.py`` and
+``backend.py`` that mention the ``Signal:`` convention rather than making a claim.
+The catalog states 75 falsifiable claims, and 75 is what this file divides by.
+
+Coverage is CLAIM-ATTRIBUTED, not fixture-directory-counted, for the reason the
+DUNE pass established: one fixture can legitimately verify several claims when
+they share a deck, and nine of the SPARTA fixtures do. A fixture declares what it
+covers::
+
+    "covers": ["surface_interaction:2", "surface_interaction:3",
+               "surface_interaction:9"]
+
+and the declaration is CHECKED — an entry naming a claim that does not exist is
+rejected, and no claim may be claimed twice. Fixtures with no ``covers`` key fall
+back to their own physics/pitfall_index pair, which is how the older ones count.
+An index past the end of a list is SYNTHETIC and counts for nothing; the catalog
+smoke-test fixture uses one deliberately.
+
+What this file does NOT do is judge whether a fixture is any good. That is
+``scripts/run_tier2_fixtures.py``, which executes them. This one answers "is
+there one at all", and keeps the answer honest by rejecting bogus keys and by
+flooring the denominator so coverage cannot rise by deleting claims.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import unittest
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+_FIXTURES = _REPO / "scripts" / "tier2_fixtures" / "sparta"
+
+# Raise this ONLY upward, and only with the fixtures that earned it in the same
+# commit. The project owner's target is 80 %. The constant tracks what is
+# MEASURED, so every commit is green and the number here is never an aspiration.
+#   2026-08-06  measured 0.17 (13 of 75) before this pass
+#   2026-08-06  0.39 (29 of 75) after the covers-attribution pass
+#   2026-08-06  0.53 (40 of 75) after the three zero-coverage-area fixtures
+#   2026-08-06  0.70 (53 of 75) after the four cross-cutting fixtures
+#   2026-08-06  0.81 (61 of 75) after the per-cell and relaxation fixtures
+#   2026-08-06  0.89 (67 of 75) after the setup-trap, emit/chemistry and
+#               thermal/grid fixtures
+#   2026-08-06  0.92 (69 of 75) after the axisymmetric-weighting and dump-surf
+#               fixtures
+#   2026-08-06  0.93 (70 of 75) after the wall-flux-balance fixture
+#   2026-08-06  0.96 (72 of 75) after the adaptation-targeting fixture
+#   2026-08-06  0.97 (73 of 75) after the unresolved-shear fixture
+#   2026-08-06  0.98 (74 of 75) after the surface-flux steady-state fixture
+MIN_COVERAGE_FRACTION = 0.98
+
+# Counted 2026-08-06 by identity, not by walking the dict. See the module
+# docstring for why those differ by a factor of 2.2 on this backend.
+CLAIMS_COUNTED = 75
+
+
+def _claim_inventory() -> dict[str, str]:
+    """Every falsifiable SPARTA claim, keyed the way ``covers`` names it."""
+    from backends.sparta.generators import (  # noqa: E402
+        KNOWLEDGE, UNIVERSAL_PITFALLS,
+    )
+
+    universal = {text: f"universal:{i}"
+                 for i, text in enumerate(UNIVERSAL_PITFALLS)}
+    claims: dict[str, str] = dict.fromkeys(universal.values(), "")
+    for text, key in universal.items():
+        claims[key] = text
+
+    for physics, entry in sorted(KNOWLEDGE.items()):
+        if physics.startswith("_"):
+            continue
+        for i, text in enumerate(entry.get("pitfalls", [])):
+            if not isinstance(text, str) or "Signal:" not in text:
+                continue
+            if text in universal:
+                continue          # already counted once, under universal:<n>
+            claims[f"{physics}:{i}"] = text
+    return claims
+
+
+def _positional_keys() -> set[str]:
+    """`<physics>:<index>` for every pitfall slot, universal ones included.
+
+    Needed only so a legacy fixture keyed by position at a slot holding a
+    universal pitfall can be translated to that pitfall's identity key instead
+    of being reported as bogus.
+    """
+    from backends.sparta.generators import KNOWLEDGE  # noqa: E402
+    out = set()
+    for physics, entry in KNOWLEDGE.items():
+        if physics.startswith("_"):
+            continue
+        for i in range(len(entry.get("pitfalls", []))):
+            out.add(f"{physics}:{i}")
+    return out
+
+
+def _positional_to_identity() -> dict[str, str]:
+    from backends.sparta.generators import (  # noqa: E402
+        KNOWLEDGE, UNIVERSAL_PITFALLS,
+    )
+    universal = {text: f"universal:{i}"
+                 for i, text in enumerate(UNIVERSAL_PITFALLS)}
+    out: dict[str, str] = {}
+    for physics, entry in KNOWLEDGE.items():
+        if physics.startswith("_"):
+            continue
+        for i, text in enumerate(entry.get("pitfalls", [])):
+            if isinstance(text, str) and text in universal:
+                out[f"{physics}:{i}"] = universal[text]
+    return out
+
+
+def _fixture_claims() -> tuple[dict[str, list[str]], list[str]]:
+    """(claim -> fixtures naming it, fixtures with a synthetic key)."""
+    covered: dict[str, list[str]] = {}
+    synthetic: list[str] = []
+    inventory = _claim_inventory()
+    translate = _positional_to_identity()
+    for d in sorted(p.parent for p in _FIXTURES.glob("*/fixture.json")):
+        meta = json.loads((d / "fixture.json").read_text())
+        declared = meta.get("covers")
+        if declared is None:
+            key = f"{meta.get('physics')}:{int(meta.get('pitfall_index', -1))}"
+            key = translate.get(key, key)
+            declared = [key] if key in inventory else []
+            if not declared:
+                synthetic.append(f"{d.name} ({key})")
+        elif not declared:
+            synthetic.append(f"{d.name} (covers: [] — declared as not evidence)")
+        for claim in declared:
+            key = translate.get(str(claim), str(claim))
+            owners = covered.setdefault(key, [])
+            # A fixture may name the SAME claim under both conventions — its
+            # identity key `universal:5` and the positional alias
+            # `rarefied_flow:14` that an external counter walking the
+            # rarefied_flow row will look for. Both translate to one claim, and
+            # one fixture naming it twice is one owner, not a collision. Two
+            # DIFFERENT fixtures naming it still collide, which is the rule
+            # this dedupe must not weaken.
+            if d.name not in owners:
+                owners.append(d.name)
+    return covered, synthetic
+
+
+class TestSpartaTier2ClaimCoverage(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inventory = _claim_inventory()
+        cls.covered, cls.synthetic = _fixture_claims()
+
+    def test_every_covers_entry_names_a_real_claim(self) -> None:
+        """A `covers` list is a coverage CLAIM; it has to be checkable."""
+        bogus = {c: f for c, f in self.covered.items()
+                 if c not in self.inventory}
+        self.assertEqual(
+            bogus, {},
+            f"these fixtures claim to cover SPARTA pitfalls that do not "
+            f"exist: {bogus}. Pitfall indices are POSITIONAL — inserting an "
+            f"entry earlier in a list re-points every fixture after it — so a "
+            f"stale index here means the coverage number is fiction. Re-read "
+            f"the list in src/backends/sparta/generators/ and fix the index.")
+
+    def test_no_claim_is_counted_twice(self) -> None:
+        dupes = {c: f for c, f in self.covered.items() if len(f) > 1}
+        self.assertEqual(
+            dupes, {},
+            f"these claims are named by more than one fixture: {dupes}. "
+            f"Double-counting inflates the coverage fraction; pick one owner "
+            f"per claim.")
+
+    def test_the_ten_universal_pitfalls_are_counted_once_each(self) -> None:
+        """The defect this whole keying scheme exists for.
+
+        UNIVERSAL_PITFALLS is appended to all ten physics rows, so a positional
+        walk sees each of those ten strings ten times. If the inventory ever
+        grows past 75 by that route, the denominator has silently inflated and
+        every coverage number computed from it is wrong.
+        """
+        from backends.sparta.generators import UNIVERSAL_PITFALLS  # noqa: E402
+        universal_keys = [k for k in self.inventory
+                          if k.startswith("universal:")]
+        self.assertEqual(
+            len(universal_keys), len(UNIVERSAL_PITFALLS),
+            f"expected each of the {len(UNIVERSAL_PITFALLS)} universal "
+            f"pitfalls once, got {len(universal_keys)} keys")
+        positional = _positional_keys()
+        self.assertGreater(
+            len(positional), len(self.inventory),
+            "a positional walk should see MORE slots than there are distinct "
+            "claims on this backend; if it does not, the universal pitfalls "
+            "are no longer being shared and this test's premise has changed")
+
+    def test_coverage_meets_the_floor(self) -> None:
+        n_total = len(self.inventory)
+        n_covered = len([c for c in self.covered if c in self.inventory])
+        fraction = n_covered / n_total if n_total else 0.0
+        uncovered = sorted(set(self.inventory) - set(self.covered))
+        self.assertGreaterEqual(
+            fraction, MIN_COVERAGE_FRACTION,
+            f"SPARTA tier-2 claim coverage is {n_covered}/{n_total} = "
+            f"{fraction:.1%}, below the {MIN_COVERAGE_FRACTION:.0%} floor. "
+            f"Still uncovered:\n  " + "\n  ".join(uncovered))
+
+    def test_the_inventory_itself_did_not_shrink(self) -> None:
+        """Coverage is a fraction, so shrinking the denominator is a way to
+        'improve' it without writing anything. 75 distinct claims were counted
+        on 2026-08-06; deleting claims to raise the percentage has to be a
+        deliberate, visible edit."""
+        self.assertGreaterEqual(
+            len(self.inventory), CLAIMS_COUNTED,
+            f"the SPARTA claim inventory dropped to {len(self.inventory)} "
+            f"from the {CLAIMS_COUNTED} counted on 2026-08-06. If claims were "
+            f"retired because execution falsified them, lower this number in "
+            f"the same commit and say which ones; do not let the coverage "
+            f"fraction rise by subtraction.")
+
+
+if __name__ == "__main__":                                  # pragma: no cover
+    unittest.main()

--- a/tests/test_template_variant_selection.py
+++ b/tests/test_template_variant_selection.py
@@ -1,0 +1,147 @@
+"""The tool must serve the template that was asked for, or say it cannot.
+
+A usability measurement drove `prepare_simulation` over six realistic tasks on
+three backends and got a working deck for none of them. The cause was not
+missing knowledge. Three call sites read `template_variants[0]` and nothing
+else, so:
+
+    prepare_simulation('fenics', '3d linear elasticity')  ->  the 2D template
+    prepare_simulation('fourc',  '3d linear elasticity')  ->  linear_2d
+    prepare_simulation('fenics', 'heat with time dependent BC') -> 2d_steady
+
+while a `3d` variant and a `2d_transient` variant sat in the catalog, correct
+and unreachable by any tool.
+
+Two properties are asserted here, and the second matters more than the first.
+
+  * When a variant satisfying the request exists, serve it.
+  * When one does NOT exist, SAY SO. Silent substitution is the failure a weak
+    model cannot detect: handed a deck labelled "2D plane stress" for a 3D task,
+    it ships the 2D deck. No amount of prose above the template changes that,
+    which is why this is a retrieval fix and not a knowledge fix.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+
+import pytest
+
+from tools import consolidated as C
+from tools.consolidated import _select_template_variant
+
+
+@pytest.fixture(scope="module")
+def tools():
+    from core.registry import load_all_backends
+    load_all_backends()
+    captured = {}
+
+    class _Recorder:
+        def tool(self, *a, **k):
+            def deco(fn):
+                captured[fn.__name__] = fn
+                return fn
+            return deco
+
+    C.register_consolidated_tools(_Recorder())
+    return captured
+
+
+def _call(fn, *a, **k):
+    r = fn(*a, **k)
+    return asyncio.run(r) if inspect.iscoroutine(r) else r
+
+
+def _variant(text: str) -> str:
+    m = re.search(r"## Template \(([^)]+)\)", text)
+    return m.group(1) if m else ""
+
+
+# ── the selector itself ───────────────────────────────────────────────────
+@pytest.mark.parametrize("query, variants, expected", [
+    ("3d linear elasticity", ["2d", "3d", "plate_hole"], "3d"),
+    ("linear elasticity", ["2d", "3d"], "2d"),                  # no qualifier
+    ("transient heat", ["2d_steady", "2d_transient"], "2d_transient"),
+    ("steady heat", ["2d_transient", "2d_steady"], "2d_steady"),
+    ("nonlinear 3d solid", ["linear_2d", "nonlinear_3d"], "nonlinear_3d"),
+    ("three-dimensional elasticity", ["2d", "3d"], "3d"),
+    ("time-dependent conduction", ["steady", "transient"], "transient"),
+])
+def test_a_qualifier_in_the_request_selects_the_variant(query, variants, expected):
+    chosen, _ = _select_template_variant(query, variants)
+    assert chosen == expected
+
+
+def test_an_unsatisfiable_qualifier_is_stated_not_swallowed():
+    chosen, note = _select_template_variant("3d linear elasticity", ["2d"])
+    assert chosen == "2d"
+    assert "no template variant provides it" in note
+    assert "does NOT satisfy" in note
+
+
+def test_siblings_are_always_named():
+    _, note = _select_template_variant("elasticity", ["2d", "3d", "thick_beam"])
+    assert "3d" in note and "thick_beam" in note
+
+
+def test_no_variants_is_not_a_crash():
+    assert _select_template_variant("anything", []) == ("", "")
+
+
+# ── through the real tool, on the cases that failed ───────────────────────
+def test_3d_request_gets_a_3d_template(tools):
+    out = _call(tools["prepare_simulation"], "fenics", "3d linear elasticity")
+    assert _variant(out) == "3d", _variant(out)
+    # and the served deck must actually be 3D
+    assert "create_box" in out
+
+
+def test_transient_request_gets_a_transient_template(tools):
+    out = _call(tools["prepare_simulation"], "fenics",
+                "heat with time dependent boundary condition")
+    assert "transient" in _variant(out), _variant(out)
+
+
+def test_a_backend_without_the_variant_warns(tools):
+    """scikit-fem has no 3D elasticity variant. Serving the 2D one silently is
+    how a weak model ships a plane-stress deck for a 3D problem."""
+    out = _call(tools["prepare_simulation"], "skfem", "3d linear elasticity")
+    assert "⚠" in out
+    assert "no template variant provides it" in out
+
+
+def test_a_variant_can_be_requested_by_name(tools):
+    out = _call(tools["examples"], "linear_elasticity", solver="fenics",
+                action="template", variant="3d")
+    assert "create_box" in out
+
+
+def test_an_unknown_variant_lists_the_real_ones(tools):
+    out = _call(tools["examples"], "linear_elasticity", solver="fenics",
+                action="template", variant="9d")
+    assert "No variant" in out and "3d" in out
+
+
+def test_no_call_site_still_reads_variant_zero_blindly():
+    """The regression guard. Three sites read `template_variants[0]`; if one
+    comes back, the measured failure comes back with it."""
+    import ast
+    import pathlib
+    src = pathlib.Path(C.__file__).read_text()
+    tree = ast.parse(src)
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript):
+            continue
+        val = node.value
+        if getattr(val, "attr", None) != "template_variants":
+            continue
+        sl = node.slice
+        # variants[0] or variants[:1] — both pick blindly.
+        if (isinstance(sl, ast.Constant) and sl.value == 0) or isinstance(sl, ast.Slice):
+            offenders.append(node.lineno)
+    assert not offenders, (
+        "a call site picks template_variants[0] without consulting the request, "
+        f"at line(s) {offenders}. Use _select_template_variant.")

--- a/tests/test_verification_gate.py
+++ b/tests/test_verification_gate.py
@@ -1,17 +1,24 @@
 """Tests for the verification-gate verdict (_stamp_verification).
 
-OASiS enforces verification IN SOFTWARE: OASiS verifies via numerical checks and
-*attestation* — binding every reported number to run evidence — but does not
-validate. The independent pre-execution critic is MANDATORY: a result is
-trustworthy ONLY when it passes attestation + numerical checks AND the critic
-approved (critic_approved=True). Enforced by verdict, never by error. These tests
-pin exactly that, plus the anti-fabrication labelling and the eval ablation
-(OFA_DISABLE_CRITIC lifts only the critic requirement).
+OASiS enforces verification IN SOFTWARE: it verifies via numerical checks on the
+RUN (completed, produced output, finite / converged / balanced) but does not
+validate. It does NOT currently bind a reported NUMBER to that run — an audit
+showed an invented value attached to a real run still passes — so these tests
+pin what the gate actually does, not what it was once described as doing.
+
+The independent pre-execution critic is MANDATORY and UNCONDITIONAL: a result is
+trustworthy ONLY when it passes the numerical checks AND a critic review of that
+exact setup is on the server's record. `critic_approved=True` is a self-report
+and verifies nothing by itself; there is no environment switch that lifts the
+requirement. Enforced by verdict, never by error. These tests pin exactly that,
+plus the anti-fabrication labelling.
 """
 import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 SRC = str(Path(__file__).resolve().parent.parent / "src")
 sys.path.insert(0, SRC)
@@ -19,9 +26,47 @@ sys.path.insert(0, SRC)
 from tools.consolidated import _stamp_verification  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _fresh_critic_registry(monkeypatch):
+    """Each test gets its own review record.
+
+    Without this, a review registered by one test verifies a LATER test's run:
+    the registry is module-level, and several tests here share the same solver
+    and the same one-line deck, so their digests collide. That was observed —
+    an unreviewed-run test came back "reviewed (submitted review matches this
+    setup)" and passed for entirely the wrong reason. Shared critic state
+    manufactures exactly the false green this whole gate exists to prevent.
+    """
+    import tools.consolidated as _C
+    from core.critic_gate import CriticRegistry
+    monkeypatch.setattr(_C, "_CRITIC_REGISTRY", CriticRegistry())
+
+
+def _review_on_record(solver: str, setup_text: str) -> None:
+    """Register a critic review the way an agent must.
+
+    The gate resolves the critic from the server's own record, not from the
+    caller's `critic_approved` flag, so a test that wants a VERIFIED verdict
+    has to put a review there first. Tests that skip this step are asserting
+    the behaviour of an unreviewed run, which is the interesting case anyway.
+    """
+    # Use the ONE definition rather than rebuilding it. This helper used to
+    # call `setup_digest` directly and so became a third, stale copy the moment
+    # referenced-file fingerprinting was added — four gate tests went red while
+    # the gate itself was correct.
+    from tools.consolidated import _CRITIC_REGISTRY, review_digest
+    _CRITIC_REGISTRY.submit_review(
+        solver=solver, digest=review_digest(solver, setup_text),
+        findings="Checked the problem statement, boundary conditions, units "
+                 "and discretisation against the stated physics; no issues "
+                 "found that would invalidate the run.")
+
+
 def test_evidence_and_critic_is_verified():
-    # A verified result needs BOTH attestation and the mandatory critic.
-    r = _stamp_verification({}, evidence_ok=True, critic_approved=True)
+    # A verified result needs BOTH run evidence and the mandatory critic.
+    _review_on_record("skfem", "deck")
+    r = _stamp_verification({}, evidence_ok=True, critic_approved=True,
+                            solver="skfem", setup_text="deck")
     assert r["trustworthy_result"] is True
     assert r["verification"].startswith("VERIFIED")
     # Verification is not validation — the verdict must say so.
@@ -42,14 +87,28 @@ def test_critic_is_mandatory_for_trust():
     """The whole point of OASiS: verification is enforced in software. A run that
     passes every automated check but was NOT reviewed by the mandatory critic is
     still NOT verified — enforced by verdict, not by an error."""
-    with_critic = _stamp_verification({}, evidence_ok=True, critic_approved=True)
-    without = _stamp_verification({}, evidence_ok=True, critic_approved=False)
+    _review_on_record("skfem", "mandatory-critic-deck")
+    with_critic = _stamp_verification({}, evidence_ok=True, critic_approved=True,
+                                      solver="skfem",
+                                      setup_text="mandatory-critic-deck")
+    without = _stamp_verification({}, evidence_ok=True, critic_approved=False,
+                                  solver="skfem", setup_text="unreviewed-deck")
     assert with_critic["trustworthy_result"] is True
     assert without["trustworthy_result"] is False        # critic is MANDATORY
     assert without["verification"].startswith("NOT VERIFIED")
     assert "MANDATORY" in without["verification"]
-    assert with_critic["critic_review"] == "approved"
-    assert "REQUIRED" in without["critic_review"]
+    # The note names WHERE the approval came from — a server-side record, not
+    # the caller's assertion.
+    assert "reviewed" in with_critic["critic_review"]
+    # Two distinct ways to be unreviewed, and the note must tell them apart:
+    # nothing reviewed for this solver at all …
+    never = _stamp_verification({}, evidence_ok=True, critic_approved=False,
+                                solver="dealii", setup_text="anything")
+    assert never["trustworthy_result"] is False
+    assert "no critic review is on record" in never["critic_review"]
+    # … versus a review that exists but was for a different setup, which is the
+    # review-a-clean-deck-then-run-another-one route.
+    assert "changed after it was reviewed" in without["critic_review"]
 
 
 def test_failed_checks_stay_unverified_even_with_critic_approved():
@@ -59,25 +118,42 @@ def test_failed_checks_stay_unverified_even_with_critic_approved():
     assert r["trustworthy_result"] is False
 
 
-def _critic_review_under_ablation() -> str:
+def _trust_under_env(**extra_env) -> str:
+    """What verdict does an evidence-backed but unreviewed run get, under an
+    environment an evaluation harness might plausibly be running with?"""
     code = ("import sys; sys.path.insert(0, %r);"
             "from tools.consolidated import _stamp_verification;"
-            "r=_stamp_verification({}, evidence_ok=True, critic_approved=False);"
-            "print(r['critic_review']); print(r['trustworthy_result'])" % SRC)
-    env = dict(os.environ, OFA_DISABLE_CRITIC="1")
+            "r=_stamp_verification({}, evidence_ok=True, critic_approved=True,"
+            "                      solver='skfem', setup_text='deck');"
+            "print(r['trustworthy_result'])" % SRC)
+    env = dict(os.environ, **extra_env)
     out = subprocess.run([sys.executable, "-c", code], env=env,
                          capture_output=True, text=True, timeout=120)
     assert out.returncode == 0, out.stderr[-2000:]
-    return out.stdout
+    return out.stdout.strip()
 
 
-def test_ablation_lifts_the_mandatory_critic_requirement():
-    """OFA_DISABLE_CRITIC (the held-out eval's ablation) lifts ONLY the mandatory
-    critic requirement, so an evidence-backed run verifies without critic
-    approval — this is how the eval measures the critic's contribution."""
-    review, trust = _critic_review_under_ablation().splitlines()
-    assert review == "disabled for evaluation"
-    assert trust == "True"   # under ablation, attestation alone verifies
+def test_no_environment_variable_lifts_the_mandatory_critic_requirement():
+    """This test used to assert the OPPOSITE.
+
+    OFA_DISABLE_CRITIC was an ablation switch that lifted the mandatory-critic
+    requirement, so an unreviewed run came back VERIFIED. A mandatory gate with
+    an environment-variable off-switch is not mandatory: a stray export, a
+    harness default, or a copied shell script silently converts every verdict in
+    a campaign, and nothing in the output says so. The switch is removed, and
+    the ablation arm it existed for is not run — the design is OASiS or no
+    OASiS. What is asserted here is that setting it now changes nothing.
+    """
+    assert _trust_under_env(OFA_DISABLE_CRITIC="1") == "False"
+    assert _trust_under_env() == "False"
+
+
+def test_a_tool_that_does_not_identify_its_setup_fails_closed():
+    """A caller that cannot say what it ran cannot have had that thing
+    reviewed, so the gate must refuse rather than wave it through."""
+    r = _stamp_verification({}, evidence_ok=True, critic_approved=True)
+    assert r["trustworthy_result"] is False
+    assert "did not identify its setup" in r["critic_review"]
 
 
 # ── Finiteness scan (attestation's numeric side) ─────────────────────────
@@ -217,6 +293,7 @@ def _run_sim(backend, **kw):
 
 def test_run_simulation_verified_with_finite_output_and_critic(tmp_path):
     f = tmp_path / "out.vtu"; _write_vtu(f, [1.0, 2.0, 3.0, 4.0])
+    _review_on_record("fenics", "print('x')")   # _run_sim's deck
     d = _run_sim(_Backend([f]), critic_approved=True)
     assert d["status"] == "completed"
     assert d["trustworthy_result"] is True
@@ -257,7 +334,9 @@ def test_run_simulation_no_output_is_completed_unverified(tmp_path):
     d = _run_sim(_Backend([]), critic_approved=True)
     assert d["status"] == "completed_unverified"
     assert d["trustworthy_result"] is False
-    assert d["critic_review"] == "approved"   # critic set, but no run evidence
+    # The claim is recorded and contradicted rather than silently accepted:
+    # asserting approval with no review on record is itself worth reporting.
+    assert "critic_approved=True" in d["critic_review"]
 
 
 def test_run_simulation_error_is_not_verified(tmp_path):
@@ -266,10 +345,22 @@ def test_run_simulation_error_is_not_verified(tmp_path):
     assert d["verification"].startswith("NOT VERIFIED")
 
 
-def _run_precice(logs, converged=True, **kw):
+def _run_precice(logs, converged=True, exchanged=True, exit_ok=True, **kw):
+    """Stand in for run_precice_coupling.
+
+    Its return contract changed: `converged` used to be a synonym for "every
+    process exited 0" (which two scripts that never call preCICE also satisfy),
+    and is now derived from preCICE's own per-window iteration record, alongside
+    `exit_codes_ok` and `exchanged`. The stub mirrors the real shape so the
+    assertions below still test the gate rather than the stub.
+    """
     caps = _capture_tools()
     import core.precice_config as PC
     stub = lambda *a, **k: {"converged": converged,
+                            "coupling_converged": converged,
+                            "exchanged": exchanged,
+                            "exit_codes_ok": exit_ok,
+                            "evidence": [], "config_notes": [],
                             "returncodes": {"A": 0, "B": 0}, "logs": logs}
     import tempfile
     with mock.patch.object(PC, "check_precice_available", lambda: (True, "ok")), \
@@ -285,6 +376,12 @@ def _run_precice(logs, converged=True, **kw):
 
 
 def test_couple_precice_verified_on_clean_logs():
+    from tools.consolidated import _coupling_setup_text
+    _review_on_record("couple_precice", _coupling_setup_text(
+        participants='[{"name":"A"},{"name":"B"}]', data="[]", exchanges="[]",
+        scheme="serial-explicit", dimensions=2, max_time=10.0,
+        time_window=1.0, max_iterations=20, convergence_tol=1e-6,
+        relaxation=0.5, mapping="nearest-neighbor"))
     d = _run_precice({"B": "coupling ok, residual 1e-9"}, critic_approved=True)
     assert d["trustworthy_result"] is True
 
@@ -293,3 +390,41 @@ def test_couple_precice_flags_nan_in_logs_despite_converged():
     d = _run_precice({"B": "residual nan detected"}, converged=True,
                      critic_approved=True)
     assert d["trustworthy_result"] is False   # log NaN downgrades, fails safe
+
+
+def _reviewed_precice():
+    from tools.consolidated import _coupling_setup_text
+    _review_on_record("couple_precice", _coupling_setup_text(
+        participants='[{"name":"A"},{"name":"B"}]', data="[]", exchanges="[]",
+        scheme="serial-explicit", dimensions=2, max_time=10.0, time_window=1.0,
+        max_iterations=20, convergence_tol=1e-6, relaxation=0.5,
+        mapping="nearest-neighbor"))
+
+
+def test_couple_precice_clean_exit_without_exchange_is_not_verified():
+    """Every participant exiting 0 is not a coupling.
+
+    Two scripts that never call preCICE at all exit 0, and the verdict used to be
+    driven by `converged`, which was itself just "all exited 0".
+    """
+    _reviewed_precice()
+    d = _run_precice({"B": "done"}, exchanged=False, critic_approved=True)
+    assert d["trustworthy_result"] is False
+    assert any("NO EXCHANGE" in v for v in d.get("validation", []))
+
+
+def test_couple_precice_nonconvergence_recorded_by_precice_is_not_verified():
+    """An implicit scheme that exhausts max-iterations logs it and EXITS 0."""
+    _reviewed_precice()
+    d = _run_precice({"B": "done"}, converged=False, critic_approved=True)
+    assert d["trustworthy_result"] is False
+    assert any("NOT CONVERGED" in v for v in d.get("validation", []))
+
+
+def test_couple_precice_unmeasured_convergence_is_reported_not_assumed():
+    """An explicit scheme measures no convergence: say so, do not imply it."""
+    _reviewed_precice()
+    d = _run_precice({"B": "done"}, converged=None, critic_approved=True)
+    assert d["trustworthy_result"] is True          # nothing here is WRONG
+    assert any("convergence" in c for c in d.get("checks_not_run", []))
+    assert "COVERAGE" in d["verification"]          # and the verdict says so


### PR DESCRIPTION
**Do not merge.** Every change here is already an ancestor of `consolidation/all-campaigns` (PR #50). This branch exists so a machine reviewer can actually read the code.

Copilot declined #50: 2,943 files, over its 300-file limit. 2,679 of those are tier-2 fixture scripts — bulk that a reviewer cannot usefully read. This is the remaining 69 files: the code that *judges* everything else, where a bug is most expensive.

## Where to look, in order of how much damage a bug does

**1. `scripts/run_tier2_fixtures.py::_needle_present`** — decides whether a fixture passed.

It has been wrong twice in one day, in mirror-image ways:

```
same_name_files=1   was satisfied by  same_name_files=10     (5235 expectations)
masked_max=1.000000 was satisfied by  unmasked_max=1.000000  (11 expectations)
```

The second included **both** control expectations of `dune/unmasked_ds_flux_covers_whole_boundary`, whose own docstring states the mutation drives `unmasked_max` to exactly the value that then satisfies its `masked_max` control. If there is a third hole, it is in this function.

**2. `scripts/build_execution_ledger.py`** — decides whether a fixture *discriminates*, i.e. whether it goes red when the bug it tests is put back.

There are two kinds of mutation control (an in-source `T2_MUTATE` branch, and a declared from/to recipe applied in a staged copy). Running only the first made **354 of 395** 4C fixtures run byte-identically twice and be recorded as "proving nothing". A mutated `TIMEOUT` no longer earns credit — five rows had rested on that. `MUTATION_STALE` (a recipe whose anchor text no longer matches, so it substitutes nothing) and `VACUOUS_BASELINE` are verdicts, never passes.

**3. `scripts/audit_named_input_keys.py`** — screens every identifier the knowledge names against the backend's own corpus, **including inside deck templates**, which is where an invented key does real damage.

It ships a `--selftest` that proves it still flags the known `SOUNDSPEED` fabrication on a pre-fix tree and stays silent on the corrected one. A gate that cannot demonstrate it detects the thing it was built for is just another unverified claim.

**4. `docs/CONSOLIDATION.md`, final sections** — eleven defects found in this machinery, each a check that returned a confident answer while looking at the wrong thing. Worth reading before the code, as a map of the failure modes.

## Fair warning

Several gates here are **red on purpose** and the reasons are in #50's description. A green suite was never the goal. The most useful review would be a third hole in `_needle_present`, or a way any of these gates can be satisfied without the underlying claim being true.