### PR TITLE
URGENT: remove two fabricated 4C input keys from the released knowledge

### DIFF
--- a/src/backends/fourc/backend.py
+++ b/src/backends/fourc/backend.py
@@ -480,23 +480,33 @@ class FourcBackend(SolverBackend):
                 "summary": ("SPH dam-break: 2D rectangular "
                             "column of fluid collapsing onto a "
                             "rigid floor under gravity."),
-                "needs": ["MAT_PARTICLE with SPH_FLUID "
-                          "particle type (density, "
-                          "DYN_VISCOSITY, BULK_MODULUS, "
-                          "SOUNDSPEED)",
+                "needs": ["MAT_ParticleSPHFluid (the material "
+                          "name is case-sensitive and appears "
+                          "in 60 upstream decks)",
                           "PARTICLE_PHASE for the fluid "
                           "column + a boundaryphase for the "
                           "floor/walls",
                           "PARTICLE DYNAMIC with explicit "
                           "time integration + appropriate "
                           "CFL"],
-                "pitfalls": ["SOUNDSPEED too low → fluid "
-                             "compresses unrealistically; "
-                             "rule of thumb c >= 10 * v_max",
-                             "SMOOTHING_LENGTH too small → "
-                             "spurious tensile-instability "
-                             "voids; rule of thumb h ~ 1.3 * "
-                             "particle spacing"],
+                "pitfalls": ["[Input] There is no SOUNDSPEED key "
+                             "and no SMOOTHING_LENGTH key in 4C's "
+                             "SPH input. Both were previously "
+                             "served here as required material "
+                             "parameters, one with a numeric "
+                             "tuning rule; neither appears in any "
+                             "file of 4C's source or in any of "
+                             "its 2171 upstream decks. Signal: "
+                             "writing either into MATERIALS "
+                             "aborts with \"Failed to match "
+                             "specification in section "
+                             "'MATERIALS'\" — the same message a "
+                             "mis-cased real key produces, so the "
+                             "message alone does not tell you "
+                             "which mistake you made. Check names "
+                             "against `4C -p`, which dumps the "
+                             "accepted grammar from the binary. "
+                             "(Verified 2026-08-07)"],
             },
             ("porous_media", "terzaghi_2d"): {
                 "problemtype": "Poroelasticity",


### PR DESCRIPTION
**One file, 21 insertions, 11 deletions.** Deliberately minimal so it can land ahead of the large consolidation in #50.

## What `main` serves today

```
"needs":    [... DYN_VISCOSITY, BULK_MODULUS, SOUNDSPEED]
"pitfalls": ["SOUNDSPEED too low → fluid compresses unrealistically;
              rule of thumb c >= 10 * v_max",
             "SMOOTHING_LENGTH too small → spurious tensile-instability
              voids; rule of thumb h ~ 1.3 * particle spacing"]
```

Measured against the 4C checkout:

| key | in 4C source | in 4C's 2171 upstream decks |
|---|---|---|
| `SOUNDSPEED` | **0 files** | **0 decks** |
| `SMOOTHING_LENGTH` | **0 files** | **0 decks** |
| `MAT_ParticleSPHFluid` (the real material) | 2 files | 60 decks |

Two invented keys, listed beside two real ones, one carrying a numeric tuning rule — a rule about a parameter that does not exist. A user who follows it writes a MATERIALS block 4C refuses to parse.

And the diagnostic they get, `Failed to match specification in section 'MATERIALS'`, is the **same message a mis-cased real key produces**. So the error does not tell them which mistake they made. That is why the corrected entry points at `4C -p`, which dumps the accepted grammar from the binary and is the only reliable way to tell a typo from a fabrication.

## Why this is separate from #50

#50 fixes this among ~2,900 other files and cannot be reviewed quickly — Copilot declined it for exceeding 300 files. Meanwhile these fabrications are live in the DOI-badged release (`10.5281/zenodo.20543501`), reachable by anyone who clones or cites it, and have been for the whole time the fix sat on a branch.

## Where it was hiding, which is the interesting part

The text lives in the **reference-stub catalog**, not in a `get_knowledge()` row. A knowledge-level scan does not reach it — which is why it survived earlier audits — but `prepare_simulation` serves it, so a user does. Any future audit of served content needs to cover this path.

## Verified

- `fourc` backend still loads, 48 physics rows intact.
- The fabricated tuning rule is gone from the source; the correction is present.
- Every factual claim in the replacement text was checked against `/home/alexander/4C` directly.

## Still outstanding on `main` after this

`src/backends/kratos/generators/dem.py` writes `PARTICLE_FRICTION` into every generated DEM deck. That key is absent even from the full 28-application Kratos build; the real keys are `STATIC_FRICTION`/`DYNAMIC_FRICTION`, per contact pair. It is **not** fixed by #50 either — #50 documents it in a warning while the template still emits it, the same contradiction this PR fixes for `SOUNDSPEED`. A proper generator rewrite is in progress; it needs a schema change, not a text edit, which is why it is not bundled here.